### PR TITLE
commitment_signed受信ではDB保存しない

### DIFF
--- a/ucoind/lnapp.c
+++ b/ucoind/lnapp.c
@@ -2395,7 +2395,7 @@ static void cb_commit_sig_recv(lnapp_conf_t *p_conf, void *p_param)
     }
 
     //DB保存
-    ln_db_self_save(p_conf->p_self);
+    //ln_db_self_save(p_conf->p_self);  //revoke_and_ack後のみにする
 
     char fname[FNAME_LEN];
     sprintf(fname, FNAME_AMOUNT_FMT, ln_short_channel_id(p_conf->p_self));


### PR DESCRIPTION
#221 関連

確信は持てないが、ひとまず組み込んでおく。
`revoke_and_ack` 受信でのDB保存は lnapp.cで行われているため、それで反映される予定。

ただ、他のメッセージが割り込むことでDB保存されてしまう可能性がある(`update_fee`など)。