### PR TITLE
Issue 53 2

### DIFF
--- a/include/ucoind.h
+++ b/include/ucoind.h
@@ -230,6 +230,7 @@ typedef struct {
     uint8_t     payment_hash[LN_SZ_HASH];
     uint64_t    next_short_channel_id;
     uint64_t    prev_short_channel_id;
+    uint64_t    prev_id;
     ucoin_buf_t shared_secret;
 } fwd_proc_add_t;
 

--- a/ucoin/include/ln.h
+++ b/ucoin/include/ln.h
@@ -419,6 +419,7 @@ typedef struct {
     //fulfillで戻す
     uint8_t     signature[LN_SZ_SIGNATURE];         ///< HTLC署名
     uint64_t    prev_short_channel_id;              ///< 転送元short_channel_id
+    uint64_t    prev_id;                            ///< 転送元id
     //failで戻す
     ucoin_buf_t shared_secret;                      ///< failuremsg暗号化用
 } ln_update_add_htlc_t;
@@ -731,7 +732,8 @@ typedef struct {
  *  @brief  update_fulfill_htlc受信通知(#LN_CB_FULFILL_HTLC_RECV)
  */
 typedef struct {
-    uint64_t                prev_short_channel_id;  ///< 転送元
+    uint64_t                prev_short_channel_id;  ///< 転送元short_channel_id
+    uint64_t                prev_id;                ///< 転送元id
     const uint8_t           *p_preimage;            ///< update_fulfill_htlcで受信したpreimage(スタック)
     uint64_t                id;                     ///< HTLC id
 } ln_cb_fulfill_htlc_recv_t;
@@ -741,7 +743,8 @@ typedef struct {
  *  @brief  update_fail_htlc受信通知(#LN_CB_FAIL_HTLC_RECV)
  */
 typedef struct {
-    uint64_t                prev_short_channel_id;  ///< 転送元
+    uint64_t                prev_short_channel_id;  ///< 転送元short_channel_id
+    uint64_t                prev_id;                ///< 転送元id
     const ucoin_buf_t       *p_reason;              ///< reason
     const ucoin_buf_t       *p_shared_secret;       ///< shared secret
     uint64_t                id;                     ///< HTLC id
@@ -1242,6 +1245,7 @@ bool ln_create_shutdown(ln_self_t *self, ucoin_buf_t *pShutdown);
  * @param[in]           cltv_value      CLTV値
  * @param[in]           pPaymentHash    PaymentHash(SHA256:32byte)
  * @param[in]           prev_short_channel_id   転送元short_channel_id(ない場合は0)
+ * @param[in]           prev_id                 転送元id
  * @param[in]           pSharedSecrets  保存する共有秘密鍵集(NULL:未保存)
  * @retval      true    成功
  * @note
@@ -1253,6 +1257,7 @@ bool ln_create_add_htlc(ln_self_t *self, ucoin_buf_t *pAdd,
             uint32_t cltv_value,
             const uint8_t *pPaymentHash,
             uint64_t prev_short_channel_id,
+            uint64_t prev_id,
             const ucoin_buf_t *pSharedSecrets);
 
 

--- a/ucoin/include/ln.h
+++ b/ucoin/include/ln.h
@@ -733,7 +733,6 @@ typedef struct {
  */
 typedef struct {
     uint64_t                prev_short_channel_id;  ///< 転送元short_channel_id
-    uint64_t                prev_id;                ///< 転送元id
     const uint8_t           *p_preimage;            ///< update_fulfill_htlcで受信したpreimage(スタック)
     uint64_t                id;                     ///< HTLC id
 } ln_cb_fulfill_htlc_recv_t;
@@ -744,7 +743,6 @@ typedef struct {
  */
 typedef struct {
     uint64_t                prev_short_channel_id;  ///< 転送元short_channel_id
-    uint64_t                prev_id;                ///< 転送元id
     const ucoin_buf_t       *p_reason;              ///< reason
     const ucoin_buf_t       *p_shared_secret;       ///< shared secret
     uint64_t                id;                     ///< HTLC id

--- a/ucoin/include/ln.h
+++ b/ucoin/include/ln.h
@@ -426,8 +426,6 @@ typedef struct {
 
 /** @struct     ln_update_fulfill_htlc_t
  *  @brief      update_fulfill_htlc
- *  @note
- *      - "id"はreadのみ使用する。create時はpayment_hashを検索する。
  */
 typedef struct {
     uint8_t     *p_channel_id;                      ///< 32: channel-id
@@ -1262,10 +1260,11 @@ bool ln_create_add_htlc(ln_self_t *self, ucoin_buf_t *pAdd,
  *
  * @param[in,out]       self            channel情報
  * @param[out]          pFulfill        生成したupdate_fulfill_htlcメッセージ
+ * @param[in]           id              HTLC id
  * @param[in]           pPreImage       反映するHTLCのpayment-preimage
  * @retval      true    成功
  */
-bool ln_create_fulfill_htlc(ln_self_t *self, ucoin_buf_t *pFulfill, const uint8_t *pPreImage);
+bool ln_create_fulfill_htlc(ln_self_t *self, ucoin_buf_t *pFulfill, uint64_t id, const uint8_t *pPreImage);
 
 
 /** update_fail_htlcメッセージ作成

--- a/ucoin/src/ln/ln.c
+++ b/ucoin/src/ln/ln.c
@@ -872,7 +872,7 @@ bool ln_create_add_htlc(ln_self_t *self, ucoin_buf_t *pAdd,
 }
 
 
-bool ln_create_fulfill_htlc(ln_self_t *self, ucoin_buf_t *pFulfill, const uint8_t *pPreImage)
+bool ln_create_fulfill_htlc(ln_self_t *self, ucoin_buf_t *pFulfill, uint64_t id, const uint8_t *pPreImage)
 {
     DBG_PRINTF("BEGIN\n");
 
@@ -883,6 +883,7 @@ bool ln_create_fulfill_htlc(ln_self_t *self, ucoin_buf_t *pFulfill, const uint8_
     }
     uint8_t sha256[LN_SZ_HASH];
     ucoin_util_sha256(sha256, pPreImage, LN_SZ_PREIMAGE);
+    DBG_PRINTF("id= %" PRIu64 "\n", id);
     DBG_PRINTF("recv payment_sha256= ");
     DUMPBIN(sha256, LN_SZ_PREIMAGE);
     ln_update_add_htlc_t *p_add = NULL;
@@ -890,9 +891,11 @@ bool ln_create_fulfill_htlc(ln_self_t *self, ucoin_buf_t *pFulfill, const uint8_
         //fulfill送信はReceived Outputに対して行う
         if (self->cnl_add_htlc[idx].amount_msat > 0) {
             DBG_PRINTF("LN_HTLC_FLAG_IS_RECV(self->cnl_add_htlc[idx].flag)=%d\n", LN_HTLC_FLAG_IS_RECV(self->cnl_add_htlc[idx].flag));
+            DBG_PRINTF("htlc_id=%" PRIu64 "\n", self->cnl_add_htlc[idx].id);
             DBG_PRINTF("payment_sha256= ");
             DUMPBIN(self->cnl_add_htlc[idx].payment_sha256, LN_SZ_PREIMAGE);
             if ( LN_HTLC_FLAG_IS_RECV(self->cnl_add_htlc[idx].flag) &&
+                 (id == self->cnl_add_htlc[idx].id) &&
                  (memcmp(sha256, self->cnl_add_htlc[idx].payment_sha256, LN_SZ_HASH) == 0) ) {
                 //
                 p_add = &self->cnl_add_htlc[idx];
@@ -907,7 +910,7 @@ bool ln_create_fulfill_htlc(ln_self_t *self, ucoin_buf_t *pFulfill, const uint8_
     }
     if (p_add->amount_msat == 0) {
         self->err = LNERR_INV_ID;
-        DBG_PRINTF("fail: cannot found HTLC\n");
+        DBG_PRINTF("fail: invalid id\n");
         return false;
     }
 

--- a/ucoin/src/ln/ln.c
+++ b/ucoin/src/ln/ln.c
@@ -2099,9 +2099,8 @@ static bool recv_update_fulfill_htlc(ln_self_t *self, const uint8_t *pData, uint
         //update_fulfill_htlc受信通知
         ln_cb_fulfill_htlc_recv_t fulfill;
         fulfill.prev_short_channel_id = prev_short_channel_id;
-        fulfill.prev_id = prev_id;
         fulfill.p_preimage = preimage;
-        //fulfill.id = fulfill_htlc.id;
+        fulfill.id = prev_id;
         (*self->p_callback)(self, LN_CB_FULFILL_HTLC_RECV, &fulfill);
     } else {
         self->err = LNERR_INV_ID;
@@ -2149,10 +2148,9 @@ static bool recv_update_fail_htlc(ln_self_t *self, const uint8_t *pData, uint16_
 
             ln_cb_fail_htlc_recv_t fail_recv;
             fail_recv.prev_short_channel_id = self->cnl_add_htlc[idx].prev_short_channel_id;
-            fail_recv.prev_id = self->cnl_add_htlc[idx].prev_id;
             fail_recv.p_reason = &reason;
             fail_recv.p_shared_secret = &self->cnl_add_htlc[idx].shared_secret;
-            fail_recv.id = self->cnl_add_htlc[idx].id;
+            fail_recv.id = self->cnl_add_htlc[idx].prev_id;
             (*self->p_callback)(self, LN_CB_FAIL_HTLC_RECV, &fail_recv);
 
             clear_htlc(self, &self->cnl_add_htlc[idx]);

--- a/ucoin/src/ln/ln.c
+++ b/ucoin/src/ln/ln.c
@@ -777,6 +777,7 @@ bool ln_create_add_htlc(ln_self_t *self, ucoin_buf_t *pAdd,
             uint32_t cltv_value,
             const uint8_t *pPaymentHash,
             uint64_t prev_short_channel_id,
+            uint64_t prev_id,
             const ucoin_buf_t *pSharedSecrets)
 {
     DBG_PRINTF("BEGIN\n");
@@ -853,6 +854,7 @@ bool ln_create_add_htlc(ln_self_t *self, ucoin_buf_t *pAdd,
     memcpy(self->cnl_add_htlc[idx].payment_sha256, pPaymentHash, LN_SZ_HASH);
     self->cnl_add_htlc[idx].p_onion_route = (CONST_CAST uint8_t *)pPacket;
     self->cnl_add_htlc[idx].prev_short_channel_id = prev_short_channel_id;
+    self->cnl_add_htlc[idx].prev_id = prev_id;
     ucoin_buf_free(&self->cnl_add_htlc[idx].shared_secret);
     if (pSharedSecrets) {
         self->cnl_add_htlc[idx].shared_secret.buf = pSharedSecrets->buf;
@@ -2090,15 +2092,16 @@ static bool recv_update_fulfill_htlc(ln_self_t *self, const uint8_t *pData, uint
         self->their_msat += p_add->amount_msat;
 
         uint64_t prev_short_channel_id = p_add->prev_short_channel_id; //CB用
-        uint64_t prev_id = fulfill_htlc.id;  //CB用
+        uint64_t prev_id = p_add->prev_id;  //CB用
 
         clear_htlc(self, p_add);
 
         //update_fulfill_htlc受信通知
         ln_cb_fulfill_htlc_recv_t fulfill;
         fulfill.prev_short_channel_id = prev_short_channel_id;
+        fulfill.prev_id = prev_id;
         fulfill.p_preimage = preimage;
-        fulfill.id = prev_id;
+        //fulfill.id = fulfill_htlc.id;
         (*self->p_callback)(self, LN_CB_FULFILL_HTLC_RECV, &fulfill);
     } else {
         self->err = LNERR_INV_ID;
@@ -2146,6 +2149,7 @@ static bool recv_update_fail_htlc(ln_self_t *self, const uint8_t *pData, uint16_
 
             ln_cb_fail_htlc_recv_t fail_recv;
             fail_recv.prev_short_channel_id = self->cnl_add_htlc[idx].prev_short_channel_id;
+            fail_recv.prev_id = self->cnl_add_htlc[idx].prev_id;
             fail_recv.p_reason = &reason;
             fail_recv.p_shared_secret = &self->cnl_add_htlc[idx].shared_secret;
             fail_recv.id = self->cnl_add_htlc[idx].id;

--- a/ucoind/lnapp.c
+++ b/ucoind/lnapp.c
@@ -134,6 +134,7 @@ void ucoin_dbg_free(void *ptr, int line)
  ********************************************************************/
 
 typedef struct {
+    uint64_t    id;
     uint8_t     preimage[LN_SZ_PREIMAGE];
 } fwd_proc_fulfill_t;
 
@@ -464,6 +465,7 @@ bool lnapp_backward_fulfill(lnapp_conf_t *pAppConf, const ln_cb_fulfill_htlc_rec
     }
 
     fwd_proc_fulfill_t *p_fwd_fulfill = (fwd_proc_fulfill_t *)MM_MALLOC(sizeof(fwd_proc_fulfill_t));   //free: fwd_fulfill_backward()
+    p_fwd_fulfill->id = pFulFill->id;
     memcpy(p_fwd_fulfill->preimage, pFulFill->p_preimage, LN_SZ_PREIMAGE);
 
     return set_request_recvproc(pAppConf, FWD_PROC_FULFILL, (uint16_t)sizeof(fwd_proc_fulfill_t), p_fwd_fulfill);
@@ -1511,10 +1513,12 @@ static bool fwd_fulfill_backward(lnapp_conf_t *p_conf)
 
     show_self_param(p_conf->p_self, PRINTOUT, __LINE__);
 
+    DBG_PRINTF("id= %" PRIx64 "\n", p_fwd_fulfill->id);
     DBG_PRINTF("preimage= ");
     DUMPBIN(p_fwd_fulfill->preimage, LN_SZ_PREIMAGE);
 
-    ret = ln_create_fulfill_htlc(p_conf->p_self, &buf_bolt, p_fwd_fulfill->preimage);
+    ret = ln_create_fulfill_htlc(p_conf->p_self, &buf_bolt,
+                            p_fwd_fulfill->id, p_fwd_fulfill->preimage);
     assert(ret);
     send_peer_noise(p_conf, &buf_bolt);
     ucoin_buf_free(&buf_bolt);

--- a/ucoind/lnapp.c
+++ b/ucoind/lnapp.c
@@ -232,9 +232,9 @@ static void poll_normal_operating(lnapp_conf_t *p_conf);
 
 static bool set_request_recvproc(lnapp_conf_t *p_conf, recv_proc_t cmd, uint16_t Len, void *pData);
 
-static bool fwd_payment_forward(lnapp_conf_t *pAppConf);
-static bool fwd_fulfill_backward(lnapp_conf_t *pAppConf);
-static bool fwd_fail_backward(lnapp_conf_t *pAppConf);
+static bool fwd_payment_forward(lnapp_conf_t *p_conf, fwd_proc_add_t *p_fwd_add);
+static bool fwd_fulfill_backward(lnapp_conf_t *p_conf, fwd_proc_fulfill_t *p_fwd_fulfill);
+static bool fwd_fail_backward(lnapp_conf_t *p_conf, fwd_proc_fail_t *p_fwd_fail);
 
 static void notify_cb(ln_self_t *self, ln_cb_t reason, void *p_param);
 static void cb_error_recv(lnapp_conf_t *p_conf, void *p_param);
@@ -491,7 +491,7 @@ bool lnapp_backward_fail(lnapp_conf_t *pAppConf, const ln_cb_fail_htlc_recv_t *p
     fwd_proc_fail_t *p_fwd_fail = (fwd_proc_fail_t *)MM_MALLOC(sizeof(fwd_proc_fail_t));   //free: fwd_fail_backward()
     p_fwd_fail->id = pFail->id;
     ucoin_buf_alloccopy(&p_fwd_fail->reason, pFail->p_reason->buf, pFail->p_reason->len);
-    ucoin_buf_alloccopy(&p_fwd_fail->shared_secret,
+    ucoin_buf_alloccopy(&p_fwd_fail->shared_secret,     //free:fwd_fail_backward()
                             pFail->p_shared_secret->buf, pFail->p_shared_secret->len);
     p_fwd_fail->b_first = bFirst;
 
@@ -1128,15 +1128,15 @@ static void recv_node_proc(lnapp_conf_t *p_conf)
     switch (p_conf->fwd_proc[p_conf->fwd_proc_rpnt].cmd) {
     case FWD_PROC_ADD:
         DBG_PRINTF("FWD_PROC_ADD\n");
-        ret = fwd_payment_forward(p_conf);
+        ret = fwd_payment_forward(p_conf, (fwd_proc_add_t *)p_conf->fwd_proc[p_conf->fwd_proc_rpnt].p_data);
         break;
     case FWD_PROC_FULFILL:
         DBG_PRINTF("FWD_PROC_FULFILL\n");
-        ret = fwd_fulfill_backward(p_conf);
+        ret = fwd_fulfill_backward(p_conf, (fwd_proc_fulfill_t *)p_conf->fwd_proc[p_conf->fwd_proc_rpnt].p_data);
         break;
     case FWD_PROC_FAIL:
         DBG_PRINTF("FWD_PROC_FAIL\n");
-        ret = fwd_fail_backward(p_conf);
+        ret = fwd_fail_backward(p_conf, (fwd_proc_fail_t *)p_conf->fwd_proc[p_conf->fwd_proc_rpnt].p_data);
         break;
     case INNER_SEND_ANNO_SIGNS:
         {
@@ -1432,18 +1432,15 @@ static bool set_request_recvproc(lnapp_conf_t *p_conf, recv_proc_t cmd, uint16_t
  ********************************************************************/
 
 // 別ノードからの update_add_htlc
-static bool fwd_payment_forward(lnapp_conf_t *p_conf)
+static bool fwd_payment_forward(lnapp_conf_t *p_conf, fwd_proc_add_t *p_fwd_add)
 {
     DBGTRACE_BEGIN
 
     bool ret;
     ucoin_buf_t buf_bolt;
     ucoin_buf_init(&buf_bolt);
-    fwd_proc_add_t *p_fwd_add = (fwd_proc_add_t *)(p_conf->fwd_proc[p_conf->fwd_proc_rpnt].p_data);
 
     wait_mutex_lock(MUX_CHG_HTLC);
-
-    show_self_param(p_conf->p_self, PRINTOUT, __LINE__);
 
     //DBG_PRINTF("------------------------------: %p\n", p_fwd_add);
     //DBG_PRINTF("fwd_proc_add_t.amt_to_forward= %" PRIu64 "\n", p_fwd_add->amt_to_forward);
@@ -1480,8 +1477,6 @@ static bool fwd_payment_forward(lnapp_conf_t *p_conf)
 LABEL_EXIT:
     ucoin_buf_free(&buf_bolt);
 
-    //free(p_fwd_add);    //malloc: lnapp_forward_payment()-->recv_node_proc()で解放
-
     if (ret) {
         // method: forward
         // $1: short_channel_id
@@ -1499,19 +1494,18 @@ LABEL_EXIT:
 
     DBGTRACE_END
 
-    return ret;
+    return true;    //true:キュー解放
 }
 
 
 // 別ノードからの update_fullfil_htlc
-static bool fwd_fulfill_backward(lnapp_conf_t *p_conf)
+static bool fwd_fulfill_backward(lnapp_conf_t *p_conf, fwd_proc_fulfill_t *p_fwd_fulfill)
 {
     DBGTRACE_BEGIN
 
     bool ret;
     ucoin_buf_t buf_bolt;
     ucoin_buf_init(&buf_bolt);
-    fwd_proc_fulfill_t *p_fwd_fulfill = (fwd_proc_fulfill_t *)(p_conf->fwd_proc[p_conf->fwd_proc_rpnt].p_data);
 
     show_self_param(p_conf->p_self, PRINTOUT, __LINE__);
 
@@ -1524,7 +1518,6 @@ static bool fwd_fulfill_backward(lnapp_conf_t *p_conf)
     assert(ret);
     send_peer_noise(p_conf, &buf_bolt);
     ucoin_buf_free(&buf_bolt);
-    //free(p_fwd_fulfill);        //malloc: lnapp_backward_fulfill()-->recv_node_proc()で解放
 
     //fulfill送信する場合はcommitment_signedも送信する
     ret = ln_create_commit_signed(p_conf->p_self, &buf_bolt);
@@ -1554,19 +1547,18 @@ static bool fwd_fulfill_backward(lnapp_conf_t *p_conf)
 
     DBGTRACE_END
 
-    return ret;
+    return true;    //true:キュー解放
 }
 
 
 // 別ノードからの update_fail_htlc
-static bool fwd_fail_backward(lnapp_conf_t *p_conf)
+static bool fwd_fail_backward(lnapp_conf_t *p_conf, fwd_proc_fail_t *p_fwd_fail)
 {
     DBGTRACE_BEGIN
 
     bool ret = false;
     ucoin_buf_t buf_bolt;
     ucoin_buf_init(&buf_bolt);
-    fwd_proc_fail_t *p_fwd_fail = (fwd_proc_fail_t *)(p_conf->fwd_proc[p_conf->fwd_proc_rpnt].p_data);
 
     show_self_param(p_conf->p_self, PRINTOUT, __LINE__);
 
@@ -1590,7 +1582,6 @@ static bool fwd_fail_backward(lnapp_conf_t *p_conf)
     ucoin_buf_free(&buf_bolt);
     ucoin_buf_free(&p_fwd_fail->reason);
     ucoin_buf_free(&p_fwd_fail->shared_secret);
-    //free(p_fwd_fail);       //malloc: lnapp_backward_fail()-->recv_node_proc()で解放
 
     //fail送信する場合はcommitment_signedも送信する
     ret = ln_create_commit_signed(p_conf->p_self, &buf_bolt);
@@ -1612,7 +1603,7 @@ static bool fwd_fail_backward(lnapp_conf_t *p_conf)
 
     DBGTRACE_END
 
-    return ret;
+    return true;    //true:キュー解放
 }
 
 
@@ -1954,125 +1945,114 @@ static void cb_add_htlc_recv(lnapp_conf_t *p_conf, void *p_param)
     DBG_PRINTF("mMuxTiming %d\n", mMuxTiming);
     DBG_PRINTF2("  id=%" PRIu64 "\n", p_add->id);
 
-    if (p_add->amount_msat) {
-        //
-        //転送https://github.com/lightningnetwork/lightning-rfc
-        //
+    DBG_PRINTF2("  b_exit: %d\n", p_add->p_hop->b_exit);
+    //転送先
+    DBG_PRINTF2("  FWD: short_channel_id: %" PRIx64 "\n", p_add->p_hop->short_channel_id);
+    DBG_PRINTF2("  FWD: amt_to_forward: %" PRIu64 "\n", p_add->p_hop->amt_to_forward);
+    DBG_PRINTF2("  FWD: outgoing_cltv_value: %d\n", p_add->p_hop->outgoing_cltv_value);
+    DBG_PRINTF2("  -------\n");
+    //自分への通知
+    DBG_PRINTF2("  amount_msat: %" PRIu64 "\n", p_add->amount_msat);
+    DBG_PRINTF2("  cltv_expiry: %d\n", p_add->cltv_expiry);
+    DBG_PRINTF2("  my fee : %" PRIu64 "\n", (uint64_t)(p_add->amount_msat - p_add->p_hop->amt_to_forward));
+    DBG_PRINTF2("  cltv_delta : %" PRIu32 " - %" PRIu32" = %d\n", p_add->cltv_expiry, p_add->p_hop->outgoing_cltv_value, p_add->cltv_expiry - p_add->p_hop->outgoing_cltv_value);
 
-        DBG_PRINTF2("  b_exit: %d\n", p_add->p_hop->b_exit);
-        //転送先
-        DBG_PRINTF2("  FWD: short_channel_id: %" PRIx64 "\n", p_add->p_hop->short_channel_id);
-        DBG_PRINTF2("  FWD: amt_to_forward: %" PRIu64 "\n", p_add->p_hop->amt_to_forward);
-        DBG_PRINTF2("  FWD: outgoing_cltv_value: %d\n", p_add->p_hop->outgoing_cltv_value);
-        DBG_PRINTF2("  -------\n");
-        //自分への通知
-        DBG_PRINTF2("  amount_msat: %" PRIu64 "\n", p_add->amount_msat);
-        DBG_PRINTF2("  cltv_expiry: %d\n", p_add->cltv_expiry);
-        DBG_PRINTF2("  my fee : %" PRIu64 "\n", (uint64_t)(p_add->amount_msat - p_add->p_hop->amt_to_forward));
-        DBG_PRINTF2("  cltv_delta : %" PRIu32 " - %" PRIu32" = %d\n", p_add->cltv_expiry, p_add->p_hop->outgoing_cltv_value, p_add->cltv_expiry - p_add->p_hop->outgoing_cltv_value);
+    preimage_lock();
+    if (p_add->p_hop->b_exit) {
+        //自分宛
+        DBG_PRINTF("自分宛\n");
 
-        preimage_lock();
-        if (p_add->p_hop->b_exit) {
-            //自分宛
-            DBG_PRINTF("自分宛\n");
+        SYSLOG_INFO("arrive: %" PRIx64 "(%" PRIu64 " msat)", ln_short_channel_id(p_conf->p_self), p_add->amount_msat);
 
-            SYSLOG_INFO("arrive: %" PRIx64 "(%" PRIu64 " msat)", ln_short_channel_id(p_conf->p_self), p_add->amount_msat);
+        //preimage-hashチェック
+        uint8_t preimage_hash[LN_SZ_HASH];
+        const preimage_t *p_preimage;
 
-            //preimage-hashチェック
-            uint8_t preimage_hash[LN_SZ_HASH];
-            const preimage_t *p_preimage;
-
-            int lp;
-            for (lp = 0; lp < PREIMAGE_NUM; lp++) {
-                p_preimage = preimage_get(lp);
-                if (p_preimage->use) {
-                    ln_calc_preimage_hash(preimage_hash, p_preimage->preimage);
-                    if (memcmp(preimage_hash, p_add->p_payment_hash, LN_SZ_HASH) == 0) {
-                        //一致
-                        break;
-                    }
+        int lp;
+        for (lp = 0; lp < PREIMAGE_NUM; lp++) {
+            p_preimage = preimage_get(lp);
+            if (p_preimage->use) {
+                ln_calc_preimage_hash(preimage_hash, p_preimage->preimage);
+                if (memcmp(preimage_hash, p_add->p_payment_hash, LN_SZ_HASH) == 0) {
+                    //一致
+                    break;
                 }
             }
-            if (lp < PREIMAGE_NUM) {
-                //last nodeチェック
-                // https://github.com/nayuta-ueno/lightning-rfc/blob/master/04-onion-routing.md#payload-for-the-last-node
-                //    * outgoing_cltv_value is set to the final expiry specified by the recipient
-                //    * amt_to_forward is set to the final amount specified by the recipient
-#if 0
-                if ( (p_add->p_hop->amt_to_forward == p_preimage->amount) &&
-                     (p_add->p_hop->outgoing_cltv_value == ln_cltv_expily_delta(p_conf->p_self)) ) {
-#else
-                if ( (p_add->p_hop->amt_to_forward == p_preimage->amount) &&
-                     (p_add->p_hop->amt_to_forward == p_add->amount_msat) &&
-                     //(p_add->p_hop->outgoing_cltv_value == ln_cltv_expily_delta(p_conf->p_self)) &&
-                     (p_add->p_hop->outgoing_cltv_value == p_add->cltv_expiry)  ) {
-#endif
-                    DBG_PRINTF("last node OK\n");
-                } else {
-                    SYSLOG_ERR("%s(): last node check", __func__);
-                    DBG_PRINTF("%" PRIu64 " != %" PRIu64 "\n", p_add->p_hop->amt_to_forward, p_preimage->amount);
-                    //DBG_PRINTF("%" PRIu32 " != %" PRIu32 "\n", p_add->p_hop->outgoing_cltv_value, ln_cltv_expily_delta(p_conf->p_self));
-                    lp = PREIMAGE_NUM;
-                }
+        }
+        if (lp < PREIMAGE_NUM) {
+            //last nodeチェック
+            // https://github.com/nayuta-ueno/lightning-rfc/blob/master/04-onion-routing.md#payload-for-the-last-node
+            //    * outgoing_cltv_value is set to the final expiry specified by the recipient
+            //    * amt_to_forward is set to the final amount specified by the recipient
+            if ( (p_add->p_hop->amt_to_forward == p_preimage->amount) &&
+                 (p_add->p_hop->amt_to_forward == p_add->amount_msat) &&
+                 //(p_add->p_hop->outgoing_cltv_value == ln_cltv_expily_delta(p_conf->p_self)) &&
+                 (p_add->p_hop->outgoing_cltv_value == p_add->cltv_expiry)  ) {
+                DBG_PRINTF("last node OK\n");
             } else {
-                DBG_PRINTF("fail: preimage mismatch\n");
-                DUMPBIN(p_add->p_payment_hash, LN_SZ_HASH);
-            }
-            if (lp < PREIMAGE_NUM) {
-                //キューにためる(fulfill)
-                queue_fulfill_t *fulfill = (queue_fulfill_t *)MM_MALLOC(sizeof(queue_fulfill_t));
-                fulfill->type = QTYPE_BWD_FULFILL_HTLC;
-                fulfill->id = p_add->id;
-                ucoin_buf_alloccopy(&fulfill->buf, p_preimage->preimage, LN_SZ_PREIMAGE);
-                push_queue(p_conf, fulfill);
-
-                //preimageを使い終わったら消す
-                preimage_clear(lp);
-
-                //アプリ判定はOK
-                p_add->ok = true;
-            } else {
-                SYSLOG_ERR("%s(): payment stop", __func__);
-
-                //キューにためる(fail)
-                queue_fulfill_t *fulfill = (queue_fulfill_t *)MM_MALLOC(sizeof(queue_fulfill_t));
-                fulfill->type = QTYPE_BWD_FAIL_HTLC;
-                fulfill->id = p_add->id;
-                ucoin_buf_alloccopy(&fulfill->buf, p_add->p_shared_secret->buf, p_add->p_shared_secret->len);
-                push_queue(p_conf, fulfill);
+                SYSLOG_ERR("%s(): last node check", __func__);
+                DBG_PRINTF("%" PRIu64 " != %" PRIu64 "\n", p_add->p_hop->amt_to_forward, p_preimage->amount);
+                //DBG_PRINTF("%" PRIu32 " != %" PRIu32 "\n", p_add->p_hop->outgoing_cltv_value, ln_cltv_expily_delta(p_conf->p_self));
+                lp = PREIMAGE_NUM;
             }
         } else {
-            //転送
-            SYSLOG_INFO("forward: %" PRIx64 "(%" PRIu64 " msat) --> %" PRIx64 "(%" PRIu64 " msat)", ln_short_channel_id(p_conf->p_self), p_add->amount_msat, p_add->p_hop->short_channel_id, p_add->p_hop->amt_to_forward);
-
-            //キューにためる(add)
-            queue_fulfill_t *fulfill = (queue_fulfill_t *)MM_MALLOC(sizeof(queue_fulfill_t));
-            fulfill->type = QTYPE_FWD_ADD_HTLC;
-            fulfill->id = p_add->id;
-            //forward情報
-            ucoin_buf_alloc(&fulfill->buf, sizeof(fwd_proc_add_t));
-            fwd_proc_add_t *p_fwd_add = (fwd_proc_add_t *)fulfill->buf.buf;
-            memcpy(p_fwd_add->onion_route, p_add->p_onion_route, LN_SZ_ONION_ROUTE);
-            p_fwd_add->amt_to_forward = p_add->p_hop->amt_to_forward;
-            p_fwd_add->outgoing_cltv_value = p_add->p_hop->outgoing_cltv_value;
-            p_fwd_add->next_short_channel_id = p_add->p_hop->short_channel_id;
-            p_fwd_add->prev_short_channel_id = ln_short_channel_id(p_conf->p_self);
-            p_fwd_add->prev_id = p_add->id;
-            memcpy(p_fwd_add->payment_hash, p_add->p_payment_hash, LN_SZ_HASH);
-            ucoin_buf_alloccopy(&p_fwd_add->shared_secret, p_add->p_shared_secret->buf, p_add->p_shared_secret->len);
-
-            push_queue(p_conf, fulfill);
-            p_add->ok = true;
-            //DBG_PRINTF("------------------------------: %p\n", p_fwd_add);
-            //DBG_PRINTF("fwd_proc_add_t.amt_to_forward= %" PRIu64 "\n", p_fwd_add->amt_to_forward);
-            //DBG_PRINTF("fwd_proc_add_t.outgoing_cltv_value= %d\n", (int)p_fwd_add->outgoing_cltv_value);
-            //DBG_PRINTF("fwd_proc_add_t.next_short_channel_id= %" PRIx64 "\n", p_fwd_add->next_short_channel_id);  //next
-            //DBG_PRINTF("fwd_proc_add_t.prev_short_channel_id= %" PRIx64 "\n", p_fwd_add->prev_short_channel_id);  //next
-            //DBG_PRINTF("short_channel_id= %" PRIx64 "\n", ln_short_channel_id(p_conf->p_self));         //current
-            //DBG_PRINTF("------------------------------\n");
+            DBG_PRINTF("fail: preimage mismatch\n");
+            DUMPBIN(p_add->p_payment_hash, LN_SZ_HASH);
         }
-        preimage_unlock();
+        if (lp < PREIMAGE_NUM) {
+            //キューにためる(fulfill)
+            queue_fulfill_t *fulfill = (queue_fulfill_t *)MM_MALLOC(sizeof(queue_fulfill_t));
+            fulfill->type = QTYPE_BWD_FULFILL_HTLC;
+            fulfill->id = p_add->id;
+            ucoin_buf_alloccopy(&fulfill->buf, p_preimage->preimage, LN_SZ_PREIMAGE);
+            push_queue(p_conf, fulfill);
+
+            //preimageを使い終わったら消す
+            preimage_clear(lp);
+
+            //アプリ判定はOK
+            p_add->ok = true;
+        } else {
+            SYSLOG_ERR("%s(): payment stop", __func__);
+
+            //キューにためる(fail)
+            queue_fulfill_t *fulfill = (queue_fulfill_t *)MM_MALLOC(sizeof(queue_fulfill_t));
+            fulfill->type = QTYPE_BWD_FAIL_HTLC;
+            fulfill->id = p_add->id;
+            ucoin_buf_alloccopy(&fulfill->buf, p_add->p_shared_secret->buf, p_add->p_shared_secret->len);
+            push_queue(p_conf, fulfill);
+        }
+    } else {
+        //転送
+        SYSLOG_INFO("forward: %" PRIx64 "(%" PRIu64 " msat) --> %" PRIx64 "(%" PRIu64 " msat)", ln_short_channel_id(p_conf->p_self), p_add->amount_msat, p_add->p_hop->short_channel_id, p_add->p_hop->amt_to_forward);
+
+        //キューにためる(add)
+        queue_fulfill_t *fulfill = (queue_fulfill_t *)MM_MALLOC(sizeof(queue_fulfill_t));
+        fulfill->type = QTYPE_FWD_ADD_HTLC;
+        fulfill->id = (uint64_t)-1;     //未使用
+        //forward情報
+        ucoin_buf_alloc(&fulfill->buf, sizeof(fwd_proc_add_t));
+        fwd_proc_add_t *p_fwd_add = (fwd_proc_add_t *)fulfill->buf.buf;
+        memcpy(p_fwd_add->onion_route, p_add->p_onion_route, LN_SZ_ONION_ROUTE);
+        p_fwd_add->amt_to_forward = p_add->p_hop->amt_to_forward;
+        p_fwd_add->outgoing_cltv_value = p_add->p_hop->outgoing_cltv_value;
+        p_fwd_add->next_short_channel_id = p_add->p_hop->short_channel_id;
+        p_fwd_add->prev_short_channel_id = ln_short_channel_id(p_conf->p_self);
+        p_fwd_add->prev_id = p_add->id;
+        memcpy(p_fwd_add->payment_hash, p_add->p_payment_hash, LN_SZ_HASH);
+        ucoin_buf_alloccopy(&p_fwd_add->shared_secret, p_add->p_shared_secret->buf, p_add->p_shared_secret->len);   // freeなし: lnで管理
+
+        push_queue(p_conf, fulfill);
+        p_add->ok = true;
+        //DBG_PRINTF("------------------------------: %p\n", p_fwd_add);
+        //DBG_PRINTF("fwd_proc_add_t.amt_to_forward= %" PRIu64 "\n", p_fwd_add->amt_to_forward);
+        //DBG_PRINTF("fwd_proc_add_t.outgoing_cltv_value= %d\n", (int)p_fwd_add->outgoing_cltv_value);
+        //DBG_PRINTF("fwd_proc_add_t.next_short_channel_id= %" PRIx64 "\n", p_fwd_add->next_short_channel_id);  //next
+        //DBG_PRINTF("fwd_proc_add_t.prev_short_channel_id= %" PRIx64 "\n", p_fwd_add->prev_short_channel_id);  //next
+        //DBG_PRINTF("short_channel_id= %" PRIx64 "\n", ln_short_channel_id(p_conf->p_self));         //current
+        //DBG_PRINTF("------------------------------\n");
     }
+    preimage_unlock();
 
     wait_mutex_unlock(MUX_CHG_HTLC);
 

--- a/ucoind/lnapp.c
+++ b/ucoind/lnapp.c
@@ -1509,7 +1509,7 @@ static bool fwd_fulfill_backward(lnapp_conf_t *p_conf, fwd_proc_fulfill_t *p_fwd
 
     show_self_param(p_conf->p_self, PRINTOUT, __LINE__);
 
-    DBG_PRINTF("id= %" PRIx64 "\n", p_fwd_fulfill->id);
+    DBG_PRINTF("id= %" PRIu64 "\n", p_fwd_fulfill->id);
     DBG_PRINTF("preimage= ");
     DUMPBIN(p_fwd_fulfill->preimage, LN_SZ_PREIMAGE);
 
@@ -2083,7 +2083,7 @@ static void cb_fulfill_htlc_recv(lnapp_conf_t *p_conf, void *p_param)
         //mMuxTiming |= MUX_RECV_FULFILL_HTLC | MUX_SEND_FULFILL_HTLC;
 
         //フラグを立てて、相手の受信スレッドで処理してもらう
-        DBG_PRINTF("戻す: %" PRIx64 ", id=%" PRIx64 "\n", p_fulfill->prev_short_channel_id, p_fulfill->prev_id);
+        DBG_PRINTF("戻す: %" PRIx64 ", id=%" PRIx64 "\n", p_fulfill->prev_short_channel_id, p_fulfill->id);
         backward_fulfill(p_fulfill);
     } else {
         //mMuxTiming |= MUX_RECV_FULFILL_HTLC;
@@ -2117,7 +2117,7 @@ static void cb_fail_htlc_recv(lnapp_conf_t *p_conf, void *p_param)
 
     if (p_fail->prev_short_channel_id != 0) {
         //フラグを立てて、相手の受信スレッドで処理してもらう
-        DBG_PRINTF("fail戻す: %" PRIx64 ", id=%" PRIx64 "\n", p_fail->prev_short_channel_id, p_fail->prev_id);
+        DBG_PRINTF("fail戻す: %" PRIx64 ", id=%" PRIx64 "\n", p_fail->prev_short_channel_id, p_fail->id);
         backward_fail(p_fail);
     } else {
         DBG_PRINTF("ここまで\n");


### PR DESCRIPTION
fix #53 

`update_fulfill_htlc` は payment_hashがわかるため idは不要だが、 `update_fail_htlc` はわからないため、 previous idが必要