### PR TITLE
JSON-RPC only localhost

### DIFF
--- a/libs/Makefile
+++ b/libs/Makefile
@@ -10,7 +10,7 @@ mk_install:
 	@mkdir -p $(INSTALL_DIR)/lib
 
 mk_jsonrpc_c:
-	cd jsonrpc-c; autoreconf -i ; ./configure --prefix=$(INSTALL_DIR) --disable-shared ; make CFLAGS=-DNO_CHECK_LOCALHOST LDFLAGS=-lm ; make install ; cd ..
+	cd jsonrpc-c; autoreconf -i ; ./configure --prefix=$(INSTALL_DIR) --disable-shared ; make CFLAGS=LDFLAGS=-lm ; make install ; cd ..
 
 mk_inih:
 	cd inih/extra ; EXTRACCFLAGS="-g -O2 -D'INI_INLINE_COMMENT_PREFIXES=\"#\"' -DINI_STOP_ON_FIRST_ERROR=1" make -f Makefile.static ; cd ../..


### PR DESCRIPTION
テスト用に別IPアドレスからでもJSON-RPCを受け付けるようにしていたが、元に戻しておく。