### PR TITLE
Issue 53

### DIFF
--- a/include/ucoind.h
+++ b/include/ucoind.h
@@ -229,7 +229,6 @@ typedef struct {
     uint8_t     payment_hash[LN_SZ_HASH];
     uint64_t    next_short_channel_id;
     uint64_t    prev_short_channel_id;
-    uint64_t    prev_id;
     ucoin_buf_t shared_secret;
 } fwd_proc_add_t;
 

--- a/include/ucoind.h
+++ b/include/ucoind.h
@@ -229,6 +229,7 @@ typedef struct {
     uint8_t     payment_hash[LN_SZ_HASH];
     uint64_t    next_short_channel_id;
     uint64_t    prev_short_channel_id;
+    uint64_t    prev_id;
     ucoin_buf_t shared_secret;
 } fwd_proc_add_t;
 

--- a/ucoin/include/ln.h
+++ b/ucoin/include/ln.h
@@ -415,7 +415,6 @@ typedef struct {
     //fulfillで戻す
     uint8_t     signature[LN_SZ_SIGNATURE];         ///< HTLC署名
     uint64_t    prev_short_channel_id;              ///< 転送元short_channel_id
-    uint64_t    prev_id;                            ///< 転送元id
     //failで戻す
     ucoin_buf_t shared_secret;                      ///< failuremsg暗号化用
 } ln_update_add_htlc_t;
@@ -728,8 +727,7 @@ typedef struct {
  *  @brief  update_fulfill_htlc受信通知(#LN_CB_FULFILL_HTLC_RECV)
  */
 typedef struct {
-    uint64_t                prev_short_channel_id;  ///< 転送元short_channel_id
-    uint64_t                prev_id;                ///< 転送元id
+    uint64_t                prev_short_channel_id;  ///< 転送元
     const uint8_t           *p_preimage;            ///< update_fulfill_htlcで受信したpreimage(スタック)
     uint64_t                id;                     ///< HTLC id
 } ln_cb_fulfill_htlc_recv_t;
@@ -739,8 +737,7 @@ typedef struct {
  *  @brief  update_fail_htlc受信通知(#LN_CB_FAIL_HTLC_RECV)
  */
 typedef struct {
-    uint64_t                prev_short_channel_id;  ///< 転送元short_channel_id
-    uint64_t                prev_id;                ///< 転送元id
+    uint64_t                prev_short_channel_id;  ///< 転送元
     const ucoin_buf_t       *p_reason;              ///< reason
     const ucoin_buf_t       *p_shared_secret;       ///< shared secret
     uint64_t                id;                     ///< HTLC id
@@ -1241,7 +1238,6 @@ bool ln_create_shutdown(ln_self_t *self, ucoin_buf_t *pShutdown);
  * @param[in]           cltv_value      CLTV値
  * @param[in]           pPaymentHash    PaymentHash(SHA256:32byte)
  * @param[in]           prev_short_channel_id   転送元short_channel_id(ない場合は0)
- * @param[in]           prev_id                 転送元id
  * @param[in]           pSharedSecrets  保存する共有秘密鍵集(NULL:未保存)
  * @retval      true    成功
  * @note
@@ -1253,7 +1249,6 @@ bool ln_create_add_htlc(ln_self_t *self, ucoin_buf_t *pAdd,
             uint32_t cltv_value,
             const uint8_t *pPaymentHash,
             uint64_t prev_short_channel_id,
-            uint64_t prev_id,
             const ucoin_buf_t *pSharedSecrets);
 
 

--- a/ucoin/include/ln.h
+++ b/ucoin/include/ln.h
@@ -422,6 +422,8 @@ typedef struct {
 
 /** @struct     ln_update_fulfill_htlc_t
  *  @brief      update_fulfill_htlc
+ *  @note
+ *      - "id"はreadのみ使用する。create時はpayment_hashを検索する。
  */
 typedef struct {
     uint8_t     *p_channel_id;                      ///< 32: channel-id
@@ -1256,11 +1258,10 @@ bool ln_create_add_htlc(ln_self_t *self, ucoin_buf_t *pAdd,
  *
  * @param[in,out]       self            channel情報
  * @param[out]          pFulfill        生成したupdate_fulfill_htlcメッセージ
- * @param[in]           id              HTLC id
  * @param[in]           pPreImage       反映するHTLCのpayment-preimage
  * @retval      true    成功
  */
-bool ln_create_fulfill_htlc(ln_self_t *self, ucoin_buf_t *pFulfill, uint64_t id, const uint8_t *pPreImage);
+bool ln_create_fulfill_htlc(ln_self_t *self, ucoin_buf_t *pFulfill, const uint8_t *pPreImage);
 
 
 /** update_fail_htlcメッセージ作成

--- a/ucoin/include/ln.h
+++ b/ucoin/include/ln.h
@@ -415,6 +415,7 @@ typedef struct {
     //fulfillで戻す
     uint8_t     signature[LN_SZ_SIGNATURE];         ///< HTLC署名
     uint64_t    prev_short_channel_id;              ///< 転送元short_channel_id
+    uint64_t    prev_id;                            ///< 転送元id
     //failで戻す
     ucoin_buf_t shared_secret;                      ///< failuremsg暗号化用
 } ln_update_add_htlc_t;
@@ -727,7 +728,8 @@ typedef struct {
  *  @brief  update_fulfill_htlc受信通知(#LN_CB_FULFILL_HTLC_RECV)
  */
 typedef struct {
-    uint64_t                prev_short_channel_id;  ///< 転送元
+    uint64_t                prev_short_channel_id;  ///< 転送元short_channel_id
+    uint64_t                prev_id;                ///< 転送元id
     const uint8_t           *p_preimage;            ///< update_fulfill_htlcで受信したpreimage(スタック)
     uint64_t                id;                     ///< HTLC id
 } ln_cb_fulfill_htlc_recv_t;
@@ -737,7 +739,8 @@ typedef struct {
  *  @brief  update_fail_htlc受信通知(#LN_CB_FAIL_HTLC_RECV)
  */
 typedef struct {
-    uint64_t                prev_short_channel_id;  ///< 転送元
+    uint64_t                prev_short_channel_id;  ///< 転送元short_channel_id
+    uint64_t                prev_id;                ///< 転送元id
     const ucoin_buf_t       *p_reason;              ///< reason
     const ucoin_buf_t       *p_shared_secret;       ///< shared secret
     uint64_t                id;                     ///< HTLC id
@@ -1238,6 +1241,7 @@ bool ln_create_shutdown(ln_self_t *self, ucoin_buf_t *pShutdown);
  * @param[in]           cltv_value      CLTV値
  * @param[in]           pPaymentHash    PaymentHash(SHA256:32byte)
  * @param[in]           prev_short_channel_id   転送元short_channel_id(ない場合は0)
+ * @param[in]           prev_id                 転送元id
  * @param[in]           pSharedSecrets  保存する共有秘密鍵集(NULL:未保存)
  * @retval      true    成功
  * @note
@@ -1249,6 +1253,7 @@ bool ln_create_add_htlc(ln_self_t *self, ucoin_buf_t *pAdd,
             uint32_t cltv_value,
             const uint8_t *pPaymentHash,
             uint64_t prev_short_channel_id,
+            uint64_t prev_id,
             const ucoin_buf_t *pSharedSecrets);
 
 

--- a/ucoin/src/ln/ln.c
+++ b/ucoin/src/ln/ln.c
@@ -872,7 +872,7 @@ bool ln_create_add_htlc(ln_self_t *self, ucoin_buf_t *pAdd,
 }
 
 
-bool ln_create_fulfill_htlc(ln_self_t *self, ucoin_buf_t *pFulfill, uint64_t id, const uint8_t *pPreImage)
+bool ln_create_fulfill_htlc(ln_self_t *self, ucoin_buf_t *pFulfill, const uint8_t *pPreImage)
 {
     DBG_PRINTF("BEGIN\n");
 
@@ -883,7 +883,6 @@ bool ln_create_fulfill_htlc(ln_self_t *self, ucoin_buf_t *pFulfill, uint64_t id,
     }
     uint8_t sha256[LN_SZ_HASH];
     ucoin_util_sha256(sha256, pPreImage, LN_SZ_PREIMAGE);
-    DBG_PRINTF("id= %" PRIu64 "\n", id);
     DBG_PRINTF("recv payment_sha256= ");
     DUMPBIN(sha256, LN_SZ_PREIMAGE);
     ln_update_add_htlc_t *p_add = NULL;
@@ -891,11 +890,9 @@ bool ln_create_fulfill_htlc(ln_self_t *self, ucoin_buf_t *pFulfill, uint64_t id,
         //fulfill送信はReceived Outputに対して行う
         if (self->cnl_add_htlc[idx].amount_msat > 0) {
             DBG_PRINTF("LN_HTLC_FLAG_IS_RECV(self->cnl_add_htlc[idx].flag)=%d\n", LN_HTLC_FLAG_IS_RECV(self->cnl_add_htlc[idx].flag));
-            DBG_PRINTF("htlc_id=%" PRIu64 "\n", self->cnl_add_htlc[idx].id);
             DBG_PRINTF("payment_sha256= ");
             DUMPBIN(self->cnl_add_htlc[idx].payment_sha256, LN_SZ_PREIMAGE);
             if ( LN_HTLC_FLAG_IS_RECV(self->cnl_add_htlc[idx].flag) &&
-                 (id == self->cnl_add_htlc[idx].id) &&
                  (memcmp(sha256, self->cnl_add_htlc[idx].payment_sha256, LN_SZ_HASH) == 0) ) {
                 //
                 p_add = &self->cnl_add_htlc[idx];
@@ -910,7 +907,7 @@ bool ln_create_fulfill_htlc(ln_self_t *self, ucoin_buf_t *pFulfill, uint64_t id,
     }
     if (p_add->amount_msat == 0) {
         self->err = LNERR_INV_ID;
-        DBG_PRINTF("fail: invalid id\n");
+        DBG_PRINTF("fail: cannot found HTLC\n");
         return false;
     }
 

--- a/ucoin/src/ln/ln.c
+++ b/ucoin/src/ln/ln.c
@@ -777,6 +777,7 @@ bool ln_create_add_htlc(ln_self_t *self, ucoin_buf_t *pAdd,
             uint32_t cltv_value,
             const uint8_t *pPaymentHash,
             uint64_t prev_short_channel_id,
+            uint64_t prev_id,
             const ucoin_buf_t *pSharedSecrets)
 {
     DBG_PRINTF("BEGIN\n");
@@ -853,6 +854,7 @@ bool ln_create_add_htlc(ln_self_t *self, ucoin_buf_t *pAdd,
     memcpy(self->cnl_add_htlc[idx].payment_sha256, pPaymentHash, LN_SZ_HASH);
     self->cnl_add_htlc[idx].p_onion_route = (CONST_CAST uint8_t *)pPacket;
     self->cnl_add_htlc[idx].prev_short_channel_id = prev_short_channel_id;
+    self->cnl_add_htlc[idx].prev_id = prev_id;
     ucoin_buf_free(&self->cnl_add_htlc[idx].shared_secret);
     if (pSharedSecrets) {
         self->cnl_add_htlc[idx].shared_secret.buf = pSharedSecrets->buf;
@@ -2090,15 +2092,16 @@ static bool recv_update_fulfill_htlc(ln_self_t *self, const uint8_t *pData, uint
         self->their_msat += p_add->amount_msat;
 
         uint64_t prev_short_channel_id = p_add->prev_short_channel_id; //CB用
-        uint64_t prev_id = fulfill_htlc.id;  //CB用
+        uint64_t prev_id = p_add->prev_id;  //CB用
 
         clear_htlc(self, p_add);
 
         //update_fulfill_htlc受信通知
         ln_cb_fulfill_htlc_recv_t fulfill;
         fulfill.prev_short_channel_id = prev_short_channel_id;
+        fulfill.prev_id = prev_id;
         fulfill.p_preimage = preimage;
-        fulfill.id = prev_id;
+        //fulfill.id = fulfill_htlc.id;
         (*self->p_callback)(self, LN_CB_FULFILL_HTLC_RECV, &fulfill);
     } else {
         self->err = LNERR_INV_ID;
@@ -2146,6 +2149,7 @@ static bool recv_update_fail_htlc(ln_self_t *self, const uint8_t *pData, uint16_
 
             ln_cb_fail_htlc_recv_t fail_recv;
             fail_recv.prev_short_channel_id = self->cnl_add_htlc[idx].prev_short_channel_id;
+            fail_recv.prev_id = self->cnl_add_htlc[idx].prev_id;
             fail_recv.p_reason = &reason;
             fail_recv.p_shared_secret = &self->cnl_add_htlc[idx].shared_secret;
             fail_recv.id = self->cnl_add_htlc[idx].id;

--- a/ucoind/lnapp.c
+++ b/ucoind/lnapp.c
@@ -134,7 +134,6 @@ void ucoin_dbg_free(void *ptr, int line)
  ********************************************************************/
 
 typedef struct {
-    uint64_t    id;
     uint8_t     preimage[LN_SZ_PREIMAGE];
 } fwd_proc_fulfill_t;
 
@@ -458,7 +457,6 @@ bool lnapp_backward_fulfill(lnapp_conf_t *pAppConf, const ln_cb_fulfill_htlc_rec
     }
 
     fwd_proc_fulfill_t *p_fwd_fulfill = (fwd_proc_fulfill_t *)MM_MALLOC(sizeof(fwd_proc_fulfill_t));   //free: fwd_fulfill_backward()
-    p_fwd_fulfill->id = pFulFill->id;
     memcpy(p_fwd_fulfill->preimage, pFulFill->p_preimage, LN_SZ_PREIMAGE);
 
     return set_request_recvproc(pAppConf, FWD_PROC_FULFILL, (uint16_t)sizeof(fwd_proc_fulfill_t), p_fwd_fulfill);
@@ -1502,12 +1500,10 @@ static bool fwd_fulfill_backward(lnapp_conf_t *p_conf)
 
     show_self_param(p_conf->p_self, PRINTOUT, __LINE__);
 
-    DBG_PRINTF("id= %" PRIx64 "\n", p_fwd_fulfill->id);
     DBG_PRINTF("preimage= ");
     DUMPBIN(p_fwd_fulfill->preimage, LN_SZ_PREIMAGE);
 
-    ret = ln_create_fulfill_htlc(p_conf->p_self, &buf_bolt,
-                            p_fwd_fulfill->id, p_fwd_fulfill->preimage);
+    ret = ln_create_fulfill_htlc(p_conf->p_self, &buf_bolt, p_fwd_fulfill->preimage);
     assert(ret);
     send_peer_noise(p_conf, &buf_bolt);
     ucoin_buf_free(&buf_bolt);

--- a/ucoind/lnapp.c
+++ b/ucoind/lnapp.c
@@ -374,7 +374,6 @@ bool lnapp_payment(lnapp_conf_t *pAppConf, const payment_conf_t *pPay)
                         pPay->hop_datain[0].outgoing_cltv_value,
                         pPay->payment_hash,
                         0,
-                        0,
                         &secrets);  //secretsはln.cで管理するので、ここでは解放しない
     if (!ret) {
         goto LABEL_EXIT;
@@ -1447,7 +1446,6 @@ static bool fwd_payment_forward(lnapp_conf_t *p_conf)
                         p_fwd_add->outgoing_cltv_value,
                         p_fwd_add->payment_hash,
                         p_fwd_add->prev_short_channel_id,
-                        p_fwd_add->prev_id,
                         &p_fwd_add->shared_secret);
     //ucoin_buf_free(&p_fwd_add->shared_secret);  //ln.cで管理するため、freeさせない
     if (!ret) {
@@ -2046,7 +2044,6 @@ static void cb_add_htlc_recv(lnapp_conf_t *p_conf, void *p_param)
             p_fwd_add->outgoing_cltv_value = p_add->p_hop->outgoing_cltv_value;
             p_fwd_add->next_short_channel_id = p_add->p_hop->short_channel_id;
             p_fwd_add->prev_short_channel_id = ln_short_channel_id(p_conf->p_self);
-            p_fwd_add->prev_id = p_add->id;
             memcpy(p_fwd_add->payment_hash, p_add->p_payment_hash, LN_SZ_HASH);
             ucoin_buf_alloccopy(&p_fwd_add->shared_secret, p_add->p_shared_secret->buf, p_add->p_shared_secret->len);
 
@@ -2092,7 +2089,7 @@ static void cb_fulfill_htlc_recv(lnapp_conf_t *p_conf, void *p_param)
         //mMuxTiming |= MUX_RECV_FULFILL_HTLC | MUX_SEND_FULFILL_HTLC;
 
         //フラグを立てて、相手の受信スレッドで処理してもらう
-        DBG_PRINTF("戻す: %" PRIx64 ", id=%" PRIx64 "\n", p_fulfill->prev_short_channel_id, p_fulfill->prev_id);
+        DBG_PRINTF("戻す: %" PRIx64 ", id=%" PRIx64 "\n", p_fulfill->prev_short_channel_id, p_fulfill->id);
         backward_fulfill(p_fulfill);
     } else {
         //mMuxTiming |= MUX_RECV_FULFILL_HTLC;
@@ -2126,7 +2123,7 @@ static void cb_fail_htlc_recv(lnapp_conf_t *p_conf, void *p_param)
 
     if (p_fail->prev_short_channel_id != 0) {
         //フラグを立てて、相手の受信スレッドで処理してもらう
-        DBG_PRINTF("fail戻す: %" PRIx64 ", id=%" PRIx64 "\n", p_fail->prev_short_channel_id, p_fail->prev_id);
+        DBG_PRINTF("fail戻す: %" PRIx64 ", id=%" PRIx64 "\n", p_fail->prev_short_channel_id, p_fail->id);
         backward_fail(p_fail);
     } else {
         DBG_PRINTF("ここまで\n");
@@ -2764,7 +2761,7 @@ static void show_self_param(const ln_self_t *self, FILE *fp, int line)
                 fprintf(fp, "      id= %" PRIx64 "\n", p_add->id);
                 fprintf(fp, "    amount_msat= %" PRIu64 "\n", p_add->amount_msat);
                 if (p_add->prev_short_channel_id) {
-                    fprintf(fp, "    from:        %" PRIx64 ": %" PRIu64 "\n", p_add->prev_short_channel_id, p_add->prev_id);
+                    fprintf(fp, "    from:        %" PRIx64 "\n", p_add->prev_short_channel_id);
                 }
             }
         }

--- a/ucoind/lnapp.c
+++ b/ucoind/lnapp.c
@@ -374,6 +374,7 @@ bool lnapp_payment(lnapp_conf_t *pAppConf, const payment_conf_t *pPay)
                         pPay->hop_datain[0].outgoing_cltv_value,
                         pPay->payment_hash,
                         0,
+                        0,
                         &secrets);  //secretsはln.cで管理するので、ここでは解放しない
     if (!ret) {
         goto LABEL_EXIT;
@@ -1446,6 +1447,7 @@ static bool fwd_payment_forward(lnapp_conf_t *p_conf)
                         p_fwd_add->outgoing_cltv_value,
                         p_fwd_add->payment_hash,
                         p_fwd_add->prev_short_channel_id,
+                        p_fwd_add->prev_id,
                         &p_fwd_add->shared_secret);
     //ucoin_buf_free(&p_fwd_add->shared_secret);  //ln.cで管理するため、freeさせない
     if (!ret) {
@@ -2044,6 +2046,7 @@ static void cb_add_htlc_recv(lnapp_conf_t *p_conf, void *p_param)
             p_fwd_add->outgoing_cltv_value = p_add->p_hop->outgoing_cltv_value;
             p_fwd_add->next_short_channel_id = p_add->p_hop->short_channel_id;
             p_fwd_add->prev_short_channel_id = ln_short_channel_id(p_conf->p_self);
+            p_fwd_add->prev_id = p_add->id;
             memcpy(p_fwd_add->payment_hash, p_add->p_payment_hash, LN_SZ_HASH);
             ucoin_buf_alloccopy(&p_fwd_add->shared_secret, p_add->p_shared_secret->buf, p_add->p_shared_secret->len);
 
@@ -2089,7 +2092,7 @@ static void cb_fulfill_htlc_recv(lnapp_conf_t *p_conf, void *p_param)
         //mMuxTiming |= MUX_RECV_FULFILL_HTLC | MUX_SEND_FULFILL_HTLC;
 
         //フラグを立てて、相手の受信スレッドで処理してもらう
-        DBG_PRINTF("戻す: %" PRIx64 ", id=%" PRIx64 "\n", p_fulfill->prev_short_channel_id, p_fulfill->id);
+        DBG_PRINTF("戻す: %" PRIx64 ", id=%" PRIx64 "\n", p_fulfill->prev_short_channel_id, p_fulfill->prev_id);
         backward_fulfill(p_fulfill);
     } else {
         //mMuxTiming |= MUX_RECV_FULFILL_HTLC;
@@ -2123,7 +2126,7 @@ static void cb_fail_htlc_recv(lnapp_conf_t *p_conf, void *p_param)
 
     if (p_fail->prev_short_channel_id != 0) {
         //フラグを立てて、相手の受信スレッドで処理してもらう
-        DBG_PRINTF("fail戻す: %" PRIx64 ", id=%" PRIx64 "\n", p_fail->prev_short_channel_id, p_fail->id);
+        DBG_PRINTF("fail戻す: %" PRIx64 ", id=%" PRIx64 "\n", p_fail->prev_short_channel_id, p_fail->prev_id);
         backward_fail(p_fail);
     } else {
         DBG_PRINTF("ここまで\n");
@@ -2761,7 +2764,7 @@ static void show_self_param(const ln_self_t *self, FILE *fp, int line)
                 fprintf(fp, "      id= %" PRIx64 "\n", p_add->id);
                 fprintf(fp, "    amount_msat= %" PRIu64 "\n", p_add->amount_msat);
                 if (p_add->prev_short_channel_id) {
-                    fprintf(fp, "    from:        %" PRIx64 "\n", p_add->prev_short_channel_id);
+                    fprintf(fp, "    from:        %" PRIx64 ": %" PRIu64 "\n", p_add->prev_short_channel_id, p_add->prev_id);
                 }
             }
         }


### PR DESCRIPTION
#53 
`update_fulfill_htlc` 作成時は `id` を使わず、 HTLCから `payment_hash` を検索する