### PR TITLE
set feerate_per_kw

### DIFF
--- a/cmn/conf.c
+++ b/cmn/conf.c
@@ -266,6 +266,8 @@ static int handler_fund_conf(void* user, const char* section, const char* name, 
         pconfig->funding_sat = strtoull(value, NULL, 10);
     } else if (strcmp(name, "push_sat") == 0) {
         pconfig->push_sat = strtoull(value, NULL, 10);
+    } else if (strcmp(name, "feerate_per_kw") == 0) {
+        pconfig->feerate_per_kw = strtoull(value, NULL, 10);
     } else {
         return 0;  /* unknown section/name, error */
     }

--- a/include/ucoind.h
+++ b/include/ucoind.h
@@ -185,6 +185,7 @@ typedef struct {
     char            signaddr[UCOIN_SZ_ADDR_MAX];
     uint64_t        funding_sat;
     uint64_t        push_sat;
+    uint32_t        feerate_per_kw;
 } funding_conf_t;
 
 

--- a/ucoin/include/ln.h
+++ b/ucoin/include/ln.h
@@ -1621,6 +1621,16 @@ static inline bool ln_is_funding(const ln_self_t *self) {
 }
 
 
+/** feerate_per_kw取得
+ *
+ * @param[in]           self            channel情報
+ * @return      feerate_per_kw
+ */
+static inline uint32_t ln_feerate(ln_self_t *self) {
+    return self->feerate_per_kw;
+}
+
+
 /** feerate_per_kw設定
  *
  * @param[out]          self            channel情報

--- a/ucoincli/ucoincli.c
+++ b/ucoincli/ucoincli.c
@@ -491,11 +491,11 @@ static void fund_rpc(char *pJson, const funding_conf_t *pFund)
                 //peer_nodeid, peer_addr, peer_port
                 M_QQ("%s") "," M_QQ("%s") ",%d,"
                 //txid, txindex, signaddr, funding_sat, push_sat
-                M_QQ("%s") ",%d," M_QQ("%s") ",%" PRIu64 ",%" PRIu64
+                M_QQ("%s") ",%d," M_QQ("%s") ",%" PRIu64 ",%" PRIu64 ",%" PRIu32
             " ]"
         "}",
             mPeerNodeId, mPeerAddr, mPeerPort,
-            txid, pFund->txindex, pFund->signaddr, pFund->funding_sat, pFund->push_sat);
+            txid, pFund->txindex, pFund->signaddr, pFund->funding_sat, pFund->push_sat, pFund->feerate_per_kw);
 }
 
 

--- a/ucoind/cmd_json.c
+++ b/ucoind/cmd_json.c
@@ -248,6 +248,14 @@ static cJSON *cmd_fund(jrpc_context *ctx, cJSON *params, cJSON *id)
         index = -1;
         goto LABEL_EXIT;
     }
+    //feerate_per_kw
+    json = cJSON_GetArrayItem(params, index++);
+    if (json && (json->type == cJSON_Number)) {
+        p_fundconf->feerate_per_kw = (uint32_t)json->valueu64;
+        DBG_PRINTF("feerate_per_kw=%" PRIu32 "\n", p_fundconf->feerate_per_kw);
+    } else {
+        //スルー
+    }
 
     print_funding_conf(p_fundconf);
 

--- a/ucoind/cmd_json.c
+++ b/ucoind/cmd_json.c
@@ -255,7 +255,9 @@ static cJSON *cmd_fund(jrpc_context *ctx, cJSON *params, cJSON *id)
 
     bool ret = lnapp_funding(p_appconf, p_fundconf);
     if (ret) {
-        result = cJSON_CreateString("Progressing");
+        result = cJSON_CreateObject();
+        cJSON_AddItemToObject(result, "status", cJSON_CreateString("Progressing"));
+        cJSON_AddItemToObject(result, "feerate_per_kw", cJSON_CreateNumber64(ln_feerate(p_appconf->p_self)));
     } else {
         ctx->error_code = RPCERR_FUNDING;
         ctx->error_message = strdup(RPCERR_FUNDING_STR);

--- a/ucoind/lnapp.c
+++ b/ucoind/lnapp.c
@@ -641,6 +641,8 @@ void lnapp_show_self(const lnapp_conf_t *pAppConf, cJSON *pResult)
         cJSON_AddItemToObject(result, "confirmation", cJSON_CreateNumber(confirm));
         //minimum_depth
         cJSON_AddItemToObject(result, "minimum_depth", cJSON_CreateNumber(pAppConf->funding_min_depth));
+        //feerate_per_kw
+        cJSON_AddItemToObject(result, "feerate_per_kw", cJSON_CreateNumber(ln_feerate(pAppConf->p_self)));
     } else if (p_self && ln_is_funding(p_self)) {
         char str[256];
 
@@ -1111,8 +1113,6 @@ static bool send_open_channel(lnapp_conf_t *p_conf)
 
         ucoin_chain_t chain;
         ucoin_util_wif2keys(&p_conf->p_opening->fundin_keys, &chain, wif);
-printf("chain: %d\n", chain);
-printf("get_chain: %d\n", ucoin_get_chain());
         assert(ucoin_get_chain() == chain);
         //TODO: データ構造に無駄が多い
         //      スタックに置けないものを詰めていったせいだが、整理したいところだ。

--- a/ucoind/lnapp.c
+++ b/ucoind/lnapp.c
@@ -616,7 +616,6 @@ void lnapp_show_self(const lnapp_conf_t *pAppConf, cJSON *pResult)
         //confirmation
         uint32_t confirm = btcprc_get_confirmation(ln_funding_txid(pAppConf->p_self));
         cJSON_AddItemToObject(result, "confirmation", cJSON_CreateNumber(confirm));
-
         //short_channel_id
         sprintf(str, "%016" PRIx64, ln_short_channel_id(p_self));
         cJSON_AddItemToObject(result, "short_channel_id", cJSON_CreateString(str));
@@ -624,6 +623,8 @@ void lnapp_show_self(const lnapp_conf_t *pAppConf, cJSON *pResult)
         cJSON_AddItemToObject(result, "our_msat", cJSON_CreateNumber64(ln_our_msat(p_self)));
         //their_msat
         cJSON_AddItemToObject(result, "their_msat", cJSON_CreateNumber64(ln_their_msat(p_self)));
+        //feerate_per_kw
+        cJSON_AddItemToObject(result, "feerate_per_kw", cJSON_CreateNumber(ln_feerate(pAppConf->p_self)));
     } else if (pAppConf->funding_waiting) {
         char str[256];
 
@@ -1104,7 +1105,6 @@ static bool send_open_channel(lnapp_conf_t *p_conf)
             //  which this side will pay for commitment and HTLC transactions
             //  as described in BOLT #3 (this can be adjusted later with an update_fee message).
             feerate = (uint32_t)(feerate / 4);
-#warning issue#46
             if (!ret) {
             // https://github.com/nayutaco/ptarmigan/issues/46
             DBG_PRINTF("fail: estimatefee\n");


### PR DESCRIPTION
`feerate_per_kw`がかけ離れてfundingできない場合のために、fund.confで設定可能にする。
未指定時、あるいは0を設定した場合は、bitcoindのestimatefeeで取得した値を4分の1した値を使用する。