### PR TITLE
last err in getinfo

### DIFF
--- a/ucoind/lnapp.c
+++ b/ucoind/lnapp.c
@@ -655,6 +655,9 @@ void lnapp_show_self(const lnapp_conf_t *pAppConf, cJSON *pResult)
     } else {
         cJSON_AddItemToObject(result, "status", cJSON_CreateString("disconnected"));
     }
+    if ((pAppConf->err != 0) && (pAppConf->p_errstr != NULL)) {
+        cJSON_AddItemToObject(result, "last_errmsg", cJSON_CreateString(pAppConf->p_errstr));
+    }
     cJSON_AddItemToArray(pResult, result);
 }
 


### PR DESCRIPTION
getinfoでlast errorを出力する。
-wは使わなくてもよくなるが、残しておく。