### PR TITLE
Fix 216

### DIFF
--- a/ucoin/src/ln/ln.c
+++ b/ucoin/src/ln/ln.c
@@ -1487,6 +1487,7 @@ bool ln_create_toremote_spent(const ln_self_t *self, ucoin_tx_t *pTx, uint64_t V
     uint64_t fee_toremote = M_SZ_TO_REMOTE_TX(self->shutdown_scriptpk_local.len) * self->feerate_per_kw / 1000;
     if (Value < UCOIN_DUST_LIMIT + fee_toremote) {
         DBG_PRINTF("fail: vout below dust(value=%" PRIu64 ", fee=%" PRIu64 ")\n", Value, fee_toremote);
+        ret = false;
         goto LABEL_EXIT;
     }
 
@@ -3764,6 +3765,7 @@ static bool create_to_remote(ln_self_t *self,
                     ucoin_tx_init(&tx);     //txはfreeさせない
                 } else {
                     ucoin_tx_free(&tx);
+                    ucoin_tx_init(pTxToRemote);
                 }
                 break;
             }

--- a/ucoin/src/ln/ln.c
+++ b/ucoin/src/ln/ln.c
@@ -3765,7 +3765,6 @@ static bool create_to_remote(ln_self_t *self,
                     ucoin_tx_init(&tx);     //txはfreeさせない
                 } else {
                     ucoin_tx_free(&tx);
-                    ucoin_tx_init(pTxToRemote);
                 }
                 break;
             }

--- a/ucoind/monitoring.c
+++ b/ucoind/monitoring.c
@@ -198,7 +198,6 @@ bool monitor_close_unilateral_local(ln_self_t *self, void *pDbParam)
                 }
             } else {
                 DBG_PRINTF("skip tx[%d]\n", lp);
-                del = false;
             }
         }
 


### PR DESCRIPTION
fix #216 

自分からunilateral closeを行い、to_remoteがbitcoindのdust未満だった場合、DBから削除されていなかった。
おそらく、HTLCでも同様の事態が発生していたことと思われる。