### PR TITLE
Fix announcement sigs

### DIFF
--- a/ucoin/include/ln.h
+++ b/ucoin/include/ln.h
@@ -142,6 +142,7 @@ typedef enum {
     LN_CB_COMMIT_SIG_RECV_PREV, ///< commitment_signed処理前通知
     LN_CB_COMMIT_SIG_RECV,      ///< commitment_signed受信通知
     LN_CB_HTLC_CHANGED,         ///< HTLC変化通知
+    LN_CB_SHUTDOWN_RECV,        ///< shutdown受信通知
     LN_CB_CLOSED,               ///< closing_signed受信通知
     LN_CB_SEND_REQ,             ///< peerへの送信要求
     LN_CB_MAX,

--- a/ucoin/src/ln/ln.c
+++ b/ucoin/src/ln/ln.c
@@ -1747,6 +1747,10 @@ static bool recv_shutdown(ln_self_t *self, const uint8_t *pData, uint16_t Len)
     ucoin_buf_init(&buf_bolt);
     if (!(self->shutdown_flag & M_SHDN_FLAG_SEND)) {
         //shutdown未送信の場合 == shutdownを要求された方
+
+        //feeと送金先
+        (*self->p_callback)(self, LN_CB_SHUTDOWN_RECV, NULL);
+
         ret = ln_create_shutdown(self, &buf_bolt);
         if (ret) {
             self->shutdown_flag |= M_SHDN_FLAG_SEND;

--- a/ucoin/src/ln/ln.c
+++ b/ucoin/src/ln/ln.c
@@ -636,6 +636,11 @@ bool ln_create_announce_signs(ln_self_t *self, ucoin_buf_t *pBufAnnoSigns)
     uint8_t *p_sig_node;
     uint8_t *p_sig_btc;
 
+    if (self->cnl_anno.buf == NULL) {
+        DBG_PRINTF("fail: no funding_locked\n");
+        return false;
+    }
+
     //  self->cnl_annoはfundindg_lockedメッセージ作成時に行っている
     //  localのsignature
     ln_msg_get_anno_signs(self, &p_sig_node, &p_sig_btc, true);
@@ -2487,6 +2492,10 @@ static bool recv_channel_announcement(ln_self_t *self, const uint8_t *pData, uin
             DBG_PRINTF("同じものが送られてきたので、スルー\n");
         } else {
             DBG_PRINTF("不一致のためblacklist入りする予定\n");
+            DBG_PRINTF("buf_bolt: ");
+            DUMPBIN(buf_bolt.buf, buf_bolt.len);
+            DBG_PRINTF("buf: ");
+            DUMPBIN(buf.buf, buf.len);
             assert(0);
         }
     }

--- a/ucoind/lnapp.c
+++ b/ucoind/lnapp.c
@@ -70,14 +70,13 @@
 #define M_WAIT_RECV_MULTI_MSEC  (1000)      //複数パケット受信した時の処理間隔[msec]
 #define M_WAIT_RECV_TO_MSEC     (100)       //socket受信待ちタイムアウト[msec]
 
-#define M_SHUTDOWN_FEE          UCOIN_MBTC2SATOSHI(0.1)     ///< shutdown時のFEE
-
 //デフォルト値
 //  announcement
 #define M_CLTV_EXPIRY_DELTA             (36)
 #define M_HTLC_MINIMUM_MSAT_ANNO        (0)
 #define M_FEE_BASE_MSAT                 (10)
 #define M_FEE_PROP_MILLIONTHS           (100)
+
 //  establish
 #define M_DUST_LIMIT_SAT                (546)
 #define M_MAX_HTLC_VALUE_IN_FLIGHT_MSAT (UINT64_MAX)


### PR DESCRIPTION
タイミングによっては、 `announcement_signatures` の作成時に、 NULLアクセスが発生して異常終了することがある。

おそらく #23 対応の際、 `announcement_signatures` までのconfirmation待ち処理を移動させたことによる副作用で、 `funding_locked` の送信前に `announcement_signatures` を送信しようとしていたのだと思われる。

現象がタイミング依存になり、今発生させることができないので、ひとまずmergeさせて評価する。

----

現象の発見が、元々やろうとしていた「close用のアドレス生成を `shutdown` 受信時に行う」の動作確認中だったため、そちらの変更も混ざっている。