### PR TITLE
unilateral/revoked transaction close to_remote pay

### DIFF
--- a/cmn/btcrpc.c
+++ b/cmn/btcrpc.c
@@ -813,7 +813,7 @@ bool btcprc_getxout(bool *pUnspent, uint64_t *pSat, const uint8_t *pTxid, int Tx
     //まずtxの存在確認を行う
     retval = getraw_txstr(NULL, txid);
     if (!retval) {
-        DBG_PRINTF("fail: maybe not broadcasted\n");
+        //DBG_PRINTF("fail: maybe not broadcasted\n");
         goto LABEL_EXIT;
     }
 

--- a/ucoin/include/ln.h
+++ b/ucoin/include/ln.h
@@ -94,6 +94,11 @@ extern "C" {
 #define LN_CNLUPD_FLAGS_DIRECTION       (0x0001)    ///< b0: direction
 #define LN_CNLUPD_FLAGS_DISABLE         (0x0002)    ///< b1: disable
 
+// ln_close_force_t.p_tx, p_htlc_idxのインデックス値
+#define LN_CLOSE_IDX_COMMIT             (0)         ///< commit_tx
+#define LN_CLOSE_IDX_TOLOCAL            (1)         ///< to_local tx
+#define LN_CLOSE_IDX_HTLC               (2)         ///< HTLC tx
+
 #define LN_UGLY_NORMAL                              ///< payment_hashを保存するタイプ
                                                     ///< コメントアウトするとDB保存しなくなるが、revoked transaction closeから取り戻すために
                                                     ///< 相手のアクションが必要となる
@@ -418,6 +423,11 @@ typedef struct {
 
 /** @struct ln_close_force_t
  *  @brief  [Close]Unilateral Close / Revoked Transaction Close用
+ *  @note
+ *      - p_tx, p_htlc_idxのインデックス値
+ *          - commit_tx: LN_CLOSE_IDX_COMMIT
+ *          - to_local output: LN_CLOSE_IDX_TOLOCAL
+ *          - HTLC: LN_CLOSE_IDX_HTLC～
  */
 typedef struct {
     int             num;                            ///< p_bufのtransaction数

--- a/ucoin/include/ucoin.h
+++ b/ucoin/include/ucoin.h
@@ -109,6 +109,12 @@ extern "C" {
 #define UCOIN_OP_SZ32           "\x20"          ///< 32byte値
 #define UCOIN_OP_SZ_PUBKEY      "\x21"          ///< 33byte値
 
+#define UCOIN_DUST_LIMIT        ((uint64_t)546) ///< voutに指定できるamountの下限[satoshis]
+                                                // 2018/02/11 17:54(JST)
+                                                // https://github.com/bitcoin/bitcoin/blob/fe53d5f3636aed064823bc220d828c7ff08d1d52/src/test/transaction_tests.cpp#L695
+                                                //
+                                                // https://github.com/bitcoin/bitcoin/blob/5961b23898ee7c0af2626c46d5d70e80136578d3/src/policy/policy.cpp#L52-L55
+
 
 /**************************************************************************
  * macro functions
@@ -143,6 +149,11 @@ extern "C" {
  *  @brief  scriptPubKey(P2SH)からPubKeyHashアドレス位置算出
  */
 #define UCOIN_VOUT2PKH_P2SH(script)     ((script) + 2)
+
+/** @def    UCOIN_IS_DUST
+ *  @brief  amountが支払いに使用できないDUSTかどうかチェックする(true:支払えない)
+ */
+#define UCOIN_IS_DUST(amount)           (UCOIN_DUST_LIMIT > (amount))
 
 
 /**************************************************************************
@@ -831,7 +842,7 @@ bool ucoin_tx_verify_p2sh_addr(const ucoin_tx_t *pTx, int Index, const uint8_t *
 
 
 /** 公開鍵復元
- * 
+ *
  * @param[out]      pPubKey
  * @param[in]       RecId       recovery ID
  * @param[in]       pRS
@@ -842,7 +853,7 @@ bool ucoin_tx_recover_pubkey(uint8_t *pPubKey, int RecId, const uint8_t *pRS, co
 
 
 /** 公開鍵復元ID取得
- * 
+ *
  * @param[out]      pRecId      recovery ID
  * @param[in]       pPubKey
  * @param[in]       pRS

--- a/ucoin/src/ln/ln.c
+++ b/ucoin/src/ln/ln.c
@@ -63,6 +63,23 @@
                                                             //      amount 8
                                                             //      scriptpk 1+len
                                                             // locktime 4
+
+#define M_SZ_TO_REMOTE_TX(len)                  (169+len)   ///< to_remote transaction長[byte]
+                                                            // <version> 4
+                                                            // <flag><marker> 2
+                                                            // vin_cnt 1
+                                                            //      outpoint 36
+                                                            //      scriptSig 1
+                                                            //      sequence 4
+                                                            // witness 1
+                                                            //      sig 73
+                                                            //      1
+                                                            //      pubkey 33
+                                                            // vout_cnt 1
+                                                            //      amount 8
+                                                            //      scriptpk 1+len
+                                                            // locktime 4
+
 #define M_SZ_TO_LOCAL_PENALTY                   (324)
 #define M_SZ_OFFERED_PENALTY                    (407)
 #define M_SZ_RECEIVED_PENALTY                   (413)
@@ -998,18 +1015,27 @@ void ln_free_close_force_tx(ln_close_force_t *pClose)
 }
 
 
+/* 相手にrevoked transaction closeされた場合に1回だけ呼び出す。
+ * これ以降、鍵などは相手が送信したrevoked transaction当時のものに戻される。
+ *      1. sequenceとlocktimeからcommitment number復元
+ *      2. localとremoteの per_commitment_secret復元
+ *      3. 鍵復元
+ *      4. HTLCごと
+ *          4.1 DBから当時のpayment_hashを検索
+ *          4.2 script復元
+ */
 bool ln_close_ugly(ln_self_t *self, const ucoin_tx_t *pRevokedTx, void *pDbParam)
 {
     //取り戻す必要があるvout数
     self->revoked_cnt = 0;
     for (int lp = 0; lp < pRevokedTx->vout_cnt; lp++) {
         if (pRevokedTx->vout[lp].script.len != M_SZ_WITPROG_WPKH) {
-            //to_remote output以外は取り戻す
+            //to_remote output以外はスクリプトを作って取り戻す
             self->revoked_cnt++;
         }
     }
     DBG_PRINTF("revoked_cnt=%d\n", self->revoked_cnt);
-    self->revoked_num = 1 + self->revoked_cnt;  //[0]にto_local系を入れるため+1する
+    self->revoked_num = LN_RCLOSE_IDX_HTLC + self->revoked_cnt;  //[0]to_local, [1]to_remote, [2-]HTLC
     ln_alloc_revoked_buf(self);
 
     //
@@ -1026,11 +1052,11 @@ bool ln_close_ugly(ln_self_t *self, const ucoin_tx_t *pRevokedTx, void *pDbParam
     ucoin_buf_alloc(&self->revoked_sec, UCOIN_SZ_PRIVKEY);
     bool ret = ln_derkey_storage_get_secret(self->revoked_sec.buf, &self->peer_storage, (uint64_t)(M_SECINDEX_INIT - commit_num));
     assert(ret);
-    DBG_PRINTF2("  pri:");
-    DUMPBIN(self->revoked_sec.buf, UCOIN_SZ_PRIVKEY);
-    DBG_PRINTF2("  pub:");
     ucoin_keys_priv2pub(self->funding_remote.pubkeys[MSG_FUNDIDX_PER_COMMIT], self->revoked_sec.buf);
-    DUMPBIN(self->funding_remote.pubkeys[MSG_FUNDIDX_PER_COMMIT], UCOIN_SZ_PUBKEY);
+    //DBG_PRINTF2("  pri:");
+    //DUMPBIN(self->revoked_sec.buf, UCOIN_SZ_PRIVKEY);
+    //DBG_PRINTF2("  pub:");
+    //DUMPBIN(self->funding_remote.pubkeys[MSG_FUNDIDX_PER_COMMIT], UCOIN_SZ_PUBKEY);
 
     //local per_commitment_secretの復元
     ln_derkey_create_secret(self->funding_local.keys[MSG_FUNDIDX_PER_COMMIT].priv, self->storage_seed, (uint64_t)(M_SECINDEX_INIT - commit_num));
@@ -1043,14 +1069,14 @@ bool ln_close_ugly(ln_self_t *self, const ucoin_tx_t *pRevokedTx, void *pDbParam
 
     //to_local outputとHTLC Timeout/Success Txのoutputは同じ形式のため、to_local outputの有無にかかわらず作っておく。
     //p_revoked_vout[0]にはscriptPubKey、p_revoked_wit[0]にはwitnessProgramを作る。
-    ln_create_script_local(&self->p_revoked_wit[0],
+    ln_create_script_local(&self->p_revoked_wit[LN_RCLOSE_IDX_TOLOCAL],
                 self->funding_remote.scriptpubkeys[MSG_SCRIPTIDX_REVOCATION],
                 self->funding_remote.scriptpubkeys[MSG_SCRIPTIDX_DELAYED],
                 self->commit_local.to_self_delay);
-    ucoin_buf_alloc(&self->p_revoked_vout[0], M_SZ_WITPROG_WSH);
-    ucoin_sw_wit2prog_p2wsh(self->p_revoked_vout[0].buf, &self->p_revoked_wit[0]);
+    ucoin_buf_alloc(&self->p_revoked_vout[LN_RCLOSE_IDX_TOLOCAL], M_SZ_WITPROG_WSH);
+    ucoin_sw_wit2prog_p2wsh(self->p_revoked_vout[LN_RCLOSE_IDX_TOLOCAL].buf, &self->p_revoked_wit[LN_RCLOSE_IDX_TOLOCAL]);
     DBG_PRINTF("calc to_local vout: ");
-    DUMPBIN(self->p_revoked_vout[0].buf, self->p_revoked_vout[0].len);
+    DUMPBIN(self->p_revoked_vout[LN_RCLOSE_IDX_TOLOCAL].buf, self->p_revoked_vout[LN_RCLOSE_IDX_TOLOCAL].len);
 
     for (int lp = 0; lp < pRevokedTx->vout_cnt; lp++) {
         DBG_PRINTF("vout[%d]: ", lp);
@@ -1058,7 +1084,8 @@ bool ln_close_ugly(ln_self_t *self, const ucoin_tx_t *pRevokedTx, void *pDbParam
         if (pRevokedTx->vout[lp].script.len == M_SZ_WITPROG_WPKH) {
             //to_remote output
             DBG_PRINTF("[%d]to_remote_output\n", lp);
-        } else if (ucoin_buf_cmp(&pRevokedTx->vout[lp].script, &self->p_revoked_vout[0])) {
+            ucoin_buf_alloccopy(&self->p_revoked_vout[LN_RCLOSE_IDX_TOREMOTE], pRevokedTx->vout[lp].script.buf, pRevokedTx->vout[lp].script.len);
+        } else if (ucoin_buf_cmp(&pRevokedTx->vout[lp].script, &self->p_revoked_vout[LN_RCLOSE_IDX_TOLOCAL])) {
             //to_local output
             DBG_PRINTF("[%d]to_local_output\n", lp);
         } else {
@@ -1072,16 +1099,16 @@ bool ln_close_ugly(ln_self_t *self, const ucoin_tx_t *pRevokedTx, void *pDbParam
             if (srch) {
                 DBG_PRINTF("[%d]detect!\n", lp);
 
-                ln_create_htlcinfo(&self->p_revoked_wit[1 + lp],
+                ln_create_htlcinfo(&self->p_revoked_wit[LN_RCLOSE_IDX_HTLC + lp],
                         type,
                         self->funding_remote.scriptpubkeys[MSG_SCRIPTIDX_LOCALHTLCKEY],
                         self->funding_remote.scriptpubkeys[MSG_SCRIPTIDX_REVOCATION],
                         self->funding_remote.scriptpubkeys[MSG_SCRIPTIDX_REMOTEHTLCKEY],
                         payhash,
                         expiry);
-                ucoin_buf_alloc(&self->p_revoked_vout[1 + lp], M_SZ_WITPROG_WSH);
-                ucoin_sw_wit2prog_p2wsh(self->p_revoked_vout[1 + lp].buf, &self->p_revoked_wit[1 + lp]);
-                self->p_revoked_type[1 + lp] = type;
+                ucoin_buf_alloc(&self->p_revoked_vout[LN_RCLOSE_IDX_HTLC + lp], M_SZ_WITPROG_WSH);
+                ucoin_sw_wit2prog_p2wsh(self->p_revoked_vout[LN_RCLOSE_IDX_HTLC + lp].buf, &self->p_revoked_wit[LN_RCLOSE_IDX_HTLC + lp]);
+                self->p_revoked_type[LN_RCLOSE_IDX_HTLC + lp] = type;
             } else {
                 DBG_PRINTF("[%d]not detect\n", lp);
             }
@@ -1413,7 +1440,8 @@ bool ln_create_tolocal_spent(const ln_self_t *self, ucoin_tx_t *pTx, uint64_t Va
 
     //to_localのFEE
     uint64_t fee_tolocal = M_SZ_TO_LOCAL_TX(self->shutdown_scriptpk_local.len) * self->feerate_per_kw / 1000;
-    if (Value < self->commit_local.dust_limit_sat + fee_tolocal) {
+    if (Value < UCOIN_DUST_LIMIT + fee_tolocal) {
+        DBG_PRINTF("fail: vout below dust(value=%" PRIu64 ", fee=%" PRIu64 ")\n", Value, fee_tolocal);
         goto LABEL_EXIT;
     }
     ret = ln_create_tolocal_tx(pTx, Value - fee_tolocal,
@@ -1438,13 +1466,58 @@ bool ln_create_tolocal_spent(const ln_self_t *self, ucoin_tx_t *pTx, uint64_t Va
                     self->revoked_sec.buf);
         ucoin_keys_priv2pub(signkey.pub, signkey.priv);
     }
-    DBG_PRINTF("key-priv: ");
-    DUMPBIN(signkey.priv, UCOIN_SZ_PRIVKEY);
-    DBG_PRINTF("key-pub : ");
-    DUMPBIN(signkey.pub, UCOIN_SZ_PUBKEY);
+    //DBG_PRINTF("key-priv: ");
+    //DUMPBIN(signkey.priv, UCOIN_SZ_PRIVKEY);
+    //DBG_PRINTF("key-pub : ");
+    //DUMPBIN(signkey.pub, UCOIN_SZ_PUBKEY);
 
     ucoin_buf_init(&sig);
     ret = ln_sign_tolocal_tx(pTx, &sig, Value, &signkey, pScript, bRevoked);
+    ucoin_buf_free(&sig);
+
+LABEL_EXIT:
+    return ret;
+}
+
+
+bool ln_create_toremote_spent(const ln_self_t *self, ucoin_tx_t *pTx, uint64_t Value, const uint8_t *pTxid, int Index)
+{
+    bool ret;
+    ucoin_util_keys_t signkey;
+    ucoin_buf_t sig;
+
+    //to_remoteのFEE
+    uint64_t fee_toremote = M_SZ_TO_REMOTE_TX(self->shutdown_scriptpk_local.len) * self->feerate_per_kw / 1000;
+    if (Value < UCOIN_DUST_LIMIT + fee_toremote) {
+        DBG_PRINTF("fail: vout below dust(value=%" PRIu64 ", fee=%" PRIu64 ")\n", Value, fee_toremote);
+        goto LABEL_EXIT;
+    }
+
+    // remotekeyへの支払いを self->shutdown_scriptpk_local に送金する
+    //  通常のP2WPKHなので、bRevoedはfalse扱い
+    //  to_local用の関数を使っているが、最低限の設定をしているだけなので同じ処理でよい
+    ucoin_tx_init(pTx);
+
+    ret = ln_create_tolocal_tx(pTx, Value - fee_toremote,
+            &self->shutdown_scriptpk_local, 0, pTxid, Index, false);
+    if (!ret) {
+        goto LABEL_EXIT;
+    }
+    //<remotesecretkey>
+    //  revoked transaction close後はremotekeyも当時のものになっているため、同じ処理でよい
+    ln_derkey_privkey(signkey.priv,
+                self->funding_local.keys[MSG_FUNDIDX_PAYMENT].pub,
+                self->funding_remote.pubkeys[MSG_FUNDIDX_PER_COMMIT],
+                self->funding_local.keys[MSG_FUNDIDX_PAYMENT].priv);
+    ucoin_keys_priv2pub(signkey.pub, signkey.priv);
+    assert(memcmp(signkey.pub, self->funding_remote.scriptpubkeys[MSG_SCRIPTIDX_REMOTEKEY], UCOIN_SZ_PUBKEY) == 0);
+    //DBG_PRINTF("key-priv: ");
+    //DUMPBIN(signkey.priv, UCOIN_SZ_PRIVKEY);
+    //DBG_PRINTF("key-pub : ");
+    //DUMPBIN(signkey.pub, UCOIN_SZ_PUBKEY);
+
+    ucoin_buf_init(&sig);
+    ret = ucoin_util_sign_p2wpkh(pTx, Index, Value, &signkey);
     ucoin_buf_free(&sig);
 
 LABEL_EXIT:
@@ -3197,19 +3270,21 @@ static bool create_to_local(ln_self_t *self,
     ucoin_buf_t buf_sig;
     ln_feeinfo_t feeinfo;
     ln_tx_cmt_t lntx_commit;
-    ucoin_tx_t tx_local;
+    ucoin_tx_t tx_commit;
     ucoin_tx_t *pTxCommit = NULL;
     ucoin_tx_t *pTxToLocal = NULL;
+    ucoin_tx_t *pTxToRemote = NULL;
     ucoin_tx_t *pTxHtlcs = NULL;
     ucoin_push_t push;
 
-    ucoin_tx_init(&tx_local);
+    ucoin_tx_init(&tx_commit);
     ucoin_buf_init(&buf_sig);
     ucoin_buf_init(&buf_ws);
 
     if (pClose != NULL) {
         pTxCommit = &pClose->p_tx[LN_CLOSE_IDX_COMMIT];
         pTxToLocal = &pClose->p_tx[LN_CLOSE_IDX_TOLOCAL];
+        pTxToRemote = &pClose->p_tx[LN_CLOSE_IDX_TOREMOTE];
         pTxHtlcs = &pClose->p_tx[LN_CLOSE_IDX_HTLC];
         ucoin_push_init(&push, &pClose->tx_buf, 0);
     }
@@ -3283,19 +3358,19 @@ static bool create_to_local(ln_self_t *self,
     lntx_commit.htlcinfo_num = cnt;
 
     DBG_PRINTF("self->commit_num=%" PRIx64 "\n", self->commit_num);
-    ret = ln_create_commit_tx(&tx_local, &buf_sig, &lntx_commit, ln_is_funder(self));
+    ret = ln_create_commit_tx(&tx_commit, &buf_sig, &lntx_commit, ln_is_funder(self));
     if (!ret) {
         DBG_PRINTF("fail: ln_create_commit_tx\n");
         return false;
     }
 
-    ret = ucoin_tx_txid(self->commit_local.txid, &tx_local);
+    ret = ucoin_tx_txid(self->commit_local.txid, &tx_commit);
     if (!ret) {
         DBG_PRINTF("fail: ucoin_tx_txid\n");
     }
 
     int htlc_num = 0;
-    if (tx_local.vout_cnt > 0) {
+    if (tx_commit.vout_cnt > 0) {
         //各HTLCの署名
         DBG_PRINTF("HTLC sign\n");
 
@@ -3314,12 +3389,12 @@ static bool create_to_local(ln_self_t *self,
             assert(memcmp(htlckey.pub, self->funding_local.scriptpubkeys[MSG_SCRIPTIDX_LOCALHTLCKEY], UCOIN_SZ_PUBKEY) == 0);
         }
 
-        for (int vout_idx = 0; vout_idx < tx_local.vout_cnt; vout_idx++) {
-            uint8_t htlc_idx = tx_local.vout[vout_idx].opt;
+        for (int vout_idx = 0; vout_idx < tx_commit.vout_cnt; vout_idx++) {
+            uint8_t htlc_idx = tx_commit.vout[vout_idx].opt;
             if (htlc_idx == LN_HTLCTYPE_TOLOCAL) {
                 DBG_PRINTF("+++[%d]to_local\n", vout_idx);
                 if (pTxToLocal != NULL) {
-                    ret = ln_create_tolocal_spent(self, &tx, tx_local.vout[vout_idx].value, to_self_delay,
+                    ret = ln_create_tolocal_spent(self, &tx, tx_commit.vout[vout_idx].value, to_self_delay,
                             &buf_ws, self->commit_local.txid, vout_idx, false);
                     if (ret) {
                         M_DBG_PRINT_TX(&tx);
@@ -3329,11 +3404,14 @@ static bool create_to_local(ln_self_t *self,
                 }
             } else if (htlc_idx == LN_HTLCTYPE_TOREMOTE) {
                 DBG_PRINTF("+++[%d]to_remote\n", vout_idx);
+                if (pTxToRemote != NULL) {
+                    ucoin_tx_init(pTxToRemote);    //to_remoteは相手が処理する
+                }
             } else {
                 uint64_t fee = (pp_htlcinfo[htlc_idx]->type == LN_HTLCTYPE_OFFERED) ? feeinfo.htlc_timeout : feeinfo.htlc_success;
-                if (tx_local.vout[vout_idx].value >= feeinfo.dust_limit_satoshi + fee) {
+                if (tx_commit.vout[vout_idx].value >= feeinfo.dust_limit_satoshi + fee) {
                     DBG_PRINTF("+++[%d]%s HTLC\n", vout_idx, (pp_htlcinfo[htlc_idx]->type == LN_HTLCTYPE_OFFERED) ? "offered" : "received");
-                    ln_create_htlc_tx(&tx, tx_local.vout[vout_idx].value - fee, &buf_ws,
+                    ln_create_htlc_tx(&tx, tx_commit.vout[vout_idx].value - fee, &buf_ws,
                                 pp_htlcinfo[htlc_idx]->type, pp_htlcinfo[htlc_idx]->expiry,
                                 self->commit_local.txid, vout_idx);
                     M_DBG_PRINT_TX(&tx);
@@ -3343,7 +3421,7 @@ static bool create_to_local(ln_self_t *self,
                         ucoin_buf_t buf_sig;
                         ln_misc_sigexpand(&buf_sig, p_htlc_sigs + htlc_num * LN_SZ_SIGNATURE);
                         ret = ln_verify_htlc_tx(&tx,
-                                    tx_local.vout[vout_idx].value,
+                                    tx_commit.vout[vout_idx].value,
                                     NULL,
                                     self->funding_local.scriptpubkeys[MSG_SCRIPTIDX_REMOTEHTLCKEY],
                                     NULL,
@@ -3380,7 +3458,7 @@ static bool create_to_local(ln_self_t *self,
                         ucoin_buf_t buf_local_sig;
                         ret = ln_sign_htlc_tx(&tx,
                                     &buf_local_sig,                 //<localsig>
-                                    tx_local.vout[vout_idx].value,
+                                    tx_commit.vout[vout_idx].value,
                                     &htlckey,
                                     &buf_sig,                       //<remotesig>
                                     (ret_img) ? preimage : NULL,
@@ -3391,7 +3469,7 @@ static bool create_to_local(ln_self_t *self,
 
                         ////署名チェック
                         //ret = ln_verify_htlc_tx(&tx,
-                        //            tx_local.vout[vout_idx].value,
+                        //            tx_commit.vout[vout_idx].value,
                         //            self->funding_local.scriptpubkeys[MSG_SCRIPTIDX_LOCALHTLCKEY],
                         //            self->funding_local.scriptpubkeys[MSG_SCRIPTIDX_REMOTEHTLCKEY],
                         //            &buf_local_sig,
@@ -3434,7 +3512,7 @@ static bool create_to_local(ln_self_t *self,
 
                     DBG_PRINTF("HTLC Timeout vout:%d - htlc:%d\n", vout_idx, htlc_idx);
                 } else {
-                    DBG_PRINTF("[%d] %" PRIu64 " > %" PRIu64 "\n", vout_idx, tx_local.vout[vout_idx].value, feeinfo.dust_limit_satoshi + fee);
+                    DBG_PRINTF("[%d] %" PRIu64 " > %" PRIu64 "\n", vout_idx, tx_commit.vout[vout_idx].value, feeinfo.dust_limit_satoshi + fee);
                 }
             }
         }
@@ -3468,20 +3546,20 @@ static bool create_to_local(ln_self_t *self,
 
         //署名追加
         ln_misc_sigexpand(&buf_sig_from_remote, self->commit_remote.signature);
-        ucoin_util_sign_p2wsh_3_2of2(&tx_local, 0, self->key_fund_sort,
+        ucoin_util_sign_p2wsh_3_2of2(&tx_commit, 0, self->key_fund_sort,
                                 &buf_sig,
                                 &buf_sig_from_remote,
                                 &self->redeem_fund);
-        DBG_PRINTF("++++++++++++++ 自分のcommit txに署名: tx_local[%" PRIx64 "]\n", self->short_channel_id);
-        M_DBG_PRINT_TX(&tx_local);
+        DBG_PRINTF("++++++++++++++ 自分のcommit txに署名: tx_commit[%" PRIx64 "]\n", self->short_channel_id);
+        M_DBG_PRINT_TX(&tx_commit);
 
         //
         // 署名verify
         //
         DBG_PRINTF("verify\n");
         ucoin_sw_scriptcode_p2wsh(&script_code, &self->redeem_fund);
-        ucoin_sw_sighash(sighash, &tx_local, 0, self->funding_sat, &script_code);
-        ret = ucoin_sw_verify_2of2(&tx_local, 0, sighash,
+        ucoin_sw_sighash(sighash, &tx_commit, 0, self->funding_sat, &script_code);
+        ret = ucoin_sw_verify_2of2(&tx_commit, 0, sighash,
                     &self->tx_funding.vout[self->funding_local.txindex].script);
         if (ret) {
             DBG_PRINTF("verify OK\n");
@@ -3496,9 +3574,9 @@ static bool create_to_local(ln_self_t *self,
     }
     ucoin_buf_free(&buf_sig);
     if (pTxCommit != NULL) {
-        memcpy(pTxCommit, &tx_local, sizeof(ucoin_tx_t));
+        memcpy(pTxCommit, &tx_commit, sizeof(ucoin_tx_t));
     } else {
-        ucoin_tx_free(&tx_local);
+        ucoin_tx_free(&tx_commit);
     }
 
     return ret;
@@ -3523,22 +3601,24 @@ static bool create_to_remote(ln_self_t *self,
 {
     DBG_PRINTF("BEGIN\n");
 
-    ucoin_tx_t tx_remote;
+    ucoin_tx_t tx_commit;
     ucoin_buf_t buf_sig;
     ucoin_buf_t buf_ws;
     ln_feeinfo_t feeinfo;
     ln_tx_cmt_t lntx_commit;
     ucoin_tx_t *pTxCommit = NULL;
     ucoin_tx_t *pTxToLocal = NULL;
+    ucoin_tx_t *pTxToRemote = NULL;
     ucoin_tx_t *pTxHtlcs = NULL;
 
-    ucoin_tx_init(&tx_remote);
+    ucoin_tx_init(&tx_commit);
     ucoin_buf_init(&buf_sig);
     ucoin_buf_init(&buf_ws);
 
     if (pClose != NULL) {
         pTxCommit = &pClose->p_tx[LN_CLOSE_IDX_COMMIT];
         pTxToLocal = &pClose->p_tx[LN_CLOSE_IDX_TOLOCAL];
+        pTxToRemote = &pClose->p_tx[LN_CLOSE_IDX_TOREMOTE];
         pTxHtlcs = &pClose->p_tx[LN_CLOSE_IDX_HTLC];
     }
 
@@ -3623,14 +3703,14 @@ static bool create_to_remote(ln_self_t *self,
     lntx_commit.htlcinfo_num = cnt;
 
     DBG_PRINTF("self->remote_commit_num=%" PRIx64 "\n", self->remote_commit_num);
-    bool ret = ln_create_commit_tx(&tx_remote, &buf_sig, &lntx_commit, !ln_is_funder(self));
+    bool ret = ln_create_commit_tx(&tx_commit, &buf_sig, &lntx_commit, !ln_is_funder(self));
     if (!ret) {
         DBG_PRINTF("fail: ln_create_commit_tx(Remote)\n");
     }
-    DBG_PRINTF("++++++++++++++ 相手のcommit tx: tx_remote[%" PRIx64 "]\n", self->short_channel_id);
-    M_DBG_PRINT_TX(&tx_remote);
+    DBG_PRINTF("++++++++++++++ 相手のcommit tx: tx_commit[%" PRIx64 "]\n", self->short_channel_id);
+    M_DBG_PRINT_TX(&tx_commit);
 
-    ret = ucoin_tx_txid(self->commit_remote.txid, &tx_remote);
+    ret = ucoin_tx_txid(self->commit_remote.txid, &tx_commit);
     if (!ret) {
         DBG_PRINTF("fail: ucoin_tx_txid\n");
     }
@@ -3663,10 +3743,10 @@ static bool create_to_remote(ln_self_t *self,
                     self->funding_local.keys[MSG_FUNDIDX_HTLC].priv);
         ucoin_keys_priv2pub(htlckey.pub, htlckey.priv);
 
-        for (int vout_idx = 0; vout_idx < tx_remote.vout_cnt; vout_idx++) {
+        for (int vout_idx = 0; vout_idx < tx_commit.vout_cnt; vout_idx++) {
             //各HTLCのHTLC Timeout/Success Transactionを作って署名するために、
-            //BIP69ソート後のtx_remote.voutからpp_htlcinfo[]のindexを取得する
-            uint8_t htlc_idx = tx_remote.vout[vout_idx].opt;
+            //BIP69ソート後のtx_commit.voutからpp_htlcinfo[]のindexを取得する
+            uint8_t htlc_idx = tx_commit.vout[vout_idx].opt;
             if (htlc_idx == LN_HTLCTYPE_TOLOCAL) {
                 DBG_PRINTF("---[%d]to_local\n", vout_idx);
                 if (pTxToLocal != NULL) {
@@ -3674,11 +3754,20 @@ static bool create_to_remote(ln_self_t *self,
                 }
             } else if (htlc_idx == LN_HTLCTYPE_TOREMOTE) {
                 DBG_PRINTF("---[%d]to_remote\n", vout_idx);
+                if (pTxToRemote != NULL) {
+                    ret = ln_create_toremote_spent(self, &tx, tx_commit.vout[vout_idx].value,
+                                self->commit_local.txid, vout_idx);
+                    if (ret) {
+                        M_DBG_PRINT_TX(&tx);
+                        memcpy(pTxToRemote, &tx, sizeof(tx));
+                        ucoin_tx_init(&tx);     //txはfreeさせない
+                    }
+                }
             } else {
                 uint64_t fee = (pp_htlcinfo[htlc_idx]->type == LN_HTLCTYPE_OFFERED) ? feeinfo.htlc_timeout : feeinfo.htlc_success;
-                if (tx_remote.vout[vout_idx].value >= feeinfo.dust_limit_satoshi + fee) {
+                if (tx_commit.vout[vout_idx].value >= feeinfo.dust_limit_satoshi + fee) {
                     DBG_PRINTF("---[%d]%s HTLC\n", vout_idx, (pp_htlcinfo[htlc_idx]->type == LN_HTLCTYPE_OFFERED) ? "offered" : "received");
-                    ln_create_htlc_tx(&tx, tx_remote.vout[vout_idx].value - fee, &buf_ws,
+                    ln_create_htlc_tx(&tx, tx_commit.vout[vout_idx].value - fee, &buf_ws,
                                 pp_htlcinfo[htlc_idx]->type, pp_htlcinfo[htlc_idx]->expiry,
                                 self->commit_remote.txid, vout_idx);
                     M_DBG_PRINT_TX(&tx);
@@ -3716,7 +3805,7 @@ static bool create_to_remote(ln_self_t *self,
                     //署名
                     ucoin_buf_t buf_sig;
                     ret = ln_sign_htlc_tx(&tx, &buf_sig,
-                                tx_remote.vout[vout_idx].value,
+                                tx_commit.vout[vout_idx].value,
                                 &htlckey,
                                 &buf_remotesig,
                                 (ret_img) ? preimage : NULL,
@@ -3748,7 +3837,7 @@ static bool create_to_remote(ln_self_t *self,
 
                     htlc_num++;
                 } else {
-                    DBG_PRINTF("cut HTLC[%d] %" PRIu64 " > %" PRIu64 "\n", vout_idx, tx_remote.vout[vout_idx].value, feeinfo.dust_limit_satoshi + fee);
+                    DBG_PRINTF("cut HTLC[%d] %" PRIu64 " > %" PRIu64 "\n", vout_idx, tx_commit.vout[vout_idx].value, feeinfo.dust_limit_satoshi + fee);
                 }
             }
         }
@@ -3759,9 +3848,9 @@ static bool create_to_remote(ln_self_t *self,
 
     DBG_PRINTF("free\n");
     if (pTxCommit != NULL) {
-        memcpy(pTxCommit, &tx_remote, sizeof(ucoin_tx_t));
+        memcpy(pTxCommit, &tx_commit, sizeof(ucoin_tx_t));
     } else {
-        ucoin_tx_free(&tx_remote);
+        ucoin_tx_free(&tx_commit);
     }
     ucoin_buf_free(&buf_ws);
     for (int lp = 0; lp < cnt; lp++) {
@@ -3815,8 +3904,8 @@ static bool create_closing_tx(ln_self_t *self, ucoin_tx_t *pTx, bool bVerify)
 
     //vout
     //vout#0 - local
-    bool vout_local = (LN_MSAT2SATOSHI(self->our_msat) > fee_local + self->commit_local.dust_limit_sat);
-    bool vout_remote = (LN_MSAT2SATOSHI(self->their_msat) > fee_remote + self->commit_local.dust_limit_sat);
+    bool vout_local = (LN_MSAT2SATOSHI(self->our_msat) > fee_local + UCOIN_DUST_LIMIT);
+    bool vout_remote = (LN_MSAT2SATOSHI(self->their_msat) > fee_remote + UCOIN_DUST_LIMIT);
 
     if (vout_local) {
         vout = ucoin_tx_add_vout(pTx, LN_MSAT2SATOSHI(self->our_msat) - fee_local);

--- a/ucoin/src/ln/ln.c
+++ b/ucoin/src/ln/ln.c
@@ -1492,7 +1492,6 @@ bool ln_create_toremote_spent(const ln_self_t *self, ucoin_tx_t *pTx, uint64_t V
         DBG_PRINTF("fail: vout below dust(value=%" PRIu64 ", fee=%" PRIu64 ")\n", Value, fee_toremote);
         goto LABEL_EXIT;
     }
-    DBG_PRINTF("value=%" PRIu64 ", fee=%" PRIu64 "\n", Value, fee_toremote);
 
     // remotekeyへの支払いを self->shutdown_scriptpk_local に送金する
     //  通常のP2WPKHなので、bRevoedはfalse扱い
@@ -1512,19 +1511,14 @@ bool ln_create_toremote_spent(const ln_self_t *self, ucoin_tx_t *pTx, uint64_t V
                 self->funding_remote.pubkeys[MSG_FUNDIDX_PER_COMMIT],
                 self->funding_local.keys[MSG_FUNDIDX_PAYMENT].priv);
     ucoin_keys_priv2pub(signkey.pub, signkey.priv);
-    DBG_PRINTF("key-priv: ");
-    DUMPBIN(signkey.priv, UCOIN_SZ_PRIVKEY);
-    DBG_PRINTF("key-pub : ");
-    DUMPBIN(signkey.pub, UCOIN_SZ_PUBKEY);
-    if (memcmp(signkey.pub, self->funding_remote.scriptpubkeys[MSG_SCRIPTIDX_REMOTEKEY], UCOIN_SZ_PUBKEY) == 0) {
-        DBG_PRINTF("OK!\n");
-    } else {
-        DBG_PRINTF("fail: pubkey mismatch\n");
-        assert(0);
-    }
+    assert(memcmp(signkey.pub, self->funding_remote.scriptpubkeys[MSG_SCRIPTIDX_REMOTEKEY], UCOIN_SZ_PUBKEY) == 0);
+    //DBG_PRINTF("key-priv: ");
+    //DUMPBIN(signkey.priv, UCOIN_SZ_PRIVKEY);
+    //DBG_PRINTF("key-pub : ");
+    //DUMPBIN(signkey.pub, UCOIN_SZ_PUBKEY);
 
-    ret = ucoin_util_sign_p2wpkh(pTx, Index, Value, &signkey);
-    DBG_PRINTF("ret=%d\n", ret);
+    //vinは1つしかない
+    ret = ucoin_util_sign_p2wpkh(pTx, 0, Value, &signkey);
 
 LABEL_EXIT:
     return ret;

--- a/ucoin/src/ln/ln.c
+++ b/ucoin/src/ln/ln.c
@@ -1559,6 +1559,7 @@ bool ln_create_revokedhtlc_spent(const ln_self_t *self, ucoin_tx_t *pTx, uint64_
         break;
     default:
         DBG_PRINTF("index=%d, %d\n", WitIndex, self->p_revoked_type[WitIndex]);
+        assert(0);
     }
     bool ret;
     if (htlcsign != HTLCSIGN_NONE) {

--- a/ucoind/monitoring.c
+++ b/ucoind/monitoring.c
@@ -77,6 +77,7 @@ static bool close_others(ln_self_t *self, uint32_t confm, void *pDbParam);
 static bool close_revoked_first(ln_self_t *self, ucoin_tx_t *pTx, uint32_t confm, void *pDbParam);
 static bool close_revoked_after(ln_self_t *self, uint32_t confm, void *pDbParam);
 static bool close_revoked_tolocal(const ln_self_t *self, const ucoin_tx_t *pTx, int VIndex);
+static bool close_revoked_toremote(const ln_self_t *self, const ucoin_tx_t *pTx, int VIndex);
 static bool close_revoked_htlc(const ln_self_t *self, const ucoin_tx_t *pTx, int VIndex, int WitIndex);
 
 static bool search_spent_tx(ucoin_tx_t *pTx, uint32_t confm, const uint8_t *pTxid, int Index);
@@ -590,11 +591,13 @@ static bool close_others(ln_self_t *self, uint32_t confm, void *pDbParam)
             DBG_PRINTF("This is closing_tx\n");
             del = true;
         } else {
-            //revoked transaction close
+            //相手にrevoked transaction closeされた
             SYSLOG_WARN("closed: ugly way\n");
             ret = ln_close_ugly(self, &tx, pDbParam);
             if (ret) {
                 if (ln_revoked_cnt(self) > 0) {
+                    //revoked transactionのvoutに未解決あり
+                    //  2回目以降はclose_revoked_after()が呼び出される
                     del = close_revoked_first(self, &tx, confm, pDbParam);
                 } else {
                     DBG_PRINTF("all revoked transaction vout is already solved.\n");
@@ -624,30 +627,37 @@ static bool close_revoked_first(ln_self_t *self, ucoin_tx_t *pTx, uint32_t confm
 {
     bool del = false;
     bool save = true;
+    bool ret;
 
     for (int lp = 0; lp < pTx->vout_cnt; lp++) {
         const ucoin_buf_t *p_vout = ln_revoked_vout(self);
 
         DBG_PRINTF("vout[%d]=", lp);
         DUMPBIN(pTx->vout[lp].script.buf, pTx->vout[lp].script.len);
-        if (ucoin_buf_cmp(&pTx->vout[lp].script, &p_vout[0])) {
+        if (ucoin_buf_cmp(&pTx->vout[lp].script, &p_vout[LN_RCLOSE_IDX_TOLOCAL])) {
             DBG_PRINTF("[%d]to_local !\n", lp);
 
-            bool ret = close_revoked_tolocal(self, pTx, lp);
+            ret = close_revoked_tolocal(self, pTx, lp);
             if (ret) {
                 del = ln_revoked_cnt_dec(self);
                 ln_set_revoked_confm(self, confm);
             } else {
                 save = false;
             }
+        } else if (ucoin_buf_cmp(&pTx->vout[lp].script, &p_vout[LN_RCLOSE_IDX_TOREMOTE])) {
+            DBG_PRINTF("[%d]to_remote !\n", lp);
+            ret = close_revoked_toremote(self, pTx, lp);
+            if (ret) {
+                save = true;
+            }
         } else {
-            for (int lp2 = 1; lp2 < self->revoked_num; lp2++) {
+            for (int lp2 = LN_RCLOSE_IDX_HTLC; lp2 < self->revoked_num; lp2++) {
                 DBG_PRINTF("p_vout[%d]=", lp2);
                 DUMPBIN(p_vout[lp2].buf, p_vout[lp2].len);
                 if (ucoin_buf_cmp(&pTx->vout[lp].script, &p_vout[lp2])) {
                     DBG_PRINTF("[%d]HTLC vout[%d] !\n", lp, lp2);
 
-                    bool ret = close_revoked_htlc(self, pTx, lp, lp2);
+                    ret = close_revoked_htlc(self, pTx, lp, lp2);
                     if (ret) {
                         del = ln_revoked_cnt_dec(self);
                         ln_set_revoked_confm(self, confm);
@@ -733,15 +743,41 @@ static bool close_revoked_tolocal(const ln_self_t *self, const ucoin_tx_t *pTx, 
     ucoin_tx_init(&tx);
     const ucoin_buf_t *p_wit = ln_revoked_wit(self);
 
-    ln_create_tolocal_spent(self, &tx, pTx->vout[VIndex].value,
+    bool ret = ln_create_tolocal_spent(self, &tx, pTx->vout[VIndex].value,
                 ln_commit_local(self)->to_self_delay,
                 &p_wit[0], txid, VIndex, true);
-    ucoin_print_tx(&tx);
-    ucoin_buf_t buf;
-    ucoin_tx_create(&buf, &tx);
-    ucoin_tx_free(&tx);
-    bool ret = btcprc_sendraw_tx(txid, NULL, buf.buf, buf.len);
-    ucoin_buf_free(&buf);
+    if (ret) {
+        ucoin_print_tx(&tx);
+        ucoin_buf_t buf;
+        ucoin_tx_create(&buf, &tx);
+        ucoin_tx_free(&tx);
+        ret = btcprc_sendraw_tx(txid, NULL, buf.buf, buf.len);
+        ucoin_buf_free(&buf);
+    }
+
+    return ret;
+}
+
+
+//revoked to_remote outputを取り戻す
+//  to_remoteはP2WPKHで支払い済みだが、bitcoindがremotekeyを知らないため、転送する
+static bool close_revoked_toremote(const ln_self_t *self, const ucoin_tx_t *pTx, int VIndex)
+{
+    uint8_t txid[UCOIN_SZ_TXID];
+    ucoin_tx_txid(txid, pTx);
+
+    ucoin_tx_t tx;
+    ucoin_tx_init(&tx);
+
+    bool ret = ln_create_toremote_spent(self, &tx, pTx->vout[VIndex].value, txid, VIndex);
+    if (ret) {
+        ucoin_print_tx(&tx);
+        ucoin_buf_t buf;
+        ucoin_tx_create(&buf, &tx);
+        ucoin_tx_free(&tx);
+        ret = btcprc_sendraw_tx(txid, NULL, buf.buf, buf.len);
+        ucoin_buf_free(&buf);
+    }
 
     return ret;
 }


### PR DESCRIPTION
to_remoteは native P2WPKHだが、bitcoindは扱えないため、to_localなどの送金先と同じアドレスに送金する。