### PR TITLE
Ignore mainnet

### DIFF
--- a/ucoin/src/ln/ln.c
+++ b/ucoin/src/ln/ln.c
@@ -3009,8 +3009,8 @@ static bool recv_channel_update(ln_self_t *self, const uint8_t *pData, uint16_t 
     DBG_PRINTF("\n");
 
     ln_cnl_update_t upd;
+    memset(&upd, 0, sizeof(upd));
 
-    //verify
     bool ret = ln_msg_cnl_update_read(&upd, pData, Len);
     if (ret) {
         //short_channel_id と dir から node_id を取得する
@@ -3021,11 +3021,9 @@ static bool recv_channel_update(ln_self_t *self, const uint8_t *pData, uint16_t 
             ret = ln_msg_cnl_update_verify(node_id, pData, Len);
         } else {
             DBG_PRINTF("fail: maybe no DB...ignore\n");
-            ln_msg_cnl_update_print(&upd);
-            ret = true;
         }
     } else {
-        DBG_PRINTF("fail: verify\n");
+        DBG_PRINTF("fail: channel_update\n");
     }
 
     if (ret) {
@@ -3035,6 +3033,10 @@ static bool recv_channel_update(ln_self_t *self, const uint8_t *pData, uint16_t 
         buf.len = Len;
         ret = ln_db_save_anno_channel_upd(&buf, upd.short_channel_id, upd.flags & 0x0001);
         DBG_PRINTF("db save ret=%d\n", ret);
+        ret = true;
+    } else {
+        //スルーするだけにとどめる
+        ln_msg_cnl_update_print(&upd);
         ret = true;
     }
 

--- a/ucoin/src/ln/ln.c
+++ b/ucoin/src/ln/ln.c
@@ -3016,11 +3016,14 @@ static bool recv_channel_update(ln_self_t *self, const uint8_t *pData, uint16_t 
         //short_channel_id と dir から node_id を取得する
         uint8_t node_id[UCOIN_SZ_PUBKEY];
 
-        ret = get_nodeid(node_id, upd.short_channel_id, upd.flags & 0x0001);
+        ret = get_nodeid(node_id, upd.short_channel_id, upd.flags & LN_CNLUPD_FLAGS_DIRECTION);
         if (ret && ucoin_keys_chkpub(node_id)) {
             ret = ln_msg_cnl_update_verify(node_id, pData, Len);
+            if (!ret) {
+                DBG_PRINTF("fail: verify\n");
+            }
         } else {
-            DBG_PRINTF("fail: maybe no DB...ignore\n");
+            DBG_PRINTF("fail: maybe not found channel_announcement in DB\n");
         }
     } else {
         DBG_PRINTF("fail: channel_update\n");
@@ -3031,12 +3034,11 @@ static bool recv_channel_update(ln_self_t *self, const uint8_t *pData, uint16_t 
         ucoin_buf_t buf;
         buf.buf = (CONST_CAST uint8_t *)pData;
         buf.len = Len;
-        ret = ln_db_save_anno_channel_upd(&buf, upd.short_channel_id, upd.flags & 0x0001);
+        ret = ln_db_save_anno_channel_upd(&buf, upd.short_channel_id, upd.flags & LN_CNLUPD_FLAGS_DIRECTION);
         DBG_PRINTF("db save ret=%d\n", ret);
         ret = true;
     } else {
         //スルーするだけにとどめる
-        ln_msg_cnl_update_print(&upd);
         ret = true;
     }
 

--- a/ucoin/src/ln/ln_msg_anno.c
+++ b/ucoin/src/ln/ln_msg_anno.c
@@ -809,14 +809,13 @@ bool HIDDEN ln_msg_cnl_update_read(ln_cnl_update_t *pMsg, const uint8_t *pData, 
     pos += LN_SZ_SIGNATURE;
 
     //    [32:chain_hash]
-    int cmp = memcmp(gGenesisChainHash, pData + pos, sizeof(gGenesisChainHash));
-    if (cmp != 0) {
+    bool chain_match = (memcmp(gGenesisChainHash, pData + pos, sizeof(gGenesisChainHash)) == 0);
+    if (!chain_match) {
         DBG_PRINTF("fail: chain_hash mismatch\n");
         DBG_PRINTF2("node: ");
         DUMPBIN(gGenesisChainHash, LN_SZ_HASH);
         DBG_PRINTF2("msg:  ");
         DUMPBIN(pData + pos, LN_SZ_HASH);
-        return false;
     }
     pos += sizeof(gGenesisChainHash);
 
@@ -855,7 +854,7 @@ bool HIDDEN ln_msg_cnl_update_read(ln_cnl_update_t *pMsg, const uint8_t *pData, 
     ln_msg_cnl_update_print(pMsg);
 #endif  //DBG_PRINT_CREATE
 
-    return true;
+    return chain_match;
 }
 
 
@@ -872,7 +871,6 @@ bool HIDDEN ln_msg_cnl_update_verify(const uint8_t *pPubkey, const uint8_t *pDat
     //DUMPBIN(hash, UCOIN_SZ_HASH256);
 
     ret = ucoin_tx_verify_rs(pData + sizeof(uint16_t), hash, pPubkey);
-    assert(ret);
 
     return ret;
 }

--- a/ucoind/lnapp.c
+++ b/ucoind/lnapp.c
@@ -1187,7 +1187,12 @@ static void *thread_recv_start(void *pArg)
             pthread_mutex_lock(&p_conf->mux_proc);
             ret = ln_recv(p_conf->p_self, buf_recv.buf, buf_recv.len);
             DBG_PRINTF("ln_recv() result=%d\n", ret);
-            assert(ret);
+            if (!ret) {
+                DBG_PRINTF("DISC: fail recv message\n");
+                lnapp_close_channel_force(ln_their_node_id(p_conf->p_self));
+                stop_threads(p_conf);
+                break;
+            }
             DBG_PRINTF("mux_proc: end\n");
             pthread_mutex_unlock(&p_conf->mux_proc);
         }


### PR DESCRIPTION
当面、mainnetに対応できていないため、chain_hashが不一致の場合は無視する。

- channel_update : DBに保存しない
- open_channel : socket切断