### PR TITLE
Add closedb

### DIFF
--- a/include/ucoind.h
+++ b/include/ucoind.h
@@ -169,13 +169,6 @@ typedef struct {
 
 
 typedef struct {
-    ln_fundin_t         fundin;
-    ucoin_util_keys_t   fundin_keys;
-    char                chargeaddr[UCOIN_SZ_ADDR_MAX];
-} opening_t;
-
-
-typedef struct {
     uint8_t         txid[UCOIN_SZ_TXID];
     int             txindex;
     char            signaddr[UCOIN_SZ_ADDR_MAX];

--- a/install/script/error.sh
+++ b/install/script/error.sh
@@ -4,8 +4,8 @@
 #   $2: node_id
 #   $3: err_str
 DATE=`date +"%c %N"`
-echo { \"method\": \"error\", \"short_channel_id\": \"$1\", \"node_id\": \"$2\", \"date\": \"$DATE\", \"err_str\": \"$3\" } | jq .
+echo "{ \"method\": \"error\", \"short_channel_id\": \"$1\", \"node_id\": \"$2\", \"date\": \"$DATE\", \"err_str\": \"$3\" }" | jq .
 
-echo from $2($1): >> err_$1.log
-echo $3 >> err_$1.log
-echo >> err_$1.log
+echo "from $2($1):" >> err_$1.log
+echo "$3" >> err_$1.log
+echo "" >> err_$1.log

--- a/routing/routing.cpp
+++ b/routing/routing.cpp
@@ -265,7 +265,7 @@ static void dumpit_self(MDB_txn *txn, MDB_dbi dbi, const uint8_t *p1, const uint
             //p1が非NULL == my node_id
             if (self.short_channel_id != 0) {
                 //チャネルは開設している
-                p2 = self.peer_node.node_id;
+                p2 = self.peer_node_id;
 
 #ifdef M_DEBUG
                 fprintf(fp_err, "self.short_channel_id: %" PRIx64 "\n", self.short_channel_id);

--- a/showdb/showdb.c
+++ b/showdb/showdb.c
@@ -109,7 +109,11 @@ static void dumpit_self(MDB_txn *txn, MDB_dbi dbi)
         memset(&self, 0, sizeof(self));
 
         int retval = ln_lmdb_self_load(&self, txn, dbi);
+        if (retval == 0) {
+            retval = ln_lmdb_self_ss_load(&self, txn);
+        }
         if (retval != 0) {
+            printf(M_QQ("load") ":" M_QQ("fail"));
             return;
         }
 

--- a/ucoin/gtests/testinc_ln_bolt3_c2.cpp
+++ b/ucoin/gtests/testinc_ln_bolt3_c2.cpp
@@ -684,9 +684,9 @@ TEST_F(ln_bolt3_c2, committx5untrim_commit)
     //est.cnl_open.funding_sat = SATOSHI_FUNDING;
     //est.cnl_open.feerate_per_kw
     //est.p_fundin = &fundin;
-    //est.defval = ;
+    //est.estprm = ;
 
-    //self.p_est = &est;
+    //self.p_establish = &est;
     //create_funding_tx(&self);
 
     ret = create_to_local(&self, sigs,

--- a/ucoin/include/ln.h
+++ b/ucoin/include/ln.h
@@ -370,7 +370,7 @@ typedef struct {
     uint64_t                    amount;                         ///< 2-of-2へ入金するtxのvout amount
     const uint8_t               *p_change_pubkey;               ///< 2-of-2へ入金したお釣りの送金先アドレス
     const char                  *p_change_addr;                 ///< 2-of-2へ入金したお釣りの送金先アドレス
-    const ucoin_util_keys_t     *p_keys;                        ///< 2-of-2へ入金するtxの鍵(署名用)
+    ucoin_util_keys_t           keys;                           ///< 2-of-2へ入金するtxの鍵(署名用)
     bool                        b_native;                       ///< true:fundinがnative segwit output
 } ln_fundin_t;
 

--- a/ucoin/include/ln.h
+++ b/ucoin/include/ln.h
@@ -957,7 +957,7 @@ typedef struct {
  */
 struct ln_self_t {
     ln_node_t                   *p_node;                        ///< 属しているnode情報
-    ln_node_info_t              peer_node;                      ///< 接続先ノード
+    uint8_t                     peer_node_id[UCOIN_SZ_PUBKEY];  ///< 接続先ノード
 
     //key storage
     uint64_t                    storage_index;                  ///< 現在のindex
@@ -1881,7 +1881,7 @@ static inline const uint8_t *ln_our_node_id(const ln_self_t *self) {
  * @return      自channelの他node_id
  */
 static inline const uint8_t *ln_their_node_id(const ln_self_t *self) {
-    return self->peer_node.node_id;
+    return self->peer_node_id;
 }
 
 

--- a/ucoin/include/ln.h
+++ b/ucoin/include/ln.h
@@ -717,8 +717,8 @@ typedef struct {
 } ln_announce_signs_t;
 
 
-/** @struct     ln_anno_default_t
- *  @brief      announce関連のデフォルト値
+/** @struct     ln_anno_prm_t
+ *  @brief      announce関連のパラメータ
  */
 typedef struct {
     //channel_update
@@ -726,7 +726,7 @@ typedef struct {
     uint64_t    htlc_minimum_msat;                  ///< 8 : htlc_minimum_msat
     uint32_t    fee_base_msat;                      ///< 4 : fee_base_msat
     uint32_t    fee_prop_millionths;                ///< 4 : fee_proportional_millionths
-} ln_anno_default_t;
+} ln_anno_prm_t;
 
 /// @}
 
@@ -980,7 +980,7 @@ struct ln_self_t {
 
     //announce
     uint8_t                     anno_flag;                      ///< announcement_signaturesなど
-    ln_anno_default_t           anno_default;
+    ln_anno_prm_t               anno_prm;                       ///< announcementパラメータ
     ucoin_buf_t                 cnl_anno;                       ///< 自channel_announcement
 
     //msg:init
@@ -1058,11 +1058,11 @@ struct ln_self_t {
  * @param[in,out]       self            channel情報
  * @param[in]           node            関連付けるnode
  * @param[in]           pSeed           per-commit-secret生成用
- * @param[in]           pAnnoDef        announcement値(NULLの場合、デフォルト値を使用する)
+ * @param[in]           pAnnoPrm        announcementパラメータ
  * @param[in]           pFunc           通知用コールバック関数
  * @retval      true    成功
  */
-bool ln_init(ln_self_t *self, ln_node_t *node, const uint8_t *pSeed, const ln_anno_default_t *pAnnoDef, ln_callback_t pFunc);
+bool ln_init(ln_self_t *self, ln_node_t *node, const uint8_t *pSeed, const ln_anno_prm_t *pAnnoPrm, ln_callback_t pFunc);
 
 
 /** 終了
@@ -1892,7 +1892,7 @@ static inline const uint8_t *ln_their_node_id(const ln_self_t *self) {
  * @return      cltv_expiry_delta
  */
 static inline uint32_t ln_cltv_expily_delta(const ln_self_t *self) {
-    return self->anno_default.cltv_expiry_delta;
+    return self->anno_prm.cltv_expiry_delta;
 }
 
 
@@ -1903,7 +1903,7 @@ static inline uint32_t ln_cltv_expily_delta(const ln_self_t *self) {
  * @return      転送FEE(msat)
  */
 static inline uint64_t ln_forward_fee(const ln_self_t *self, uint64_t amount) {
-    return (uint64_t)self->anno_default.fee_base_msat + (amount * (uint64_t)self->anno_default.fee_prop_millionths / (uint64_t)1000000);
+    return (uint64_t)self->anno_prm.fee_base_msat + (amount * (uint64_t)self->anno_prm.fee_prop_millionths / (uint64_t)1000000);
 }
 
 

--- a/ucoin/include/ln.h
+++ b/ucoin/include/ln.h
@@ -365,11 +365,11 @@ typedef struct {
  *      - open_channelする方が #ln_establish_t .p_fundinに設定して使う
  */
 typedef struct {
-    const uint8_t               *p_txid;                        ///< 2-of-2へ入金するTXID
+    uint8_t                     txid[UCOIN_SZ_TXID];            ///< 2-of-2へ入金するTXID
     int32_t                     index;                          ///< 未設定時(channelを開かれる方)は-1
     uint64_t                    amount;                         ///< 2-of-2へ入金するtxのvout amount
-    const uint8_t               *p_change_pubkey;               ///< 2-of-2へ入金したお釣りの送金先アドレス
-    const char                  *p_change_addr;                 ///< 2-of-2へ入金したお釣りの送金先アドレス
+    uint8_t                     *p_change_pubkey;               ///< 2-of-2へ入金したお釣りの送金先アドレス(未使用時:NULL)
+    char                        *p_change_addr;                 ///< 2-of-2へ入金したお釣りの送金先アドレス(未使用時:NULL)
     ucoin_util_keys_t           keys;                           ///< 2-of-2へ入金するtxの鍵(署名用)
     bool                        b_native;                       ///< true:fundinがnative segwit output
 } ln_fundin_t;

--- a/ucoin/include/ln.h
+++ b/ucoin/include/ln.h
@@ -994,7 +994,6 @@ struct ln_self_t {
     uint64_t                    close_last_fee_sat;             ///< 最後に送信したclosing_txのFEE
     ucoin_buf_t                 shutdown_scriptpk_local;        ///< close時の送金先(local)
     ucoin_buf_t                 shutdown_scriptpk_remote;       ///< mutual close時の送金先(remote)
-    ln_closing_signed_t         cnl_closing_signed;             ///< 受信したclosing_signed
     ucoin_buf_t                 *p_revoked_vout;                ///< revoked transaction close時に検索するvoutスクリプト([0]は必ずto_local系)
     ucoin_buf_t                 *p_revoked_wit;                 ///< revoked transaction close時のwitnessスクリプト
     ln_htlctype_t               *p_revoked_type;                ///< p_revoked_vout/p_revoked_witに対応するtype

--- a/ucoin/include/ln.h
+++ b/ucoin/include/ln.h
@@ -375,8 +375,8 @@ typedef struct {
 } ln_fundin_t;
 
 
-/** @struct ln_est_default_t
- *  @brief  Establish関連のデフォルト値
+/** @struct ln_establish_prm_t
+ *  @brief  Establish関連のパラメータ
  *  @note
  *      - #ln_set_establish()で初期化する
  */
@@ -388,7 +388,7 @@ typedef struct {
     uint16_t    to_self_delay;                      ///< 2 : to-self-delay
     uint16_t    max_accepted_htlcs;                 ///< 2 : max-accepted-htlcs
     uint32_t    min_depth;                          ///< 4 : minimum-depth(acceptのみ)
-} ln_est_default_t;
+} ln_establish_prm_t;
 
 
 /** @struct ln_establish_t
@@ -401,7 +401,7 @@ typedef struct {
     ln_funding_signed_t         cnl_funding_signed;             ///< 送信 or 受信したfunding_signed
 
     ln_fundin_t                 *p_fundin;                      ///< 非NULL:open_channel側
-    ln_est_default_t            defval;                         ///< デフォルト値
+    ln_establish_prm_t          estprm;                         ///< channel establish parameter
 } ln_establish_t;
 
 /// @}
@@ -975,7 +975,7 @@ struct ln_self_t {
     ucoin_keys_sort_t           key_fund_sort;                  ///< 2-of-2のソート順(local, remoteを正順とした場合)
     ucoin_tx_t                  tx_funding;                     ///< funding_tx
     uint8_t                     flck_flag;                      ///< funding_lockedフラグ(M_FLCK_FLAG_xxx)。 b1:受信済み b0:送信済み
-    ln_establish_t              *p_est;                         ///< Establish時ワーク領域
+    ln_establish_t              *p_establish;                   ///< Establishワーク領域
     uint32_t                    min_depth;                      ///< minimum_depth
 
     //announce
@@ -1094,12 +1094,12 @@ const uint8_t* ln_get_genesishash(void);
  *
  * @param[in,out]       self            channel情報
  * @param[in]           pNodeId         Establish先(NULL可)
- * @param[in]           pEstDef         Establishデフォルト値
+ * @param[in]           pEstPrm         Establishパラメータ
  * @retval      true    成功
  * @note
  *      - pEstablishは接続完了まで保持すること
  */
-bool ln_set_establish(ln_self_t *self, const uint8_t *pNodeId, const ln_est_default_t *pEstDef);
+bool ln_set_establish(ln_self_t *self, const uint8_t *pNodeId, const ln_establish_prm_t *pEstPrm);
 
 
 /** funding鍵設定

--- a/ucoin/include/ln.h
+++ b/ucoin/include/ln.h
@@ -400,7 +400,7 @@ typedef struct {
     ln_funding_created_t        cnl_funding_created;            ///< 送信 or 受信したfunding_created
     ln_funding_signed_t         cnl_funding_signed;             ///< 送信 or 受信したfunding_signed
 
-    const ln_fundin_t           *p_fundin;                      ///< 非NULL:open_channel側
+    ln_fundin_t                 *p_fundin;                      ///< 非NULL:open_channel側
     ln_est_default_t            defval;                         ///< デフォルト値
 } ln_establish_t;
 

--- a/ucoin/include/ln.h
+++ b/ucoin/include/ln.h
@@ -1093,14 +1093,13 @@ const uint8_t* ln_get_genesishash(void);
 /** Channel Establish設定
  *
  * @param[in,out]       self            channel情報
- * @param[out]          pEstablish      ワーク領域
  * @param[in]           pNodeId         Establish先(NULL可)
  * @param[in]           pEstDef         Establishデフォルト値
  * @retval      true    成功
  * @note
  *      - pEstablishは接続完了まで保持すること
  */
-bool ln_set_establish(ln_self_t *self, ln_establish_t *pEstablish, const uint8_t *pNodeId, const ln_est_default_t *pEstDef);
+bool ln_set_establish(ln_self_t *self, const uint8_t *pNodeId, const ln_est_default_t *pEstDef);
 
 
 /** funding鍵設定

--- a/ucoin/include/ln.h
+++ b/ucoin/include/ln.h
@@ -138,12 +138,18 @@ extern "C" {
 #define LN_MSAT2SATOSHI(msat)   ((msat) / 1000)
 
 
+//
+// [ucoincli -d]マクロがtrueになるのが通常動作とする
+//
+
 // 1: update_fulfill_htlcを返さない
 #define LN_DBG_FULFILL()        ((ln_get_debug() & 0x01) == 0)
 // 2: closeでclosing_txを展開しない
 #define LN_DBG_CLOSING_TX()     ((ln_get_debug() & 0x02) == 0)
 // 4: HTLC scriptでpreimageが一致しても不一致とみなす
 #define LN_DBG_MATCH_PREIMAGE() ((ln_get_debug() & 0x04) == 0)
+// 8: monitoringで未接続ノードに接続しに行かない
+#define LN_DBG_NODE_AUTO_CONNECT() ((ln_get_debug() & 0x08) == 0)
 
 
 /********************************************************************

--- a/ucoin/include/ln_db.h
+++ b/ucoin/include/ln_db.h
@@ -381,11 +381,55 @@ bool ln_db_annonod_cur_get(void *pCur, ucoin_buf_t *pBuf, uint32_t *pTimeStamp, 
 // payment_preimage
 ////////////////////
 
+/** preimage保存
+ * 
+ * @param[in]       pPreImage
+ * @param[in]       Amount
+ * @param[in,out]   pDbParam
+ * @retval  true
+ */
 bool ln_db_preimg_save(const uint8_t *pPreImage, uint64_t Amount, void *pDbParam);
+
+
+/** preimage削除
+ * 
+ * @param[in]       pPreImage
+ * @retval  true
+ */
 bool ln_db_preimg_del(const uint8_t *pPreImage);
+
+
+/** preimage削除(payment_hash検索)
+ * 
+ * @param[in]       pPreImageHash
+ * @retval  true
+ */
 bool ln_db_preimg_del_hash(const uint8_t *pPreImageHash);
+
+
+/** preimage curosrオープン
+ * 
+ * @param[in,out]   ppCur
+ * @retval  true
+ */
 bool ln_db_preimg_cur_open(void **ppCur);
+
+
+/** preimage cursorクローズ
+ * 
+ * @param[in]       pCur
+ * @retval  true
+ */
 void ln_db_preimg_cur_close(void *pCur);
+
+
+/** preimage取得
+ * 
+ * @param[in]       pCur
+ * @param[out]      pPreImage
+ * @param[out]      pAmount
+ * @retval  true
+ */
 bool ln_db_preimg_cur_get(void *pCur, uint8_t *pPreImage, uint64_t *pAmount);
 
 
@@ -400,6 +444,7 @@ bool ln_db_preimg_cur_get(void *pCur, uint8_t *pPreImage, uint64_t *pAmount);
  * @param[in]       pVout           pPayHashを含むvoutスクリプトを#ucoin_sw_wit2prog_p2wsh()した結果。大きさはLNL_SZ_WITPROG_WSH。
  * @param[in]       Type            pVout先のHTLC種別(LN_HTLCTYPE_OFFERED / LN_HTLCTYPE_RECEIVED)
  * @param[in]       Expiry          Expiry
+ * @retval  true
  */
 bool ln_db_phash_save(const uint8_t *pPayHash, const uint8_t *pVout, ln_htlctype_t Type, uint32_t Expiry);
 
@@ -411,6 +456,7 @@ bool ln_db_phash_save(const uint8_t *pPayHash, const uint8_t *pVout, ln_htlctype
  * @param[out]      pExpiry         Expiry
  * @param[in]       pVout           検索するvout
  * @param[in,out]   pDbParam        DBパラメータ
+ * @retval  true
  */
 bool ln_db_phash_search(uint8_t *pPayHash, ln_htlctype_t *pType, uint32_t *pExpiry, const uint8_t *pVout, void *pDbParam);
 
@@ -421,7 +467,22 @@ bool ln_db_phash_search(uint8_t *pPayHash, ln_htlctype_t *pType, uint32_t *pExpi
 // revoked transaction close
 ////////////////////
 
+/** revoked transaction情報読込み
+ * 
+ * @param[in,out]   self
+ * @param[in,out]   pDbParam
+ * @retval  true        .
+ */
 bool ln_db_revtx_load(ln_self_t *self, void *pDbParam);
+
+
+/** revoked transaction情報保存
+ * 
+ * @param[in]       self
+ * @param[in]       bUpdate
+ * @param[in,out]   pDbParam
+ * @retval  true        .
+ */
 bool ln_db_revtx_save(const ln_self_t *self, bool bUpdate, void *pDbParam);
 
 

--- a/ucoin/include/ln_db_lmdb.h
+++ b/ucoin/include/ln_db_lmdb.h
@@ -40,10 +40,9 @@ extern "C" {
  ********************************************************************/
 
 //key名
-#define LNDBK_SELF1             "self1"         ///< [self]パラメータ
-#define M_DBK_SELF2             "self2"         ///< [self]スクリプト
 #define LNDBK_RVV               "rvv"           ///< [revoked]vout
 #define LNDBK_RVW               "rvw"           ///< [revoked]witness
+#define LNDBK_RVT               "rvt"           ///< [revoked]HTLC type
 #define LNDBK_RVS               "rvs"           ///< [revoked]script
 #define LNDBK_RVN               "rvn"           ///< [revoked]num
 #define LNDBK_RVC               "rvc"           ///< [revoked]count

--- a/ucoin/include/ln_db_lmdb.h
+++ b/ucoin/include/ln_db_lmdb.h
@@ -94,12 +94,23 @@ typedef struct {
  * @param[out]      self
  * @param[in]       txn
  * @param[in]       pdbi
- * @retval      true    成功
+ * @retval      0       成功
  * @attention
  *      -
- *      - 新規 self に読込を行う場合は、事前に #ln_self_ini()を行っておくこと(seedはNULLでよい)
+ *      - 新規 self に読込を行う場合は、事前に #ln_self_init()を行っておくこと(seedはNULLでよい)
  */
 int ln_lmdb_self_load(ln_self_t *self, MDB_txn *txn, MDB_dbi dbi);
+
+
+/** channel shared_secret読込み
+ *
+ * @param[in,out]   self
+ * @param[in]       txn
+ * @retval      0       成功
+ * @note
+ *      - self->channel_idをDBのkeyとして使用する
+ */
+int ln_lmdb_self_ss_load(ln_self_t *self, MDB_txn *txn);
 
 
 /**

--- a/ucoin/src/inc/ln/ln_local.h
+++ b/ucoin/src/inc/ln/ln_local.h
@@ -91,15 +91,6 @@
 #define MSGTYPE_IS_PINGPONG(type)           (((type) == MSGTYPE_PING) || (type) == MSGTYPE_PONG) 
 #define MSGTYPE_IS_ANNOUNCE(type)           ((MSGTYPE_CHANNEL_ANNOUNCEMENT <= (type)) && ((type) <= MSGTYPE_CHANNEL_UPDATE))
 
-
-// self.init_flag
-#define INIT_FLAG_SEND              (0x01)
-#define INIT_FLAG_RECV              (0x02)
-#define INIT_FLAG_INITED(flag)      ((flag & (INIT_FLAG_SEND | INIT_FLAG_RECV)) == (INIT_FLAG_SEND | INIT_FLAG_RECV))
-#define INIT_FLAG_REEST_SEND        (0x04)
-#define INIT_FLAG_REEST_RECV        (0x08)
-#define INIT_FLAG_REESTED(flag)     ((flag & (INIT_FLAG_REEST_SEND | INIT_FLAG_REEST_RECV)) == (INIT_FLAG_REEST_SEND | INIT_FLAG_REEST_RECV))
-
 // init.localfeatures
 #define INIT_LF_OPT_DATALOSS_REQ    (1 << 0)    ///< option-data-loss-protect
 #define INIT_LF_OPT_DATALOSS_OPT    (1 << 1)    ///< option-data-loss-protect

--- a/ucoin/src/inc/ln/ln_msg_anno.h
+++ b/ucoin/src/inc/ln/ln_msg_anno.h
@@ -72,7 +72,7 @@ void HIDDEN ln_msg_cnl_announce_print(const uint8_t *pData, uint16_t Len);
  *
  */
  void HIDDEN ln_msg_cnl_update_print(const ln_cnl_update_t *pMsg);
- 
+
 
 /** node_announcement生成
  *
@@ -153,6 +153,6 @@ bool HIDDEN ln_msg_announce_signs_read(ln_announce_signs_t *pMsg, const uint8_t 
 /** announcement_signaturesの署名アドレス取得
  *
  */
-void HIDDEN ln_msg_get_anno_signs(ln_self_t *self, uint8_t **pp_sig_node, uint8_t **pp_sig_btc, bool bLocal);
+void HIDDEN ln_msg_get_anno_signs(ln_self_t *self, uint8_t **pp_sig_node, uint8_t **pp_sig_btc, bool bLocal, ucoin_keys_sort_t Sort);
 
 #endif /* LN_MSG_ANNO_H__ */

--- a/ucoin/src/ln/ln.c
+++ b/ucoin/src/ln/ln.c
@@ -3113,11 +3113,7 @@ static bool recv_announcement_signatures(ln_self_t *self, const uint8_t *pData, 
 
     //DB保存
     ret = ln_db_annocnl_save(&self->cnl_anno, ln_short_channel_id(self), ln_their_node_id(self));
-    if (ret) {
-        //これ以降はchannel DBで管理する
-        //ucoin_buf_free(&self->cnl_anno);
-        //ln_db_self_save(self);
-    } else {
+    if (!ret) {
         DBG_PRINTF("fail: ln_db_annocnl_save\n");
         //goto LABEL_EXIT;
     }

--- a/ucoin/src/ln/ln.c
+++ b/ucoin/src/ln/ln.c
@@ -3292,7 +3292,7 @@ static bool create_funding_tx(ln_self_t *self)
     //署名
     self->funding_local.txindex = M_FUNDING_INDEX;      //TODO: vout#0は2-of-2、vout#1はchangeにしている
     ucoin_util_sign_p2wpkh_native(&self->tx_funding, self->funding_local.txindex,
-                        self->p_est->p_fundin->amount, self->p_est->p_fundin->p_keys, self->p_est->p_fundin->b_native);
+                        self->p_est->p_fundin->amount, &self->p_est->p_fundin->keys, self->p_est->p_fundin->b_native);
     ucoin_tx_txid(self->funding_local.txid, &self->tx_funding);
 
     return true;

--- a/ucoin/src/ln/ln.c
+++ b/ucoin/src/ln/ln.c
@@ -114,8 +114,11 @@
 
 #ifndef M_DBG_VERBOSE
 #define M_DBG_PRINT_TX(tx)      //NONE
+//#define M_DBG_PRINT_TX2(tx)     //NONE
+#define M_DBG_PRINT_TX2(tx)     ucoin_print_tx(tx)
 #else
 #define M_DBG_PRINT_TX(tx)      ucoin_print_tx(tx)
+#define M_DBG_PRINT_TX2(tx)     ucoin_print_tx(tx)
 #endif  //M_DBG_VERBOSE
 
 
@@ -3446,7 +3449,7 @@ static bool create_to_local(ln_self_t *self,
                     ret = ln_create_tolocal_spent(self, &tx, tx_commit.vout[vout_idx].value, to_self_delay,
                             &buf_ws, self->commit_local.txid, vout_idx, false);
                     if (ret) {
-                        M_DBG_PRINT_TX(&tx);
+                        M_DBG_PRINT_TX2(&tx);
                         memcpy(pTxToLocal, &tx, sizeof(tx));
                         ucoin_tx_init(&tx);     //txはfreeさせない
                     }
@@ -3460,7 +3463,7 @@ static bool create_to_local(ln_self_t *self,
                     ln_create_htlc_tx(&tx, tx_commit.vout[vout_idx].value - fee, &buf_ws,
                                 pp_htlcinfo[htlc_idx]->type, pp_htlcinfo[htlc_idx]->expiry,
                                 self->commit_local.txid, vout_idx);
-                    M_DBG_PRINT_TX(&tx);
+                    M_DBG_PRINT_TX2(&tx);
 
                     if (p_htlc_sigs != NULL) {
                         //署名チェック
@@ -3528,7 +3531,7 @@ static bool create_to_local(ln_self_t *self,
                         if ( ((pp_htlcinfo[htlc_idx]->type == LN_HTLCTYPE_RECEIVED) && ret_img) ||
                              (pp_htlcinfo[htlc_idx]->type == LN_HTLCTYPE_OFFERED) ) {
                             DBG_PRINTF("create HTLC tx[%d]\n", htlc_num);
-                            M_DBG_PRINT_TX(&tx);
+                            M_DBG_PRINT_TX2(&tx);
                             memcpy(&pTxHtlcs[htlc_num], &tx, sizeof(tx));
 
                             // HTLC Timeout/Success Txを作った場合はそれを取り戻すトランザクションも作る
@@ -3540,7 +3543,7 @@ static bool create_to_local(ln_self_t *self,
                                         &buf_ws, txid, 0, false);
                             if (ret) {
                                 DBG_PRINTF("*** HTLC out Tx ***\n");
-                                M_DBG_PRINT_TX(&tx2);
+                                M_DBG_PRINT_TX2(&tx2);
                                 ucoin_push_data(&push, &tx2, sizeof(ucoin_tx_t));
                             } else {
                                 ucoin_tx_free(&tx2);
@@ -3769,7 +3772,7 @@ static bool create_to_remote(ln_self_t *self,
                 ret = ln_create_toremote_spent(self, &tx, tx_commit.vout[vout_idx].value,
                             self->commit_remote.txid, vout_idx);
                 if (ret) {
-                    M_DBG_PRINT_TX(&tx);
+                    M_DBG_PRINT_TX2(&tx);
                     memcpy(pTxToRemote, &tx, sizeof(tx));
                     ucoin_tx_init(&tx);     //txはfreeさせない
                 } else {
@@ -3823,7 +3826,7 @@ static bool create_to_remote(ln_self_t *self,
                     ln_create_htlc_tx(&tx, tx_commit.vout[vout_idx].value - fee, &buf_ws,
                                 pp_htlcinfo[htlc_idx]->type, pp_htlcinfo[htlc_idx]->expiry,
                                 self->commit_remote.txid, vout_idx);
-                    M_DBG_PRINT_TX(&tx);
+                    M_DBG_PRINT_TX2(&tx);
 
                     uint8_t preimage[LN_SZ_PREIMAGE];
                     bool ret_img;
@@ -3876,7 +3879,7 @@ static bool create_to_remote(ln_self_t *self,
                         if ( ((pp_htlcinfo[htlc_idx]->type == LN_HTLCTYPE_OFFERED) && ret_img) ||
                              (pp_htlcinfo[htlc_idx]->type == LN_HTLCTYPE_RECEIVED) ) {
                             DBG_PRINTF("create HTLC tx[%d]\n", htlc_num);
-                            M_DBG_PRINT_TX(&tx);
+                            M_DBG_PRINT_TX2(&tx);
                             memcpy(&pTxHtlcs[htlc_num], &tx, sizeof(tx));
                             ucoin_tx_init(&tx);     //txはfreeさせない
                         } else {
@@ -3975,7 +3978,7 @@ static bool create_closing_tx(ln_self_t *self, ucoin_tx_t *pTx, bool bVerify)
 
     //BIP69
     ucoin_util_sort_bip69(pTx);
-    ucoin_print_tx(pTx);
+    M_DBG_PRINT_TX(pTx);
 
     //署名
     uint8_t sighash[UCOIN_SZ_SIGHASH];

--- a/ucoin/src/ln/ln.c
+++ b/ucoin/src/ln/ln.c
@@ -113,9 +113,9 @@
 
 
 #ifndef M_DBG_VERBOSE
-#define M_DBG_PRINT_TX(tx)      //NONE
-//#define M_DBG_PRINT_TX2(tx)     //NONE
-#define M_DBG_PRINT_TX2(tx)     ucoin_print_tx(tx)
+//#define M_DBG_PRINT_TX(tx)      //NONE
+#define M_DBG_PRINT_TX(tx)      ucoin_print_tx(tx)
+#define M_DBG_PRINT_TX2(tx)     //NONE
 #else
 #define M_DBG_PRINT_TX(tx)      ucoin_print_tx(tx)
 #define M_DBG_PRINT_TX2(tx)     ucoin_print_tx(tx)
@@ -301,6 +301,7 @@ void ln_term(ln_self_t *self)
         self->cnl_add_htlc[idx].p_onion_route = NULL;
         ucoin_buf_free(&self->cnl_add_htlc[idx].shared_secret);
     }
+    DBG_PRINTF("END\n");
 }
 
 
@@ -3116,7 +3117,10 @@ static bool recv_announcement_signatures(ln_self_t *self, const uint8_t *pData, 
 
     //DB保存
     ret = ln_db_annocnl_save(&self->cnl_anno, ln_short_channel_id(self), ln_their_node_id(self));
-    if (!ret) {
+    if (ret) {
+        //cnl_annoは使用しないはず
+        ucoin_buf_free(&self->cnl_anno);
+    } else {
         DBG_PRINTF("fail: ln_db_annocnl_save\n");
         //goto LABEL_EXIT;
     }

--- a/ucoin/src/ln/ln.c
+++ b/ucoin/src/ln/ln.c
@@ -324,6 +324,11 @@ bool ln_set_establish(ln_self_t *self, const uint8_t *pNodeId, const ln_est_defa
 {
     DBG_PRINTF("BEGIN\n");
 
+    if (self->p_est != 0) {
+        DBG_PRINTF("already set\n");
+        return true;
+    }
+
     self->p_est = (ln_establish_t *)M_MALLOC(sizeof(ln_establish_t));   //M_FREE:proc_established()
 
     //デフォルト値
@@ -662,6 +667,7 @@ bool ln_create_open_channel(ln_self_t *self, ucoin_buf_t *pOpen,
     ln_print_keys(PRINTOUT, &self->funding_local, &self->funding_remote);
 
     //funding_tx作成用に保持
+    assert(self->p_est->p_fundin == NULL);
     self->p_est->p_fundin = (ln_fundin_t *)M_MALLOC(sizeof(ln_fundin_t));
     memcpy(self->p_est->p_fundin, pFundin, sizeof(ln_fundin_t));
 
@@ -4341,5 +4347,6 @@ static void free_establish(ln_self_t *self)
             M_FREE(self->p_est->p_fundin);  //M_MALLOC: ln_create_open_channel()
         }
         M_FREE(self->p_est);        //M_MALLOC: ln_set_establish()
+        DBG_PRINTF("END\n");
     }
 }

--- a/ucoin/src/ln/ln.c
+++ b/ucoin/src/ln/ln.c
@@ -3975,6 +3975,7 @@ static bool create_closing_tx(ln_self_t *self, ucoin_tx_t *pTx, bool bVerify)
 
     //BIP69
     ucoin_util_sort_bip69(pTx);
+    ucoin_print_tx(pTx);
 
     //署名
     uint8_t sighash[UCOIN_SZ_SIGHASH];

--- a/ucoin/src/ln/ln.c
+++ b/ucoin/src/ln/ln.c
@@ -3266,7 +3266,7 @@ static bool create_funding_tx(ln_self_t *self)
 
     //input
     //vin#0
-    ucoin_tx_add_vin(&self->tx_funding, self->p_est->p_fundin->p_txid, self->p_est->p_fundin->index);
+    ucoin_tx_add_vin(&self->tx_funding, self->p_est->p_fundin->txid, self->p_est->p_fundin->index);
 
 
     //FEE計算

--- a/ucoin/src/ln/ln.c
+++ b/ucoin/src/ln/ln.c
@@ -232,7 +232,7 @@ static unsigned long mDebug;
  * public functions
  **************************************************************************/
 
-bool ln_init(ln_self_t *self, ln_node_t *node, const uint8_t *pSeed, const ln_anno_default_t *pAnnoDef, ln_callback_t pFunc)
+bool ln_init(ln_self_t *self, ln_node_t *node, const uint8_t *pSeed, const ln_anno_prm_t *pAnnoPrm, ln_callback_t pFunc)
 {
     DBG_PRINTF("BEGIN : pSeed=%p\n", pSeed);
 
@@ -272,12 +272,11 @@ bool ln_init(ln_self_t *self, ln_node_t *node, const uint8_t *pSeed, const ln_an
     self->p_node = node;
     self->p_callback = pFunc;
 
-    //初期値
-    memcpy(&self->anno_default, pAnnoDef, sizeof(ln_anno_default_t));
-    DBG_PRINTF("cltv_expiry_delta=%" PRIu16 "\n", self->anno_default.cltv_expiry_delta);
-    DBG_PRINTF("htlc_minimum_msat=%" PRIu64 "\n", self->anno_default.htlc_minimum_msat);
-    DBG_PRINTF("fee_base_msat=%" PRIu32 "\n", self->anno_default.fee_base_msat);
-    DBG_PRINTF("fee_prop_millionths=%" PRIu32 "\n", self->anno_default.fee_prop_millionths);
+    memcpy(&self->anno_prm, pAnnoPrm, sizeof(ln_anno_prm_t));
+    DBG_PRINTF("cltv_expiry_delta=%" PRIu16 "\n", self->anno_prm.cltv_expiry_delta);
+    DBG_PRINTF("htlc_minimum_msat=%" PRIu64 "\n", self->anno_prm.htlc_minimum_msat);
+    DBG_PRINTF("fee_base_msat=%" PRIu32 "\n", self->anno_prm.fee_base_msat);
+    DBG_PRINTF("fee_prop_millionths=%" PRIu32 "\n", self->anno_prm.fee_prop_millionths);
 
     //seed
     self->storage_index = M_SECINDEX_INIT;
@@ -793,10 +792,10 @@ bool ln_create_channel_update(ln_self_t *self, ln_cnl_update_t *pUpd, ucoin_buf_
     pUpd->short_channel_id = self->short_channel_id;
     pUpd->timestamp = TimeStamp;
     //announce
-    pUpd->cltv_expiry_delta = self->anno_default.cltv_expiry_delta;
-    pUpd->htlc_minimum_msat = self->anno_default.htlc_minimum_msat;
-    pUpd->fee_base_msat = self->anno_default.fee_base_msat;
-    pUpd->fee_prop_millionths = self->anno_default.fee_prop_millionths;
+    pUpd->cltv_expiry_delta = self->anno_prm.cltv_expiry_delta;
+    pUpd->htlc_minimum_msat = self->anno_prm.htlc_minimum_msat;
+    pUpd->fee_base_msat = self->anno_prm.fee_base_msat;
+    pUpd->fee_prop_millionths = self->anno_prm.fee_prop_millionths;
     //署名
     pUpd->p_key = self->p_node->keys.priv;
     pUpd->flags = self->peer_node.sort;
@@ -822,10 +821,10 @@ bool ln_update_channel_update(ln_self_t *self, ucoin_buf_t *pCnlUpd)
     if (ret) {
         ln_msg_cnl_update_print(&upd);
 
-        if ( (upd.cltv_expiry_delta != self->anno_default.cltv_expiry_delta) ||
-             (upd.htlc_minimum_msat != self->anno_default.htlc_minimum_msat) ||
-             (upd.fee_base_msat != self->anno_default.fee_base_msat) ||
-             (upd.fee_prop_millionths != self->anno_default.fee_prop_millionths) ) {
+        if ( (upd.cltv_expiry_delta != self->anno_prm.cltv_expiry_delta) ||
+             (upd.htlc_minimum_msat != self->anno_prm.htlc_minimum_msat) ||
+             (upd.fee_base_msat != self->anno_prm.fee_base_msat) ||
+             (upd.fee_prop_millionths != self->anno_prm.fee_prop_millionths) ) {
             DBG_PRINTF("update channel_update\n");
 
             uint32_t now = (uint32_t)time(NULL);

--- a/ucoin/src/ln/ln.c
+++ b/ucoin/src/ln/ln.c
@@ -301,7 +301,7 @@ void ln_term(ln_self_t *self)
         self->cnl_add_htlc[idx].p_onion_route = NULL;
         ucoin_buf_free(&self->cnl_add_htlc[idx].shared_secret);
     }
-    DBG_PRINTF("END\n");
+    //DBG_PRINTF("END\n");
 }
 
 
@@ -3117,10 +3117,7 @@ static bool recv_announcement_signatures(ln_self_t *self, const uint8_t *pData, 
 
     //DB保存
     ret = ln_db_annocnl_save(&self->cnl_anno, ln_short_channel_id(self), ln_their_node_id(self));
-    if (ret) {
-        //cnl_annoは使用しないはず
-        ucoin_buf_free(&self->cnl_anno);
-    } else {
+    if (!ret) {
         DBG_PRINTF("fail: ln_db_annocnl_save\n");
         //goto LABEL_EXIT;
     }
@@ -4197,6 +4194,7 @@ static void proc_announce_sigsed(ln_self_t *self)
         (*self->p_callback)(self, LN_CB_ANNO_SIGSED, &anno);
 
         self->anno_flag |= M_ANNO_FLAG_END;
+        ucoin_buf_free(&self->cnl_anno);
         ln_db_self_save(self);
     }
 }

--- a/ucoin/src/ln/ln.c
+++ b/ucoin/src/ln/ln.c
@@ -318,14 +318,14 @@ const uint8_t* ln_get_genesishash(void)
 }
 
 
-bool ln_set_establish(ln_self_t *self, ln_establish_t *pEstablish, const uint8_t *pNodeId, const ln_est_default_t *pEstDef)
+bool ln_set_establish(ln_self_t *self, const uint8_t *pNodeId, const ln_est_default_t *pEstDef)
 {
     DBG_PRINTF("BEGIN\n");
 
-    self->p_est = pEstablish;
+    self->p_est = (ln_establish_t *)M_MALLOC(sizeof(ln_establish_t));   //M_FREE:
 
     //デフォルト値
-    if (pEstablish && pEstDef) {
+    if (pEstDef != NULL) {
         self->p_est->p_fundin = NULL;       //open_channel送信側が設定する
         memcpy(&self->p_est->defval, pEstDef, sizeof(ln_est_default_t));
         DBG_PRINTF("dust_limit_sat= %" PRIu64 "\n", self->p_est->defval.dust_limit_sat);
@@ -4168,6 +4168,7 @@ static void proc_established(ln_self_t *self)
         (*self->p_callback)(self, LN_CB_ESTABLISHED, &funding);
 
         //Normal Operation可能
+        M_FREE(self->p_est);        //M_MALLOC: ln_set_establish()
         self->p_est = NULL;
 
         DBG_PRINTF("Normal Operation可能\n");

--- a/ucoin/src/ln/ln_db_lmdb.c
+++ b/ucoin/src/ln/ln_db_lmdb.c
@@ -213,7 +213,7 @@ static const backup_param_t DBSELF_KEYS[] = {
     //key_fund_sort --> none
     //tx_funding --> script
     //flck_flag: none
-    //p_est: none
+    //p_establish: none
     M_ITEM(ln_self_t, min_depth),
     M_ITEM(ln_self_t, anno_flag),
     //anno_default: none
@@ -2505,7 +2505,7 @@ void HIDDEN ln_db_copy_channel(ln_self_t *pOutSelf, const ln_self_t *pInSelf)
     //key_fund_sort --> none
     //tx_funding --> script
     //flck_flag: none
-    //p_est: none
+    //p_establish: none
     pOutSelf->min_depth = pInSelf->min_depth;
     pOutSelf->anno_flag = pInSelf->anno_flag;
     //anno_default: none

--- a/ucoin/src/ln/ln_db_lmdb.c
+++ b/ucoin/src/ln/ln_db_lmdb.c
@@ -2476,6 +2476,21 @@ void HIDDEN ln_db_copy_channel(ln_self_t *pOutSelf, const ln_self_t *pInSelf)
 {
     //固定サイズ
 
+#if 1
+    for (size_t lp = 0; lp < ARRAY_SIZE(DBSELF_KEYS); lp++) {
+        memcpy((uint8_t *)pOutSelf + DBSELF_KEYS[lp].offset, (uint8_t *)pInSelf + DBSELF_KEYS[lp].offset,  DBSELF_KEYS[lp].datalen);
+    }
+
+    for (int idx = 0; idx < LN_HTLC_MAX; idx++) {
+        pOutSelf->cnl_add_htlc[idx].p_channel_id = NULL;
+        pOutSelf->cnl_add_htlc[idx].p_onion_route = NULL;
+        ucoin_buf_init(&pOutSelf->cnl_add_htlc[idx].shared_secret);
+    }
+
+    //復元データ
+    ucoin_buf_alloccopy(&pOutSelf->redeem_fund, pInSelf->redeem_fund.buf, pInSelf->redeem_fund.len);
+    pOutSelf->key_fund_sort = pInSelf->key_fund_sort;
+#else
     //p_node: none
     memcpy(&pOutSelf->peer_node, &pInSelf->peer_node, sizeof(ln_node_info_t));
     pOutSelf->storage_index = pInSelf->storage_index;
@@ -2538,6 +2553,7 @@ void HIDDEN ln_db_copy_channel(ln_self_t *pOutSelf, const ln_self_t *pInSelf)
 
     pOutSelf->funding_sat = pInSelf->funding_sat;
     pOutSelf->feerate_per_kw = pInSelf->feerate_per_kw;
+#endif
 
 
     //可変サイズ(shallow copy)

--- a/ucoin/src/ln/ln_db_lmdb.c
+++ b/ucoin/src/ln/ln_db_lmdb.c
@@ -2176,6 +2176,15 @@ bool ln_db_revtx_load(ln_self_t *self, void *pDbParam)
         p_scr += len;
     }
 
+    //HTLC type
+    key.mv_data = LNDBK_RVT;
+    retval = mdb_get(txn, dbi, &key, &data);
+    if (retval != 0) {
+        DBG_PRINTF("ERR: %s\n", mdb_strerror(retval));
+        goto LABEL_EXIT;
+    }
+    memcpy(self->p_revoked_type, data.mv_data, data.mv_size);
+
     //remote per_commit_secret
     key.mv_data = LNDBK_RVS;
     retval = mdb_get(txn, dbi, &key, &data);
@@ -2250,6 +2259,15 @@ bool ln_db_revtx_save(const ln_self_t *self, bool bUpdate, void *pDbParam)
         goto LABEL_EXIT;
     }
     ucoin_buf_free(&buf);
+
+    key.mv_data = LNDBK_RVT;
+    data.mv_size = sizeof(ln_htlctype_t) * self->revoked_num;
+    data.mv_data = self->p_revoked_type;
+    retval = mdb_put(db.txn, db.dbi, &key, &data, 0);
+    if (retval != 0) {
+        DBG_PRINTF("ERR: %s\n", mdb_strerror(retval));
+        goto LABEL_EXIT;
+    }
 
     key.mv_data = LNDBK_RVS;
     data.mv_size = self->revoked_sec.len;

--- a/ucoin/src/ln/ln_db_lmdb.c
+++ b/ucoin/src/ln/ln_db_lmdb.c
@@ -2476,7 +2476,6 @@ void HIDDEN ln_db_copy_channel(ln_self_t *pOutSelf, const ln_self_t *pInSelf)
 {
     //固定サイズ
 
-#if 1
     for (size_t lp = 0; lp < ARRAY_SIZE(DBSELF_KEYS); lp++) {
         memcpy((uint8_t *)pOutSelf + DBSELF_KEYS[lp].offset, (uint8_t *)pInSelf + DBSELF_KEYS[lp].offset,  DBSELF_KEYS[lp].datalen);
     }
@@ -2490,70 +2489,6 @@ void HIDDEN ln_db_copy_channel(ln_self_t *pOutSelf, const ln_self_t *pInSelf)
     //復元データ
     ucoin_buf_alloccopy(&pOutSelf->redeem_fund, pInSelf->redeem_fund.buf, pInSelf->redeem_fund.len);
     pOutSelf->key_fund_sort = pInSelf->key_fund_sort;
-#else
-    //p_node: none
-    memcpy(&pOutSelf->peer_node, &pInSelf->peer_node, sizeof(ln_node_info_t));
-    pOutSelf->storage_index = pInSelf->storage_index;
-    memcpy(pOutSelf->storage_seed, pInSelf->storage_seed, UCOIN_SZ_PRIVKEY);
-    pOutSelf->peer_storage = pInSelf->peer_storage;
-    pOutSelf->peer_storage_index = pInSelf->peer_storage_index;
-    pOutSelf->fund_flag = pInSelf->fund_flag;
-    pOutSelf->funding_local = pInSelf->funding_local;
-    pOutSelf->funding_remote = pInSelf->funding_remote;
-    pOutSelf->obscured = pInSelf->obscured;
-    //redeem_fund --> none
-    //key_fund_sort --> none
-    //tx_funding --> script
-    //flck_flag: none
-    //p_establish: none
-    pOutSelf->min_depth = pInSelf->min_depth;
-    pOutSelf->anno_flag = pInSelf->anno_flag;
-    //anno_prm: none
-    //cnl_anno --> none
-    //init_flag: none
-    pOutSelf->lfeature_remote = pInSelf->lfeature_remote;
-    //tx_closing: none
-    //shutdown_flag: none
-    //close_fee_sat: none
-    //close_last_fee_sat: none
-    //shutdown_scriptpk_local --> script
-    //shutdown_scriptpk_remote --> script
-    //cnl_closing_singed: none
-
-    //p_revoked_vout --> revoked db
-    //p_revoked_wit  --> revoked db
-    //p_revoked_type: --> revoked db
-    //revoked_sec: --> revoked db
-    //revoked_num: --> revoked db
-    //revoked_cnt: --> revoked db
-    //revoked_chk --> revoked db
-
-    pOutSelf->htlc_num = pInSelf->htlc_num;
-    pOutSelf->commit_num = pInSelf->commit_num;
-    pOutSelf->revoke_num = pInSelf->revoke_num;
-    pOutSelf->remote_commit_num = pInSelf->remote_commit_num;
-    pOutSelf->remote_revoke_num = pInSelf->remote_revoke_num;
-    pOutSelf->htlc_id_num = pInSelf->htlc_id_num;
-    pOutSelf->our_msat = pInSelf->our_msat;
-    pOutSelf->their_msat = pInSelf->their_msat;
-    memcpy(pOutSelf->channel_id, pInSelf->channel_id, LN_SZ_CHANNEL_ID);
-    pOutSelf->short_channel_id = pInSelf->short_channel_id;
-    for (int idx = 0; idx < LN_HTLC_MAX; idx++) {
-        pOutSelf->cnl_add_htlc[idx] = pInSelf->cnl_add_htlc[idx];
-        pOutSelf->cnl_add_htlc[idx].p_channel_id = NULL;
-        pOutSelf->cnl_add_htlc[idx].p_onion_route = NULL;
-        ucoin_buf_init(&pOutSelf->cnl_add_htlc[idx].shared_secret);
-    }
-
-    //missing_pong_cnt: none
-    //last_num_pong_bytes: none
-
-    pOutSelf->commit_local = pInSelf->commit_local;
-    pOutSelf->commit_remote = pInSelf->commit_remote;
-
-    pOutSelf->funding_sat = pInSelf->funding_sat;
-    pOutSelf->feerate_per_kw = pInSelf->feerate_per_kw;
-#endif
 
 
     //可変サイズ(shallow copy)

--- a/ucoin/src/ln/ln_db_lmdb.c
+++ b/ucoin/src/ln/ln_db_lmdb.c
@@ -73,7 +73,7 @@
 #define M_SZ_ANNOINFO_CNL       (sizeof(uint64_t) + 1)
 #define M_SZ_ANNOINFO_NODE      (UCOIN_SZ_PUBKEY)
 
-#define M_DB_VERSION_VAL        (-16)           ///< DBバージョン
+#define M_DB_VERSION_VAL        ((int32_t)-16)      ///< DBバージョン
 /*
     -1 : first
     -2 : ln_update_add_htlc_t変更
@@ -3056,7 +3056,7 @@ static int ver_write(ln_lmdb_db_t *pDb, const char *pWif, const char *pNodeName,
 {
     int         retval;
     MDB_val     key, data;
-    int         version = M_DB_VERSION_VAL;
+    int32_t     version = M_DB_VERSION_VAL;
 
     retval = mdb_dbi_open(pDb->txn, M_DBI_VERSION, MDB_CREATE, &pDb->dbi);
     if (retval != 0) {
@@ -3067,7 +3067,7 @@ static int ver_write(ln_lmdb_db_t *pDb, const char *pWif, const char *pNodeName,
     //version
     key.mv_size = LNDBK_LEN(LNDBK_VER);
     key.mv_data = LNDBK_VER;
-    data.mv_size = sizeof(int32_t);
+    data.mv_size = sizeof(version);
     data.mv_data = &version;
     retval = mdb_put(pDb->txn, pDb->dbi, &key, &data, 0);
 
@@ -3114,7 +3114,7 @@ static int ver_check(ln_lmdb_db_t *pDb, char *pWif, char *pNodeName, uint16_t *p
     key.mv_data = LNDBK_VER;
     retval = mdb_get(pDb->txn, pDb->dbi, &key, &data);
     if (retval == 0) {
-        int version = *(int *)data.mv_data;
+        int32_t version = *(int32_t *)data.mv_data;
         if (version != M_DB_VERSION_VAL) {
             DBG_PRINTF("FAIL: version mismatch : %d(require %d)\n", version, M_DB_VERSION_VAL);
             retval = -1;

--- a/ucoin/src/ln/ln_db_lmdb.c
+++ b/ucoin/src/ln/ln_db_lmdb.c
@@ -1538,6 +1538,9 @@ bool ln_db_annoskip_invoice_del(const uint8_t *pPayHash)
     MDB_dbi     dbi;
     MDB_val     key;
 
+    DBG_PRINTF("payment_hash=");
+    DUMPBIN(pPayHash, LN_SZ_HASH);
+
     retval = MDB_TXN_BEGIN(mpDbNode, NULL, 0, &txn);
     if (retval != 0) {
         DBG_PRINTF("ERR: %s\n", mdb_strerror(retval));

--- a/ucoin/src/ln/ln_db_lmdb.c
+++ b/ucoin/src/ln/ln_db_lmdb.c
@@ -216,7 +216,7 @@ static const backup_param_t DBSELF_KEYS[] = {
     //p_establish: none
     M_ITEM(ln_self_t, min_depth),
     M_ITEM(ln_self_t, anno_flag),
-    //anno_default: none
+    //anno_prm: none
     //cnl_anno --> none
     //init_flag: none
     M_ITEM(ln_self_t, lfeature_remote),
@@ -2508,7 +2508,7 @@ void HIDDEN ln_db_copy_channel(ln_self_t *pOutSelf, const ln_self_t *pInSelf)
     //p_establish: none
     pOutSelf->min_depth = pInSelf->min_depth;
     pOutSelf->anno_flag = pInSelf->anno_flag;
-    //anno_default: none
+    //anno_prm: none
     //cnl_anno --> none
     //init_flag: none
     pOutSelf->lfeature_remote = pInSelf->lfeature_remote;

--- a/ucoin/src/ln/ln_db_lmdb.c
+++ b/ucoin/src/ln/ln_db_lmdb.c
@@ -605,7 +605,7 @@ int ln_lmdb_self_load(ln_self_t *self, MDB_txn *txn, MDB_dbi dbi)
     }
 
     //復元データからさらに復元
-    ln_misc_update_scriptkeys(&self->funding_local, &self->funding_remote);
+    //ln_misc_update_scriptkeys(&self->funding_local, &self->funding_remote);
     ucoin_util_create2of2(&self->redeem_fund, &self->key_fund_sort,
             self->funding_local.keys[MSG_FUNDIDX_FUNDING].pub,
             self->funding_remote.pubkeys[MSG_FUNDIDX_FUNDING]);

--- a/ucoin/src/ln/ln_msg_anno.c
+++ b/ucoin/src/ln/ln_msg_anno.c
@@ -441,10 +441,10 @@ void HIDDEN ln_msg_cnl_announce_print(const uint8_t *pData, uint16_t Len)
 }
 
 
-void HIDDEN ln_msg_get_anno_signs(ln_self_t *self, uint8_t **pp_sig_node, uint8_t **pp_sig_btc, bool bLocal)
+void HIDDEN ln_msg_get_anno_signs(ln_self_t *self, uint8_t **pp_sig_node, uint8_t **pp_sig_btc, bool bLocal, ucoin_keys_sort_t Sort)
 {
-    if ( ((self->peer_node.sort == UCOIN_KEYS_SORT_ASC) && bLocal) ||
-         ((self->peer_node.sort != UCOIN_KEYS_SORT_ASC) && !bLocal) ) {
+    if ( ((Sort == UCOIN_KEYS_SORT_ASC) && bLocal) ||
+         ((Sort != UCOIN_KEYS_SORT_ASC) && !bLocal) ) {
         DBG_PRINTF("addr: 1\n");
         *pp_sig_node = self->cnl_anno.buf + sizeof(uint16_t);
     } else {

--- a/ucoin/src/ln/ln_node.c
+++ b/ucoin/src/ln/ln_node.c
@@ -236,14 +236,14 @@ static bool comp_func_cnl(ln_self_t *self, void *p_db_param, void *p_param)
 
             //復元データからさらに復元
             ln_misc_update_scriptkeys(&p->p_self->funding_local, &p->p_self->funding_remote);
-            ucoin_util_create2of2(&self->redeem_fund, &self->key_fund_sort,
-                    self->funding_local.keys[MSG_FUNDIDX_FUNDING].pub, self->funding_remote.pubkeys[MSG_FUNDIDX_FUNDING]);
+            ucoin_util_create2of2(&p->p_self->redeem_fund, &p->p_self->key_fund_sort,
+                    p->p_self->funding_local.keys[MSG_FUNDIDX_FUNDING].pub, p->p_self->funding_remote.pubkeys[MSG_FUNDIDX_FUNDING]);
 
-            if (self->short_channel_id != 0) {
+            if (p->p_self->short_channel_id != 0) {
                 ucoin_buf_t buf;
 
                 ucoin_buf_init(&buf);
-                bool bret2 = ln_db_annocnl_load(&p->p_self->cnl_anno, self->short_channel_id);
+                bool bret2 = ln_db_annocnl_load(&p->p_self->cnl_anno, p->p_self->short_channel_id);
                 if (bret2) {
                     ucoin_buf_alloccopy(&p->p_self->cnl_anno, buf.buf, buf.len);
                 }

--- a/ucoin/src/ln/ln_node.c
+++ b/ucoin/src/ln/ln_node.c
@@ -234,11 +234,6 @@ static bool comp_func_cnl(ln_self_t *self, void *p_db_param, void *p_param)
             //DBから復元
             ln_db_copy_channel(p->p_self, self);
 
-            //復元データからさらに復元
-            ln_misc_update_scriptkeys(&p->p_self->funding_local, &p->p_self->funding_remote);
-            ucoin_util_create2of2(&p->p_self->redeem_fund, &p->p_self->key_fund_sort,
-                    p->p_self->funding_local.keys[MSG_FUNDIDX_FUNDING].pub, p->p_self->funding_remote.pubkeys[MSG_FUNDIDX_FUNDING]);
-
             if (p->p_self->short_channel_id != 0) {
                 ucoin_buf_t buf;
 

--- a/ucoin/src/ln/ln_node.c
+++ b/ucoin/src/ln/ln_node.c
@@ -230,7 +230,7 @@ static bool comp_func_cnl(ln_self_t *self, void *p_db_param, void *p_param)
     (void)p_db_param;
     comp_param_cnl_t *p = (comp_param_cnl_t *)p_param;
 
-    bool ret = (memcmp(self->peer_node.node_id, p->p_node_id, UCOIN_SZ_PUBKEY) == 0);
+    bool ret = (memcmp(self->peer_node_id, p->p_node_id, UCOIN_SZ_PUBKEY) == 0);
     if (ret) {
         if (p->p_self) {
             //DBから復元

--- a/ucoin/src/ln/ln_node.c
+++ b/ucoin/src/ln/ln_node.c
@@ -166,7 +166,9 @@ bool ln_node_search_nodeanno(ln_node_announce_t *pNodeAnno, const uint8_t *pNode
         pNodeAnno->p_alias = NULL;
         pNodeAnno->p_my_node = NULL;
         ret = ln_msg_node_announce_read(pNodeAnno, buf_anno.buf, buf_anno.len);
-        DBG_PRINTF("ret=%d\n", ret);
+        if (!ret) {
+            DBG_PRINTF("fail: read node_announcement\n");
+        }
     }
     ucoin_buf_free(&buf_anno);
 

--- a/ucoin/src/ln/ln_node.c
+++ b/ucoin/src/ln/ln_node.c
@@ -233,7 +233,22 @@ static bool comp_func_cnl(ln_self_t *self, void *p_db_param, void *p_param)
         if (p->p_self) {
             //DBから復元
             ln_db_copy_channel(p->p_self, self);
+
+            //復元データからさらに復元
             ln_misc_update_scriptkeys(&p->p_self->funding_local, &p->p_self->funding_remote);
+            ucoin_util_create2of2(&self->redeem_fund, &self->key_fund_sort,
+                    self->funding_local.keys[MSG_FUNDIDX_FUNDING].pub, self->funding_remote.pubkeys[MSG_FUNDIDX_FUNDING]);
+
+            if (self->short_channel_id != 0) {
+                ucoin_buf_t buf;
+
+                ucoin_buf_init(&buf);
+                bool bret2 = ln_db_annocnl_load(&p->p_self->cnl_anno, self->short_channel_id);
+                if (bret2) {
+                    ucoin_buf_alloccopy(&p->p_self->cnl_anno, buf.buf, buf.len);
+                }
+                ucoin_buf_free(&buf);
+            }
         } else {
             //true時は予備元では解放しないので、ここで解放する
             ln_term(self);

--- a/ucoin/src/ln/ln_print.c
+++ b/ucoin/src/ln/ln_print.c
@@ -88,9 +88,8 @@ void ln_print_self(const ln_self_t *self)
 
     //peer_node
     fprintf(PRINTOUT, M_QQ("peer_node_id") ": \"");
-    ucoin_util_dumpbin(PRINTOUT, self->peer_node.node_id, UCOIN_SZ_PUBKEY, false);
+    ucoin_util_dumpbin(PRINTOUT, self->peer_node_id, UCOIN_SZ_PUBKEY, false);
     fprintf(PRINTOUT, "\",");
-    //fprintf(PRINTOUT, M_QQ("alias") ": " M_QQ("%s") ",", self->peer_node.alias);
 
     //key storage
     fprintf(PRINTOUT, M_QQ("storage_index") ": " M_QQ("%016" PRIx64) ",\n", self->storage_index);

--- a/ucoin/src/ln/ln_print.c
+++ b/ucoin/src/ln/ln_print.c
@@ -157,10 +157,10 @@ void ln_print_self(const ln_self_t *self)
 
     //announce
     fprintf(PRINTOUT, M_QQ("anno_flag") ": " M_QQ("%02x") ",\n", self->anno_flag);
-    fprintf(PRINTOUT, M_QQ("cltv_expiry_delta") ": %" PRIu16 ",\n", self->anno_default.cltv_expiry_delta);
-    fprintf(PRINTOUT, M_QQ("htlc_minimum_msat") ": %" PRIu64 ",\n", self->anno_default.htlc_minimum_msat);
-    fprintf(PRINTOUT, M_QQ("fee_base_msat") ": %" PRIu32 ",\n", self->anno_default.fee_base_msat);
-    fprintf(PRINTOUT, M_QQ("fee_prop_millionths") ": %" PRIu32 ",\n", self->anno_default.fee_prop_millionths);
+    fprintf(PRINTOUT, M_QQ("cltv_expiry_delta") ": %" PRIu16 ",\n", self->anno_prm.cltv_expiry_delta);
+    fprintf(PRINTOUT, M_QQ("htlc_minimum_msat") ": %" PRIu64 ",\n", self->anno_prm.htlc_minimum_msat);
+    fprintf(PRINTOUT, M_QQ("fee_base_msat") ": %" PRIu32 ",\n", self->anno_prm.fee_base_msat);
+    fprintf(PRINTOUT, M_QQ("fee_prop_millionths") ": %" PRIu32 ",\n", self->anno_prm.fee_prop_millionths);
 
     //init
     fprintf(PRINTOUT, M_QQ("init_flag") ": " M_QQ("%02x") ",\n", self->init_flag);

--- a/ucoincli/ucoincli.c
+++ b/ucoincli/ucoincli.c
@@ -137,37 +137,22 @@ int main(int argc, char *argv[])
             options = M_OPTIONS_EXEC;
             break;
 
+        case 'q':
+            if (options == M_OPTIONS_CONN) {
+                //特定接続を切る
+                disconnect_rpc(mBuf);
+                options = M_OPTIONS_EXEC;
+                conn = false;
+            } else {
+                //ucoind終了
+                stop_rpc(mBuf);
+                options = M_OPTIONS_STOP;
+            }
+            break;
+
         //
         // -c不要
         //
-        case 'q':
-            //ucoind停止
-            if (options > M_OPTIONS_STOP) {
-                if (optarg != NULL) {
-                    //特定接続を切る
-                    peer_conf_t peer;
-                    bool bret = load_peer_conf(optarg, &peer);
-                    if (bret) {
-                        //peer.conf
-                        strcpy(mPeerAddr, peer.ipaddr);
-                        mPeerPort = peer.port;
-                        misc_bin2str(mPeerNodeId, peer.node_id, UCOIN_SZ_PUBKEY);
-                        disconnect_rpc(mBuf);
-                        options = M_OPTIONS_EXEC;
-                    } else {
-                        printf("fail: peer configuration file\n");
-                        options = M_OPTIONS_HELP;
-                    }
-                } else {
-                    //ucoind終了
-                    stop_rpc(mBuf);
-                    options = M_OPTIONS_STOP;
-                }
-            } else {
-                printf("fail: too many options\n");
-                options = M_OPTIONS_HELP;
-            }
-            break;
         case 'l':
             //channel一覧
             if (options == M_OPTIONS_INIT) {

--- a/ucoincli/ucoincli.c
+++ b/ucoincli/ucoincli.c
@@ -419,10 +419,15 @@ int main(int argc, char *argv[])
         printf("\t\t-c <peer.conf> -f <fund.conf> : funding\n");
         printf("\t\t-c <peer.conf> -x : mutual close channel\n");
         printf("\t\t-c <peer.conf> -w : get last error\n");
-        // printf("\n");
+        printf("\t\t-c <peer.conf> -q : disconnect node\n");
+        printf("\n");
         // printf("\t\t-a <IP address> : [debug]JSON-RPC send address\n");
-        // printf("\t\t-d <value> : [debug]debug option\n");
-        // printf("\t\t-c <node.conf> -g : [debug]get commitment transaction\n");
+        printf("\t\t-d <value> : [debug]debug option\n");
+        printf("\t\t\tb0 ... no update_fulfill_htlc\n");
+        printf("\t\t\tb1 ... no closing transaction\n");
+        printf("\t\t\tb2 ... force payment_preimage mismatch\n");
+        printf("\t\t\tb3 ... no node auto connect\n");
+        printf("\t\t-c <node.conf> -g : [debug]get commitment transaction\n");
         return -1;
     }
 

--- a/ucoind/cmd_json.c
+++ b/ucoind/cmd_json.c
@@ -908,8 +908,21 @@ static cJSON *cmd_debug(jrpc_context *ctx, cJSON *params, cJSON *id)
 
     json = cJSON_GetArrayItem(params, 0);
     if (json && (json->type == cJSON_Number)) {
-        ln_set_debug(json->valueint);
-        sprintf(str, "%d", json->valueint);
+        unsigned long dbg = ln_get_debug();
+        ln_set_debug(dbg ^ json->valueint);
+        sprintf(str, "%08lx", dbg);
+        if (!LN_DBG_FULFILL()) {
+            DBG_PRINTF("no fulfill return\n");
+        }
+        if (!LN_DBG_CLOSING_TX()) {
+            DBG_PRINTF("no closing tx\n");
+        }
+        if (!LN_DBG_MATCH_PREIMAGE()) {
+            DBG_PRINTF("force preimage mismatch\n");
+        }
+        if (!LN_DBG_NODE_AUTO_CONNECT()) {
+            DBG_PRINTF("no node Auto connect\n");
+        }
         ret = str;
     } else {
         ret = "NG";

--- a/ucoind/cmd_json.c
+++ b/ucoind/cmd_json.c
@@ -908,8 +908,8 @@ static cJSON *cmd_debug(jrpc_context *ctx, cJSON *params, cJSON *id)
 
     json = cJSON_GetArrayItem(params, 0);
     if (json && (json->type == cJSON_Number)) {
-        unsigned long dbg = ln_get_debug();
-        ln_set_debug(dbg ^ json->valueint);
+        unsigned long dbg = ln_get_debug() ^ json->valueint;
+        ln_set_debug(dbg);
         sprintf(str, "%08lx", dbg);
         if (!LN_DBG_FULFILL()) {
             DBG_PRINTF("no fulfill return\n");

--- a/ucoind/cmd_json.c
+++ b/ucoind/cmd_json.c
@@ -159,7 +159,7 @@ static cJSON *cmd_fund(jrpc_context *ctx, cJSON *params, cJSON *id)
 
     cJSON *json;
     daemon_connect_t conn;
-    funding_conf_t *p_fundconf = (funding_conf_t *)APP_MALLOC(sizeof(funding_conf_t));  //lnapp.c cb_established()で解放
+    funding_conf_t fundconf;
     cJSON *result = NULL;
     int index = 0;
 
@@ -211,7 +211,7 @@ static cJSON *cmd_fund(jrpc_context *ctx, cJSON *params, cJSON *id)
     //txid
     json = cJSON_GetArrayItem(params, index++);
     if (json && (json->type == cJSON_String)) {
-        misc_str2bin_rev(p_fundconf->txid, UCOIN_SZ_TXID, json->valuestring);
+        misc_str2bin_rev(fundconf.txid, UCOIN_SZ_TXID, json->valuestring);
         DBG_PRINTF("txid=%s\n", json->valuestring);
     } else {
         index = -1;
@@ -220,7 +220,7 @@ static cJSON *cmd_fund(jrpc_context *ctx, cJSON *params, cJSON *id)
     //txindex
     json = cJSON_GetArrayItem(params, index++);
     if (json && (json->type == cJSON_Number)) {
-        p_fundconf->txindex = json->valueint;
+        fundconf.txindex = json->valueint;
         DBG_PRINTF("txindex=%d\n", json->valueint);
     } else {
         index = -1;
@@ -229,7 +229,7 @@ static cJSON *cmd_fund(jrpc_context *ctx, cJSON *params, cJSON *id)
     //signaddr
     json = cJSON_GetArrayItem(params, index++);
     if (json && (json->type == cJSON_String)) {
-        strcpy(p_fundconf->signaddr, json->valuestring);
+        strcpy(fundconf.signaddr, json->valuestring);
         DBG_PRINTF("signaddr=%s\n", json->valuestring);
     } else {
         index = -1;
@@ -238,8 +238,8 @@ static cJSON *cmd_fund(jrpc_context *ctx, cJSON *params, cJSON *id)
     //funding_sat
     json = cJSON_GetArrayItem(params, index++);
     if (json && (json->type == cJSON_Number)) {
-        p_fundconf->funding_sat = json->valueu64;
-        DBG_PRINTF("funding_sat=%" PRIu64 "\n", p_fundconf->funding_sat);
+        fundconf.funding_sat = json->valueu64;
+        DBG_PRINTF("funding_sat=%" PRIu64 "\n", fundconf.funding_sat);
     } else {
         index = -1;
         goto LABEL_EXIT;
@@ -247,8 +247,8 @@ static cJSON *cmd_fund(jrpc_context *ctx, cJSON *params, cJSON *id)
     //push_sat
     json = cJSON_GetArrayItem(params, index++);
     if (json && (json->type == cJSON_Number)) {
-        p_fundconf->push_sat = json->valueu64;
-        DBG_PRINTF("push_sat=%" PRIu64 "\n", p_fundconf->push_sat);
+        fundconf.push_sat = json->valueu64;
+        DBG_PRINTF("push_sat=%" PRIu64 "\n", fundconf.push_sat);
     } else {
         index = -1;
         goto LABEL_EXIT;
@@ -256,17 +256,17 @@ static cJSON *cmd_fund(jrpc_context *ctx, cJSON *params, cJSON *id)
     //feerate_per_kw
     json = cJSON_GetArrayItem(params, index++);
     if (json && (json->type == cJSON_Number)) {
-        p_fundconf->feerate_per_kw = (uint32_t)json->valueu64;
-        DBG_PRINTF("feerate_per_kw=%" PRIu32 "\n", p_fundconf->feerate_per_kw);
+        fundconf.feerate_per_kw = (uint32_t)json->valueu64;
+        DBG_PRINTF("feerate_per_kw=%" PRIu32 "\n", fundconf.feerate_per_kw);
     } else {
         //スルー
     }
 
-    print_funding_conf(p_fundconf);
+    print_funding_conf(&fundconf);
 
     SYSLOG_INFO("fund");
 
-    bool ret = lnapp_funding(p_appconf, p_fundconf);
+    bool ret = lnapp_funding(p_appconf, &fundconf);
     if (ret) {
         result = cJSON_CreateObject();
         cJSON_AddItemToObject(result, "status", cJSON_CreateString("Progressing"));

--- a/ucoind/cmd_json.c
+++ b/ucoind/cmd_json.c
@@ -679,6 +679,9 @@ LABEL_EXIT:
         ctx->error_code = RPCERR_PARSE;
         ctx->error_message = strdup(RPCERR_PARSE_STR);
     }
+    if (ctx->error_code != 0) {
+        ln_db_annoskip_invoice_del(payconf.payment_hash);
+    }
     return result;
 }
 

--- a/ucoind/inc/lnapp.h
+++ b/ucoind/inc/lnapp.h
@@ -97,7 +97,6 @@ typedef struct lnapp_conf_t {
     bool            initiator;                  ///< true:Noise Protocolのinitiator
     uint8_t         node_id[UCOIN_SZ_PUBKEY];   ///< 接続先(initiator==true時)
     daemoncmd_t     cmd;                        ///< ucoincliからの処理要求
-    funding_conf_t  *p_funding;                 ///< ucoincliで #DCMD_CREATE 時のパラメータ
     ln_fundin_t     fundin;
 
     //lnappワーク
@@ -172,7 +171,7 @@ void lnapp_stop(lnapp_conf_t *pAppConf);
 /** [lnapp]チャネル接続開始
  *
  */
-bool lnapp_funding(lnapp_conf_t *pAppConf, funding_conf_t *pFunding);
+bool lnapp_funding(lnapp_conf_t *pAppConf, const funding_conf_t *pFunding);
 
 
 /** [lnapp]送金開始

--- a/ucoind/inc/lnapp.h
+++ b/ucoind/inc/lnapp.h
@@ -103,7 +103,6 @@ typedef struct lnapp_conf_t {
     //lnappワーク
     volatile bool   loop;                   ///< true:channel動作中
     ln_self_t       *p_self;                ///< channelのコンテキスト
-    ln_establish_t  *p_establish;           ///< Establish用のワーク領域
 
     bool            initial_routing_sync;   ///< init.localfeaturesのinitial_routing_sync
     uint8_t         ping_counter;           ///< 無送受信時にping送信するカウンタ(カウントアップ)

--- a/ucoind/inc/lnapp.h
+++ b/ucoind/inc/lnapp.h
@@ -98,7 +98,7 @@ typedef struct lnapp_conf_t {
     uint8_t         node_id[UCOIN_SZ_PUBKEY];   ///< 接続先(initiator==true時)
     daemoncmd_t     cmd;                        ///< ucoincliからの処理要求
     funding_conf_t  *p_funding;                 ///< ucoincliで #DCMD_CREATE 時のパラメータ
-    opening_t       *p_opening;                 ///< establish時にmalloc()して使用する
+    ln_fundin_t     fundin;
 
     //lnappワーク
     volatile bool   loop;                   ///< true:channel動作中

--- a/ucoind/inc/lnapp.h
+++ b/ucoind/inc/lnapp.h
@@ -97,7 +97,6 @@ typedef struct lnapp_conf_t {
     bool            initiator;                  ///< true:Noise Protocolのinitiator
     uint8_t         node_id[UCOIN_SZ_PUBKEY];   ///< 接続先(initiator==true時)
     daemoncmd_t     cmd;                        ///< ucoincliからの処理要求
-    ln_fundin_t     fundin;
 
     //lnappワーク
     volatile bool   loop;                   ///< true:channel動作中

--- a/ucoind/lnapp.c
+++ b/ucoind/lnapp.c
@@ -310,7 +310,6 @@ bool lnapp_funding(lnapp_conf_t *pAppConf, const funding_conf_t *pFunding)
     }
 
     DBG_PRINTF("Establish開始\n");
-    set_establish_default(pAppConf, pAppConf->node_id);
     send_open_channel(pAppConf, pFunding);
 
     return true;

--- a/ucoind/lnapp.c
+++ b/ucoind/lnapp.c
@@ -2821,28 +2821,28 @@ static void set_establish_default(lnapp_conf_t *p_conf, const uint8_t *pNodeId)
 {
     bool ret;
     establish_conf_t econf;
-    ln_est_default_t defval;
+    ln_establish_prm_t estprm;
 
     ret = load_establish_conf("establish.conf", &econf);
     if (ret) {
-        defval.dust_limit_sat = econf.dust_limit_sat;
-        defval.max_htlc_value_in_flight_msat = econf.max_htlc_value_in_flight_msat;
-        defval.channel_reserve_sat = econf.channel_reserve_sat;
-        defval.htlc_minimum_msat = econf.htlc_minimum_msat;
-        defval.to_self_delay = econf.to_self_delay;
-        defval.max_accepted_htlcs = econf.max_accepted_htlcs;
-        defval.min_depth = econf.min_depth;
+        estprm.dust_limit_sat = econf.dust_limit_sat;
+        estprm.max_htlc_value_in_flight_msat = econf.max_htlc_value_in_flight_msat;
+        estprm.channel_reserve_sat = econf.channel_reserve_sat;
+        estprm.htlc_minimum_msat = econf.htlc_minimum_msat;
+        estprm.to_self_delay = econf.to_self_delay;
+        estprm.max_accepted_htlcs = econf.max_accepted_htlcs;
+        estprm.min_depth = econf.min_depth;
     } else {
-        defval.dust_limit_sat = M_DUST_LIMIT_SAT;
-        defval.max_htlc_value_in_flight_msat = M_MAX_HTLC_VALUE_IN_FLIGHT_MSAT;
-        defval.channel_reserve_sat = M_CHANNEL_RESERVE_SAT;
-        defval.htlc_minimum_msat = M_HTLC_MINIMUM_MSAT_EST;
-        defval.to_self_delay = M_TO_SELF_DELAY;
-        defval.max_accepted_htlcs = M_MAX_ACCEPTED_HTLCS;
-        defval.min_depth = M_MIN_DEPTH;
+        estprm.dust_limit_sat = M_DUST_LIMIT_SAT;
+        estprm.max_htlc_value_in_flight_msat = M_MAX_HTLC_VALUE_IN_FLIGHT_MSAT;
+        estprm.channel_reserve_sat = M_CHANNEL_RESERVE_SAT;
+        estprm.htlc_minimum_msat = M_HTLC_MINIMUM_MSAT_EST;
+        estprm.to_self_delay = M_TO_SELF_DELAY;
+        estprm.max_accepted_htlcs = M_MAX_ACCEPTED_HTLCS;
+        estprm.min_depth = M_MIN_DEPTH;
     }
 
-    ret = ln_set_establish(p_conf->p_self, pNodeId, &defval);
+    ret = ln_set_establish(p_conf->p_self, pNodeId, &estprm);
     assert(ret);
 }
 

--- a/ucoind/lnapp.c
+++ b/ucoind/lnapp.c
@@ -1139,11 +1139,13 @@ static bool send_open_channel(lnapp_conf_t *p_conf, const funding_conf_t *pFundi
         fundin.index = pFunding->txindex;
         fundin.amount = fundin_sat;
         fundin.p_change_pubkey = NULL;
-        fundin.p_change_addr = strdup(changeaddr);
+        fundin.p_change_addr = strdup(changeaddr);      //下位層でfreeする
         ucoin_chain_t chain;
         ucoin_util_wif2keys(&fundin.keys, &chain, wif);
         assert(ucoin_get_chain() == chain);
-        fundin.b_native = false;        //nested in BIP16
+        fundin.b_native = false;        //fundin_txの送金先アドレスのsegwit具合
+                                        //  false: nested in BIP16
+                                        //      bitcoind v0.15ではsegwitアドレスをaddwitnessaddressで行っている
 
         DBG_PRINTF("open_channel: fund_in amount=%" PRIu64 "\n", fundin_sat);
         ucoin_buf_t buf_bolt;

--- a/ucoind/lnapp.c
+++ b/ucoind/lnapp.c
@@ -957,7 +957,6 @@ LABEL_SHUTDOWN:
     //クリア
     APP_FREE(p_conf->p_opening);
     APP_FREE(p_conf->p_funding);
-    APP_FREE(p_conf->p_establish);
     APP_FREE(p_conf->p_errstr);
     for (int lp = 0; lp < APP_FWD_PROC_MAX; lp++) {
         APP_FREE(p_conf->fwd_proc[lp].p_data);
@@ -1945,7 +1944,6 @@ static void cb_established(lnapp_conf_t *p_conf, void *p_param)
     (void)p_param;
     DBGTRACE_BEGIN
 
-    APP_FREE(p_conf->p_establish);      //APP_MALLOC: set_establish_default()
     APP_FREE(p_conf->p_opening);        //APP_MALLOC: send_open_channel()
     APP_FREE(p_conf->p_funding);        //APP_MALLOC: set_lasterror()
 
@@ -2856,8 +2854,7 @@ static void set_establish_default(lnapp_conf_t *p_conf, const uint8_t *pNodeId)
         defval.min_depth = M_MIN_DEPTH;
     }
 
-    p_conf->p_establish = (ln_establish_t *)APP_MALLOC(sizeof(ln_establish_t));     //APP_FREE: cb_established()
-    ret = ln_set_establish(p_conf->p_self, p_conf->p_establish, pNodeId, &defval);
+    ret = ln_set_establish(p_conf->p_self, pNodeId, &defval);
     assert(ret);
 }
 

--- a/ucoind/lnapp.c
+++ b/ucoind/lnapp.c
@@ -955,8 +955,8 @@ LABEL_SHUTDOWN:
     SYSLOG_WARN("[exit]channel thread [%016" PRIx64 "]\n", ln_short_channel_id(&my_self));
 
     //クリア
-    APP_FREE(p_conf->p_opening);
-    APP_FREE(p_conf->p_funding);
+    APP_FREE(p_conf->p_opening);        //APP_MALLOC(): send_open_channel()
+    APP_FREE(p_conf->p_funding);        //APP_MALLOC(): cmd_fund()
     APP_FREE(p_conf->p_errstr);
     for (int lp = 0; lp < APP_FWD_PROC_MAX; lp++) {
         APP_FREE(p_conf->fwd_proc[lp].p_data);
@@ -1945,7 +1945,7 @@ static void cb_established(lnapp_conf_t *p_conf, void *p_param)
     DBGTRACE_BEGIN
 
     APP_FREE(p_conf->p_opening);        //APP_MALLOC: send_open_channel()
-    APP_FREE(p_conf->p_funding);        //APP_MALLOC: set_lasterror()
+    APP_FREE(p_conf->p_funding);        //APP_MALLOC: cmd_fund()
 
     SYSLOG_INFO("Established[%" PRIx64 "]: our_msat=%" PRIu64 ", their_msat=%" PRIu64, ln_short_channel_id(p_conf->p_self), ln_our_msat(p_conf->p_self), ln_their_msat(p_conf->p_self));
 

--- a/ucoind/lnapp.c
+++ b/ucoind/lnapp.c
@@ -3026,7 +3026,7 @@ static void set_lasterror(lnapp_conf_t *p_conf, int Err, const char *pErrStr)
         strftime(date, sizeof(date), "%d %b %Y %T %z", &tmval);
 
         p_conf->p_errstr = (char *)APP_MALLOC(len_max);        //APP_FREE: thread_main_start()
-        sprintf(p_conf->p_errstr, "\"[%s]%s\"", date, pErrStr);
+        sprintf(p_conf->p_errstr, "[%s]%s", date, pErrStr);
         DBG_PRINTF("%s\n", p_conf->p_errstr);
 
         // method: error
@@ -3037,7 +3037,7 @@ static void set_lasterror(lnapp_conf_t *p_conf, int Err, const char *pErrStr)
         char node_id[UCOIN_SZ_PUBKEY * 2 + 1];
         misc_bin2str(node_id, ln_our_node_id(p_conf->p_self), UCOIN_SZ_PUBKEY);
         sprintf(param, "%" PRIx64 " %s "
-                    "%s",
+                    "\"%s\"",
                     ln_short_channel_id(p_conf->p_self), node_id,
                     p_conf->p_errstr);
         call_script(M_EVT_ERROR, param);

--- a/ucoind/lnapp.c
+++ b/ucoind/lnapp.c
@@ -621,7 +621,7 @@ void lnapp_show_self(const lnapp_conf_t *pAppConf, cJSON *pResult)
         cJSON_AddItemToObject(result, "status", cJSON_CreateString("established"));
 
         //peer node_id
-        misc_bin2str(str, p_self->peer_node.node_id, UCOIN_SZ_PUBKEY);
+        misc_bin2str(str, p_self->peer_node_id, UCOIN_SZ_PUBKEY);
         cJSON_AddItemToObject(result, "node_id", cJSON_CreateString(str));
         //funding_tx
         misc_bin2str_rev(str, ln_funding_txid(pAppConf->p_self), UCOIN_SZ_TXID);
@@ -647,7 +647,7 @@ void lnapp_show_self(const lnapp_conf_t *pAppConf, cJSON *pResult)
         cJSON_AddItemToObject(result, "status", cJSON_CreateString("wait_minimum_depth"));
 
         //peer node_id
-        misc_bin2str(str, p_self->peer_node.node_id, UCOIN_SZ_PUBKEY);
+        misc_bin2str(str, p_self->peer_node_id, UCOIN_SZ_PUBKEY);
         cJSON_AddItemToObject(result, "node_id", cJSON_CreateString(str));
         //funding_tx
         misc_bin2str_rev(str, ln_funding_txid(pAppConf->p_self), UCOIN_SZ_TXID);
@@ -3214,7 +3214,7 @@ static void show_self_param(const ln_self_t *self, FILE *fp, int line)
             fprintf(fp, "(none)\n");
         }
         fprintf(fp, "peer node_id: ");
-        ucoin_util_dumpbin(fp, self->peer_node.node_id, UCOIN_SZ_PUBKEY, true);
+        ucoin_util_dumpbin(fp, self->peer_node_id, UCOIN_SZ_PUBKEY, true);
         fprintf(fp, "our_msat:   %" PRIu64 "\n", ln_our_msat(self));
         fprintf(fp, "their_msat: %" PRIu64 "\n", ln_their_msat(self));
         for (int lp = 0; lp < LN_HTLC_MAX; lp++) {

--- a/ucoind/lnapp.c
+++ b/ucoind/lnapp.c
@@ -165,7 +165,7 @@ typedef enum {
 static volatile bool        mLoop;          //true:チャネル有効
 
 static ln_node_t            *mpNode;
-static ln_anno_default_t    mAnnoDef;       ///< announcementデフォルト値
+static ln_anno_prm_t        mAnnoPrm;       ///< announcementパラメータ
 
 //シーケンスのmutex
 static pthread_mutexattr_t  mMuxAttr;
@@ -568,17 +568,17 @@ bool lnapp_close_channel_force(const uint8_t *pNodeId)
     anno_conf_t aconf;
     ret = load_anno_conf("anno.conf", &aconf);
     if (ret) {
-        mAnnoDef.cltv_expiry_delta = aconf.cltv_expiry_delta;
-        mAnnoDef.htlc_minimum_msat = aconf.htlc_minimum_msat;
-        mAnnoDef.fee_base_msat = aconf.fee_base_msat;
-        mAnnoDef.fee_prop_millionths = aconf.fee_prop_millionths;
+        mAnnoPrm.cltv_expiry_delta = aconf.cltv_expiry_delta;
+        mAnnoPrm.htlc_minimum_msat = aconf.htlc_minimum_msat;
+        mAnnoPrm.fee_base_msat = aconf.fee_base_msat;
+        mAnnoPrm.fee_prop_millionths = aconf.fee_prop_millionths;
     } else {
-        mAnnoDef.cltv_expiry_delta = M_CLTV_EXPIRY_DELTA;
-        mAnnoDef.htlc_minimum_msat = M_HTLC_MINIMUM_MSAT_ANNO;
-        mAnnoDef.fee_base_msat = M_FEE_BASE_MSAT;
-        mAnnoDef.fee_prop_millionths = M_FEE_PROP_MILLIONTHS;
+        mAnnoPrm.cltv_expiry_delta = M_CLTV_EXPIRY_DELTA;
+        mAnnoPrm.htlc_minimum_msat = M_HTLC_MINIMUM_MSAT_ANNO;
+        mAnnoPrm.fee_base_msat = M_FEE_BASE_MSAT;
+        mAnnoPrm.fee_prop_millionths = M_FEE_PROP_MILLIONTHS;
     }
-    ln_init(&my_self, mpNode, NULL, &mAnnoDef, NULL);
+    ln_init(&my_self, mpNode, NULL, &mAnnoPrm, NULL);
 
     ret = ln_node_search_channel(&my_self, pNodeId);
     if (!ret) {
@@ -774,19 +774,18 @@ static void *thread_main_start(void *pArg)
 
     my_self.p_param = p_conf;
 
-    //announcementデフォルト値
     anno_conf_t aconf;
     ret = load_anno_conf("anno.conf", &aconf);
     if (ret) {
-        mAnnoDef.cltv_expiry_delta = aconf.cltv_expiry_delta;
-        mAnnoDef.htlc_minimum_msat = aconf.htlc_minimum_msat;
-        mAnnoDef.fee_base_msat = aconf.fee_base_msat;
-        mAnnoDef.fee_prop_millionths = aconf.fee_prop_millionths;
+        mAnnoPrm.cltv_expiry_delta = aconf.cltv_expiry_delta;
+        mAnnoPrm.htlc_minimum_msat = aconf.htlc_minimum_msat;
+        mAnnoPrm.fee_base_msat = aconf.fee_base_msat;
+        mAnnoPrm.fee_prop_millionths = aconf.fee_prop_millionths;
     } else {
-        mAnnoDef.cltv_expiry_delta = M_CLTV_EXPIRY_DELTA;
-        mAnnoDef.htlc_minimum_msat = M_HTLC_MINIMUM_MSAT_ANNO;
-        mAnnoDef.fee_base_msat = M_FEE_BASE_MSAT;
-        mAnnoDef.fee_prop_millionths = M_FEE_PROP_MILLIONTHS;
+        mAnnoPrm.cltv_expiry_delta = M_CLTV_EXPIRY_DELTA;
+        mAnnoPrm.htlc_minimum_msat = M_HTLC_MINIMUM_MSAT_ANNO;
+        mAnnoPrm.fee_base_msat = M_FEE_BASE_MSAT;
+        mAnnoPrm.fee_prop_millionths = M_FEE_PROP_MILLIONTHS;
     }
 
     //スレッド
@@ -797,7 +796,7 @@ static void *thread_main_start(void *pArg)
     uint8_t seed[LN_SZ_SEED];
     DBG_PRINTF("ln_self_t initialize");
     ucoin_util_random(seed, LN_SZ_SEED);
-    ln_init(&my_self, mpNode, seed, &mAnnoDef, notify_cb);
+    ln_init(&my_self, mpNode, seed, &mAnnoPrm, notify_cb);
 
     p_conf->p_self = &my_self;
     p_conf->ping_counter = 0;

--- a/ucoind/monitoring.c
+++ b/ucoind/monitoring.c
@@ -256,7 +256,11 @@ static bool monfunc(ln_self_t *self, void *p_db_param, void *p_param)
             del = funding_spent(self, confm, p_db_param);
         } else {
             //funding_tx未使用
-            del = funding_unspent(self, confm, p_db_param);
+            if (LN_DBG_NODE_AUTO_CONNECT()) {
+                del = funding_unspent(self, confm, p_db_param);
+            } else {
+                DBG_PRINTF("[DBG]no Auto connect mode\n");
+            }
         }
         if (del) {
             DBG_PRINTF("delete from DB\n");


### PR DESCRIPTION
fix #218 
channelを閉じる際、単にdropさせるのではなく、いくつかの情報を別DBに残すようにする。
`ucoincli -l`で未接続のチャネルも出力させる。
`showdb`でclosedbの出力と削除を行えるようにする。

fix #241 
`ucoincli -c peer.conf -q` : 指定したpeerとのsocketを切断する。
node_announcementにIPアドレスが載っている場合は自動接続するため、 `ucoincli -d 8`によって自動接続を行わないデバッグモードも追加している。

fix #183 
shared_secretをDBから読込む