### PR TITLE
onion failのhop数を取得

### DIFF
--- a/ucoin/gtests/testinc_ln_bolt4.cpp
+++ b/ucoin/gtests/testinc_ln_bolt4.cpp
@@ -1118,14 +1118,16 @@ TEST_F(onion, testvector_failure_resolve_api)
     ucoin_buf_t err = { (CONST_CAST uint8_t *)ERR0, sizeof(ERR0) };
 
     ucoin_buf_t reason;
+    int hop;
     ucoin_buf_init(&reason);
-    ret = ln_onion_failure_read(&reason, &shared_secrets, &err);
+    ret = ln_onion_failure_read(&reason, &hop, &shared_secrets, &err);
     ASSERT_TRUE(ret);
     ucoin_buf_free(&shared_secrets);
 
     ASSERT_EQ(2, reason.len);
     ASSERT_EQ(0x20, reason.buf[0]);
     ASSERT_EQ(0x02, reason.buf[1]);
+    ASSERT_EQ(4, hop);
     ucoin_buf_free(&reason);
 }
 

--- a/ucoin/include/ln.h
+++ b/ucoin/include/ln.h
@@ -1957,10 +1957,12 @@ void ln_onion_failure_forward(ucoin_buf_t *pNextPacket,
 /** ONION failureパケット解析
  *
  * @param[out]      pReason             Failure Message
+ * @param[out]      pHop                エラー元までのノード数(0は相手ノード)
  * @param[in]       pSharedSecrets      ONIONパケット生成自の全shared secret(#ln_onion_create_packet())
  * @param[in]       pPacket             受信したONION failureパケット
  */
 bool ln_onion_failure_read(ucoin_buf_t *pReason,
+            int *pHop,
             const ucoin_buf_t *pSharedSecrets,
             const ucoin_buf_t *pPacket);
 

--- a/ucoin/src/ln/ln_onion.c
+++ b/ucoin/src/ln/ln_onion.c
@@ -414,12 +414,16 @@ void ln_onion_failure_forward(ucoin_buf_t *pNextPacket,
 
 
 bool ln_onion_failure_read(ucoin_buf_t *pReason,
+            int *pHop,
             const ucoin_buf_t *pSharedSecrets,
             const ucoin_buf_t *pPacket)
 {
     const int DATALEN = 256;
 
     int NumHops = pSharedSecrets->len / UCOIN_SZ_PRIVKEY;
+    if (pHop != NULL) {
+        *pHop = -1;
+    }
 
 #ifdef M_DBG_FAIL
     DBG_PRINTF("NumHops=%d\n", NumHops);
@@ -469,6 +473,9 @@ bool ln_onion_failure_read(ucoin_buf_t *pReason,
                     bend = memcmp(p_out->buf, hmac, M_SZ_HMAC) == 0;
                     if (bend) {
                         DBG_PRINTF("decode hops=%d\n", lp);
+                        if (pHop != NULL) {
+                            *pHop = lp;
+                        }
                         ucoin_buf_alloccopy(pReason, reason.buf, reason.len);
                     } else {
                         DBG_PRINTF("fail: HMAC not match!\n");

--- a/ucoind/lnapp.c
+++ b/ucoind/lnapp.c
@@ -2254,8 +2254,9 @@ static void cb_fail_htlc_recv(lnapp_conf_t *p_conf, void *p_param)
         mMuxTiming &= ~MUX_PAYMENT;
 
         ucoin_buf_t reason;
+        int hop;
         ucoin_buf_init(&reason);
-        bool ret = ln_onion_failure_read(&reason, p_fail->p_shared_secret, p_fail->p_reason);
+        bool ret = ln_onion_failure_read(&reason, &hop, p_fail->p_shared_secret, p_fail->p_reason);
         if (ret) {
             DBG_PRINTF("  failure reason= ");
             DUMPBIN(reason.buf, reason.len);
@@ -2268,7 +2269,7 @@ static void cb_fail_htlc_recv(lnapp_conf_t *p_conf, void *p_param)
                 sprintf(bin, "%02x", reason.buf[lp]);
                 strcat(reasonstr, bin);
             }
-            sprintf(errstr, "fail reason:%s", reasonstr);
+            sprintf(errstr, "fail reason:%s(hop=%d)", reasonstr, hop);
             set_lasterror(p_conf, RPCERR_PAYFAIL, errstr);
         } else {
             //デコード失敗


### PR DESCRIPTION
paymentがupdate_fail_htlcになったときのlast errorで、エラーを返したと思われるノードまでのhop数を返す。