### PR TITLE
no pong check and send ping always

### DIFF
--- a/ucoin/src/ln/ln.c
+++ b/ucoin/src/ln/ln.c
@@ -1359,10 +1359,10 @@ bool ln_create_ping(ln_self_t *self, ucoin_buf_t *pPing)
 {
     ln_ping_t ping;
 
-    if (self->last_num_pong_bytes != 0) {
-        DBG_PRINTF("not receive pong(last_num_pong_bytes=%d)\n", self->last_num_pong_bytes);
-        return false;
-    }
+    // if (self->last_num_pong_bytes != 0) {
+    //     DBG_PRINTF("not receive pong(last_num_pong_bytes=%d)\n", self->last_num_pong_bytes);
+    //     return false;
+    // }
 
 #if 1
     // https://github.com/lightningnetwork/lightning-rfc/issues/373
@@ -1759,7 +1759,7 @@ static bool recv_pong(ln_self_t *self, const uint8_t *pData, uint16_t Len)
     }
 
     DBG_PRINTF("END\n");
-    return ret;
+    return true;
 }
 
 


### PR DESCRIPTION
`lnd`は5分未送信であれば切断する。
しかし、`ping`に対して`pong`を必ず返すわけでも無いようである。
そうなると、`ping`送信に対する`pong`を待ち続けていると、送信するものが無くなり、5分で切断されてしまう。

やむなく、こうする。

- `ping`送信は、未送信状態が60秒経過したら送信する(bytesは0～255の乱数)
- `pong`受信は、パケットとして正常であればOKとする(num_pong_bytesのチェックをしない)