### PR TITLE
Short db lock

### DIFF
--- a/ucoin/src/ln/ln_db_lmdb.c
+++ b/ucoin/src/ln/ln_db_lmdb.c
@@ -1749,8 +1749,9 @@ bool ln_db_revtx_load(ln_self_t *self, void *pDbParam)
     }
 
     ln_free_revoked_buf(self);
-
     key.mv_size = 3;
+
+    //number of vout scripts
     key.mv_data = "rvn";
     retval = mdb_get(txn, dbi, &key, &data);
     if (retval != 0) {
@@ -1761,6 +1762,8 @@ bool ln_db_revtx_load(ln_self_t *self, void *pDbParam)
     self->revoked_cnt = p[0];
     self->revoked_num = p[1];
     ln_alloc_revoked_buf(self);
+
+    //vout scripts
     key.mv_data = "rvv";
     retval = mdb_get(txn, dbi, &key, &data);
     if (retval != 0) {
@@ -1775,6 +1778,7 @@ bool ln_db_revtx_load(ln_self_t *self, void *pDbParam)
         p_scr += len;
     }
 
+    //witness script
     key.mv_data = "rvw";
     retval = mdb_get(txn, dbi, &key, &data);
     if (retval != 0) {
@@ -1789,6 +1793,7 @@ bool ln_db_revtx_load(ln_self_t *self, void *pDbParam)
         p_scr += len;
     }
 
+    //remote per_commit_secret
     key.mv_data = "rvs";
     retval = mdb_get(txn, dbi, &key, &data);
     if (retval != 0) {
@@ -1798,6 +1803,7 @@ bool ln_db_revtx_load(ln_self_t *self, void *pDbParam)
     ucoin_buf_free(&self->revoked_sec);
     ucoin_buf_alloccopy(&self->revoked_sec, data.mv_data, data.mv_size);
 
+    //confirmation数
     key.mv_data = "rvc";
     retval = mdb_get(txn, dbi, &key, &data);
     if (retval != 0) {

--- a/ucoind/inc/lnapp.h
+++ b/ucoind/inc/lnapp.h
@@ -60,7 +60,6 @@ typedef enum {
 
     //内部用
     INNER_SEND_ANNO_SIGNS,          ///< announcement_signatures送信要求
-    INNER_SEND_ANNOUNCEMENT,        ///< announcement送信要求
 } recv_proc_t;
 
 
@@ -109,6 +108,10 @@ typedef struct lnapp_conf_t {
 
     //fulfillキュー
     queue_fulfill_t *p_fulfill_queue;
+
+    //last send announcement
+    uint64_t        last_anno_cnl;                      ///< 最後にannouncementしたchannel
+    uint8_t         last_anno_node[UCOIN_SZ_PUBKEY];    ///< 最後にannouncementしたnode
 
     int             err;            ///< last error
     char            *p_errstr;      ///< last error string

--- a/ucoind/monitoring.c
+++ b/ucoind/monitoring.c
@@ -299,6 +299,8 @@ static bool funding_spent(ln_self_t *self, uint32_t confm, void *p_db_param)
 
 static bool funding_unspent(ln_self_t *self, uint32_t confm, void *p_db_param)
 {
+    (void)p_db_param;
+
     bool del = false;
 
     DBG_PRINTF("opening: funding_tx[conf=%u, idx=%d]: ", confm, ln_funding_txindex(self));


### PR DESCRIPTION
announcementを一度に相手channelに送信するかどうかチェックしていると、DBのロック時間が長くなる。
announcementのDBはノード内の全チャネルが頻繁に確認するため、長時間ロックするのは望ましくない。

今回はチェックを毎秒行うように誌、「channel_announcement/channel_update」を3つ、「node_announcement」を3つまでチェックするように変更した。