### PR TITLE
Pong wait

### DIFF
--- a/ucoin/include/ln.h
+++ b/ucoin/include/ln.h
@@ -1213,9 +1213,10 @@ void ln_flag_proc(ln_self_t *self);
  *
  * @param[in,out]       self            channel情報
  * @param[out]          pInit           initメッセージ
+ * @param[in]           bHaveCnl        true:チャネル開設済み
  * retval       true    成功
  */
-bool ln_create_init(ln_self_t *self, ucoin_buf_t *pInit);
+bool ln_create_init(ln_self_t *self, ucoin_buf_t *pInit, bool bHaveCnl);
 
 
 /** channel_reestablishメッセージ作成

--- a/ucoin/src/ln/ln.c
+++ b/ucoin/src/ln/ln.c
@@ -1361,7 +1361,8 @@ bool ln_create_ping(ln_self_t *self, ucoin_buf_t *pPing)
 
 #if 1
     if (self->last_num_pong_bytes == 0) {
-        ucoin_util_random((uint8_t *)&self->last_num_pong_bytes, 2);
+        //ucoin_util_random((uint8_t *)&self->last_num_pong_bytes, 2);
+        self->last_num_pong_bytes = 16;
     }
     ping.num_pong_bytes = self->last_num_pong_bytes;
     ucoin_util_random((uint8_t *)&ping.byteslen, 2);
@@ -1369,7 +1370,7 @@ bool ln_create_ping(ln_self_t *self, ucoin_buf_t *pPing)
     if (ret) {
         self->missing_pong_cnt++;
     }
-    DBG_PRINTF("missing_pong_cnt: %d\n", self->missing_pong_cnt);
+    DBG_PRINTF("missing_pong_cnt: %d / last_num_pong_bytes: %d\n", self->missing_pong_cnt, self->last_num_pong_bytes);
 #else
     if (self->last_num_pong_bytes != 0) {
         DBG_PRINTF("not receive pong\n");
@@ -1755,6 +1756,7 @@ static bool recv_pong(ln_self_t *self, const uint8_t *pData, uint16_t Len)
     ret = (pong.byteslen == self->last_num_pong_bytes);
     if (ret) {
         self->missing_pong_cnt--;
+        DBG_PRINTF("missing_pong_cnt: %d / last_num_pong_bytes: %d\n", self->missing_pong_cnt, self->last_num_pong_bytes);
         self->last_num_pong_bytes = 0;
     } else {
         DBG_PRINTF("fail: pong.byteslen(%" PRIu16 ") != self->last_num_pong_bytes(%" PRIu16 ")\n", pong.byteslen, self->last_num_pong_bytes);

--- a/ucoin/src/ln/ln.c
+++ b/ucoin/src/ln/ln.c
@@ -1370,11 +1370,13 @@ bool ln_create_ping(ln_self_t *self, ucoin_buf_t *pPing)
     uint8_t r;
     ucoin_util_random(&r, 1);
     self->last_num_pong_bytes = r;
+    ucoin_util_random(&r, 1);
+    ping.byteslen = r;
 #else
     ucoin_util_random((uint8_t *)&self->last_num_pong_bytes, 2);
+    ucoin_util_random((uint8_t *)&ping.byteslen, 2);
 #endif
     ping.num_pong_bytes = self->last_num_pong_bytes;
-    ucoin_util_random((uint8_t *)&ping.byteslen, 2);
     bool ret = ln_msg_ping_create(pPing, &ping);
     //if (ret) {
     //    self->missing_pong_cnt++;

--- a/ucoin/src/ln/ln.c
+++ b/ucoin/src/ln/ln.c
@@ -1372,8 +1372,8 @@ bool ln_create_ping(ln_self_t *self, ucoin_buf_t *pPing)
     self->last_num_pong_bytes = r;
 #else
     ucoin_util_random((uint8_t *)&self->last_num_pong_bytes, 2);
-    ping.num_pong_bytes = self->last_num_pong_bytes;
 #endif
+    ping.num_pong_bytes = self->last_num_pong_bytes;
     ucoin_util_random((uint8_t *)&ping.byteslen, 2);
     bool ret = ln_msg_ping_create(pPing, &ping);
     //if (ret) {

--- a/ucoin/src/ln/ln.c
+++ b/ucoin/src/ln/ln.c
@@ -502,7 +502,7 @@ bool ln_recv(ln_self_t *self, const uint8_t *pData, uint16_t Len)
 
 
 //init作成
-bool ln_create_init(ln_self_t *self, ucoin_buf_t *pInit)
+bool ln_create_init(ln_self_t *self, ucoin_buf_t *pInit, bool bHaveCnl)
 {
     if (self->init_flag & INIT_FLAG_SEND) {
         self->err = LNERR_INV_STATE;
@@ -515,18 +515,25 @@ bool ln_create_init(ln_self_t *self, ucoin_buf_t *pInit)
     //TODO: globalfeatures と localfeatures
     ucoin_buf_init(&msg.globalfeatures);
 
-#ifdef INIT_LF_VALUE
+    if (bHaveCnl) {
+        const uint8_t INIT_VAL[] = { INIT_LF_ROUTE_SYNC };
+        ucoin_buf_alloccopy(&msg.localfeatures, INIT_VAL, sizeof(INIT_VAL));
+    } else {
+        ucoin_buf_init(&msg.localfeatures);
+    }
 
-#if INIT_LF_SZ_VALUE > 0
-    const uint8_t INIT_VAL[] = INIT_LF_VALUE;
-    ucoin_buf_alloccopy(&msg.localfeatures, INIT_VAL, INIT_LF_SZ_VALUE);
-#else
-#error feature support
-#endif
+//#ifdef INIT_LF_VALUE
 
-#else
-    ucoin_buf_init(&msg.localfeatures);
-#endif
+//#if INIT_LF_SZ_VALUE > 0
+//    const uint8_t INIT_VAL[] = INIT_LF_VALUE;
+//    ucoin_buf_alloccopy(&msg.localfeatures, INIT_VAL, INIT_LF_SZ_VALUE);
+//#else
+//#error feature support
+//#endif
+
+//#else
+//    ucoin_buf_init(&msg.localfeatures);
+//#endif
 
     bool ret = ln_msg_init_create(pInit, &msg);
     if (ret) {

--- a/ucoin/src/ln/ln.c
+++ b/ucoin/src/ln/ln.c
@@ -1359,6 +1359,18 @@ bool ln_create_ping(ln_self_t *self, ucoin_buf_t *pPing)
 {
     ln_ping_t ping;
 
+#if 1
+    if (self->last_num_pong_bytes == 0) {
+        ucoin_util_random((uint8_t *)&self->last_num_pong_bytes, 2);
+    }
+    ping.num_pong_bytes = self->last_num_pong_bytes;
+    ucoin_util_random((uint8_t *)&ping.byteslen, 2);
+    bool ret = ln_msg_ping_create(pPing, &ping);
+    if (ret) {
+        self->missing_pong_cnt++;
+    }
+    DBG_PRINTF("missing_pong_cnt: %d\n", self->missing_pong_cnt);
+#else
     if (self->last_num_pong_bytes != 0) {
         DBG_PRINTF("not receive pong\n");
         return false;
@@ -1376,6 +1388,7 @@ bool ln_create_ping(ln_self_t *self, ucoin_buf_t *pPing)
         //    ret = false;
         //}
     }
+#endif
 
     return ret;
 }

--- a/ucoin/src/ln/ln_db_lmdb.c
+++ b/ucoin/src/ln/ln_db_lmdb.c
@@ -2246,7 +2246,9 @@ static int annocnl_load(ln_lmdb_db_t *pDb, ucoin_buf_t *pCnlAnno, uint64_t Short
     if (retval == 0) {
         ucoin_buf_alloccopy(pCnlAnno, data.mv_data, data.mv_size);
     } else {
-        DBG_PRINTF("err: %s\n", mdb_strerror(retval));
+        if (retval != MDB_NOTFOUND) {
+            DBG_PRINTF("err: %s\n", mdb_strerror(retval));
+        }
     }
 
     return retval;
@@ -2262,7 +2264,7 @@ static int annocnl_load(ln_lmdb_db_t *pDb, ucoin_buf_t *pCnlAnno, uint64_t Short
  */
 static int annocnl_save(ln_lmdb_db_t *pDb, const ucoin_buf_t *pCnlAnno, uint64_t ShortChannelId)
 {
-    //DBG_PRINTF("short_channel_id=%016" PRIx64 "\n", ShortChannelId);
+    DBG_PRINTF("short_channel_id=%016" PRIx64 "\n", ShortChannelId);
 
     MDB_val key, data;
     uint8_t keydata[M_SZ_ANNOINFO_CNL];
@@ -2352,7 +2354,9 @@ static int annocnlupd_load(ln_lmdb_db_t *pDb, ucoin_buf_t *pCnlUpd, uint32_t *pT
         *pTimeStamp = *(uint32_t *)data.mv_data;
         ucoin_buf_alloccopy(pCnlUpd, (uint8_t *)data.mv_data + sizeof(uint32_t), data.mv_size - sizeof(uint32_t));
     } else {
-        DBG_PRINTF("err: %s\n", mdb_strerror(retval));
+        if (retval != MDB_NOTFOUND) {
+            DBG_PRINTF("err: %s\n", mdb_strerror(retval));
+        }
     }
 
     return retval;
@@ -2415,7 +2419,9 @@ static int annonod_load(ln_lmdb_db_t *pDb, ucoin_buf_t *pNodeAnno, uint32_t *pTi
             ucoin_buf_alloccopy(pNodeAnno, (uint8_t *)data.mv_data + sizeof(uint32_t), data.mv_size - sizeof(uint32_t));
         }
     } else {
-        //DBG_PRINTF("err: %s\n", mdb_strerror(retval));
+        if (retval != MDB_NOTFOUND) {
+            DBG_PRINTF("err: %s\n", mdb_strerror(retval));
+        }
     }
 
     return retval;

--- a/ucoind/lnapp.c
+++ b/ucoind/lnapp.c
@@ -1209,8 +1209,7 @@ static void *thread_recv_start(void *pArg)
             //DBG_PRINTF("ln_recv() result=%d\n", ret);
             if (!ret) {
                 DBG_PRINTF("DISC: fail recv message\n");
-#warning closeしなくしておく
-                //lnapp_close_channel_force(ln_their_node_id(p_conf->p_self));
+                lnapp_close_channel_force(ln_their_node_id(p_conf->p_self));
                 stop_threads(p_conf);
                 break;
             }

--- a/ucoind/lnapp.c
+++ b/ucoind/lnapp.c
@@ -854,8 +854,6 @@ static void *thread_main_start(void *pArg)
         //my_selfの主要なデータはDBから読込まれている(copy_channel() : ln_node.c)
         if (ln_short_channel_id(&my_self) != 0) {
             DBG_PRINTF("Establish済み : %d\n", p_conf->cmd);
-            send_reestablish(p_conf);
-            DBG_PRINTF("reestablish交換完了\n\n");
 
 #warning おそらく、切断によってdisableにした状態を戻すために行っているが、まだdisableにする送信を行っていない
             // //channel_update更新
@@ -879,6 +877,8 @@ static void *thread_main_start(void *pArg)
             p_conf->funding_min_depth = ln_minimum_depth(&my_self);
             p_conf->funding_waiting = true;
         }
+        send_reestablish(p_conf);
+        DBG_PRINTF("reestablish交換完了\n\n");
     } else {
         DBG_PRINTF("Establish待ち\n");
         set_establish_default(p_conf, p_conf->node_id);

--- a/ucoind/lnapp.c
+++ b/ucoind/lnapp.c
@@ -1420,8 +1420,8 @@ static void poll_ping(lnapp_conf_t *p_conf)
             send_peer_noise(p_conf, &buf_ping);
             ucoin_buf_free(&buf_ping);
         } else {
-            SYSLOG_ERR("%s(): pong not respond", __func__);
-            stop_threads(p_conf);
+            //SYSLOG_ERR("%s(): pong not respond", __func__);
+            //stop_threads(p_conf);
         }
     }
 

--- a/ucoind/lnapp.c
+++ b/ucoind/lnapp.c
@@ -819,7 +819,7 @@ static void *thread_main_start(void *pArg)
     {
         ucoin_buf_t buf_bolt;
         ucoin_buf_init(&buf_bolt);
-        ret = ln_create_init(&my_self, &buf_bolt);
+        ret = ln_create_init(&my_self, &buf_bolt, detect);
         if (!ret) {
             goto LABEL_JOIN;
         }

--- a/ucoind/lnapp.c
+++ b/ucoind/lnapp.c
@@ -1209,7 +1209,8 @@ static void *thread_recv_start(void *pArg)
             //DBG_PRINTF("ln_recv() result=%d\n", ret);
             if (!ret) {
                 DBG_PRINTF("DISC: fail recv message\n");
-                lnapp_close_channel_force(ln_their_node_id(p_conf->p_self));
+#warning closeしなくしておく
+                //lnapp_close_channel_force(ln_their_node_id(p_conf->p_self));
                 stop_threads(p_conf);
                 break;
             }


### PR DESCRIPTION
`lnd`と接続をしたが、2つ問題があった。

- `ping`を送信しても`pong`がなかなか返ってこない
  - 5回`ping`送信して`pong`が返ってこなければ切断するようにしていた
- 切断しないようにすると、`pong`がそのうち返ってきたが、どの`ping`に対する`pong`かわからなかった
- `pong`が返ってくるまでは`num_ping_bytes`を同じ値で送信するようにしたが、`pong`がいつ返ってくるか分からない
- `pong`が返ってくるまで何も送信しないようにしたら、5分未送信で`lnd`から切断された

`pong`は返ってこないことがあるらしく、そのタイムアウトや処理は今のところBOLTで既定はない(切断しても良い、くらい)。
https://github.com/lightningnetwork/lightning-rfc/issues/373

`lnd`の`num_ping_bytes`が現在16に固定されている影響かわからないが、大きい`num_ping_bytes`に対してのpongが遅延しているように見える。
https://github.com/lightningnetwork/lnd/blob/18741831dd6efe9cfc575ade72f4ed8bbc279505/peer.go#L1128

今は`num_ping_bytes`を16bitの乱数で指定していて`pong`がいつ返ってくるか分からないが、`lnd`と接続している範囲では、8bitの乱数程度であればすぐに`pong`を返しているようである。