### PR TITLE
Issue 35

### DIFF
--- a/ucoin/include/ln_db_lmdb.h
+++ b/ucoin/include/ln_db_lmdb.h
@@ -88,7 +88,7 @@ int ln_lmdb_load_anno_node_cursor(MDB_cursor *cur, ucoin_buf_t *pBuf, uint32_t *
  *
  *
  */
-int ln_lmdb_check_version(MDB_txn *txn);
+int ln_lmdb_check_version(MDB_txn *txn, uint8_t *pMyNodeId);
 
 
 ln_lmdb_dbtype_t ln_lmdb_get_dbtype(const char *pDbName);

--- a/ucoin/src/inc/ln/ln_local.h
+++ b/ucoin/src/inc/ln/ln_local.h
@@ -378,9 +378,9 @@ bool HIDDEN ln_derkey_storage_get_secret(uint8_t *pSecret, const ln_derkey_stora
 
 /** DB初期化
  *
- *
+ * @param[in]       pMyNodeId       非NULL時、DB保存するnode_id
  */
-void HIDDEN ln_db_init(void);
+void HIDDEN ln_db_init(const uint8_t *pMyNodeId);
 
 
 /** DBから取得したデータのみをコピー(self)

--- a/ucoin/src/ln/ln_node.c
+++ b/ucoin/src/ln/ln_node.c
@@ -70,7 +70,7 @@ bool ln_node_init(ln_node_t *node, const char *pWif, const char *pNodeName, uint
     strcpy(node->alias, pNodeName);
     node->features = Features;
 
-    ln_db_init();
+    ln_db_init(ln_node_id(node));
 
     ret = ln_db_load_anno_node(&buf_node, NULL, NULL, ln_node_id(node));
     if (!ret) {


### PR DESCRIPTION
fix #35 

* `ucoind`: DB "version"に、自node_id追加
* `routing`: 送金元が自node_id、送金先がpeerで、かつその間の short_channel_id が存在する場合、`channel_announcement` の有無にかかわらずrouting情報として追加する