### PR TITLE
revert #226

### DIFF
--- a/ucoin/src/ln/ln.c
+++ b/ucoin/src/ln/ln.c
@@ -3012,12 +3012,15 @@ static bool recv_channel_reestablish(ln_self_t *self, const uint8_t *pData, uint
         return false;
     }
 
-    if ( (self->remote_commit_num != reest.next_local_commitment_number) ||
-         (self->revoke_num != reest.next_remote_revocation_number) ) {
+    if (self->remote_commit_num != reest.next_local_commitment_number) {
         DBG_PRINTF("number mismatch\n");
-        DBG_PRINTF("  next_local_commitment_number: %" PRIu64 "(own) .. %" PRIu64 "(recv)\n", self->remote_commit_num, reest.next_local_commitment_number);
-        DBG_PRINTF("  next_remote_revocation_number:%" PRIu64 "(own) .. %" PRIu64 "(recv)\n", self->revoke_num, reest.next_remote_revocation_number);
+        DBG_PRINTF("  next_local_commitment_number: %" PRIu64 "(own) != %" PRIu64 "(recv)\n", self->remote_commit_num, reest.next_local_commitment_number);
         return false;
+    }
+    if (self->revoke_num != reest.next_remote_revocation_number) {
+        DBG_PRINTF("number mismatch : update own revoke_num\n");
+        DBG_PRINTF("  next_remote_revocation_number:%" PRIu64 "(own) <- %" PRIu64 "(recv)\n", self->revoke_num, reest.next_remote_revocation_number);
+        self->revoke_num =  reest.next_remote_revocation_number;
     }
 
     self->init_flag |= INIT_FLAG_REEST_RECV;

--- a/ucoin/src/ln/ln.c
+++ b/ucoin/src/ln/ln.c
@@ -599,7 +599,8 @@ bool ln_create_channel_reestablish(ln_self_t *self, ucoin_buf_t *pReEst)
         self->init_flag |= INIT_FLAG_REEST_SEND;
     }
     if ( ret && INIT_FLAG_REESTED(self->init_flag) &&
-        (self->commit_num == 1) && (self->remote_commit_num == 1) ) {
+            (self->commit_num == 1) && (self->remote_commit_num == 1) ) {
+        DBG_PRINTF("both commit_num == 1 ==> send funding_locked\n");
         ret = ln_funding_tx_stabled(self);
     }
     return ret;
@@ -2920,6 +2921,7 @@ static bool recv_revoke_and_ack(ln_self_t *self, const uint8_t *pData, uint16_t 
 
     //相手のrevoke_numberをインクリメント(channel_reestablish用)
     self->remote_revoke_num++;
+    DBG_PRINTF("self->remote_revoke_num=%" PRIx64 "\n", self->remote_revoke_num);
 
     //prev_secret保存
     ret = store_peer_percommit_secret(self, prev_secret);
@@ -3029,7 +3031,8 @@ static bool recv_channel_reestablish(ln_self_t *self, const uint8_t *pData, uint
     (*self->p_callback)(self, LN_CB_REESTABLISH_RECV, NULL);
 
     if (INIT_FLAG_REESTED(self->init_flag) &&
-       (self->commit_num == 1) && (self->remote_commit_num == 1)) {
+            (self->commit_num == 1) && (self->remote_commit_num == 1)) {
+        DBG_PRINTF("both commit_num == 1 ==> send funding_locked\n");
         ret = ln_funding_tx_stabled(self);
     }
 

--- a/ucoind/lnapp.c
+++ b/ucoind/lnapp.c
@@ -2392,7 +2392,7 @@ static void cb_commit_sig_recv(lnapp_conf_t *p_conf, void *p_param)
     }
 
     //DB保存
-    //ln_db_self_save(p_conf->p_self);  //revoke_and_ack後のみにする
+    ln_db_self_save(p_conf->p_self);
 
     char fname[FNAME_LEN];
     sprintf(fname, FNAME_AMOUNT_FMT, ln_short_channel_id(p_conf->p_self));


### PR DESCRIPTION
#221 関連

#226 によってDBの状態があわなくなったので、まずはそれを元に戻す。
また、`channel_reestablish`パラメータの不一致でチャネルを失敗させるのはMUSTではないため、そもそもの #221 が状態不一致によって発生したと考えると、相手のパラメータを受け入れる方が自然かもしれない。