### PR TITLE
Autoconn stop

### DIFF
--- a/ucoincli/ucoincli.c
+++ b/ucoincli/ucoincli.c
@@ -92,6 +92,7 @@ static void close_rpc(char *pJson);
 static void getlasterror_rpc(char *pJson);
 static void debug_rpc(char *pJson, int debug);
 static void getcommittx_rpc(char *pJson);
+static void disable_autoconnect_rpc(char *pJson, const char *pDisable);
 
 static int msg_send(char *pRecv, const char *pSend, const char *pAddr, uint16_t Port, bool bSend);
 
@@ -117,7 +118,7 @@ int main(int argc, char *argv[])
     bool b_send = true;
     int opt;
     int options = M_OPTIONS_INIT;
-    while ((opt = getopt(argc, argv, "htq::lc:f:i:e:mp:r:xgwa:d:")) != -1) {
+    while ((opt = getopt(argc, argv, "htq::lc:f:i:e:mp:r:xs:gwa:d:")) != -1) {
         switch (opt) {
         case 'h':
             options = M_OPTIONS_HELP;
@@ -158,6 +159,9 @@ int main(int argc, char *argv[])
             if (options == M_OPTIONS_INIT) {
                 getinfo_rpc(mBuf);
                 options = M_OPTIONS_EXEC;
+            } else {
+                printf("fail: too many options\n");
+                options = M_OPTIONS_HELP;
             }
             break;
         case 'i':
@@ -190,6 +194,9 @@ int main(int argc, char *argv[])
                     printf("fail: invalid param\n");
                     options = M_OPTIONS_ERR;
                 }
+            } else {
+                printf("fail: too many options\n");
+                options = M_OPTIONS_HELP;
             }
             break;
         case 'm':
@@ -220,7 +227,7 @@ int main(int argc, char *argv[])
                     options = M_OPTIONS_ERR;
                 }
             } else {
-                printf("-f need -c option before\n");
+                printf("fail: too many options\n");
                 options = M_OPTIONS_HELP;
             }
             break;
@@ -305,6 +312,21 @@ int main(int argc, char *argv[])
                     printf("fail: decode BOLT#11 invoice\n");
                     options = M_OPTIONS_ERR;
                 }
+            }
+            break;
+        case 's':
+            //disable auto channel connect
+            if (options == M_OPTIONS_INIT) {
+                if ((strlen(optarg) == 1) && ((optarg[0] == '1') || (optarg[0] == '0'))) {
+                    disable_autoconnect_rpc(mBuf, optarg);
+                    options = M_OPTIONS_EXEC;
+                } else {
+                    printf("fail: invalid option\n");
+                    options = M_OPTIONS_HELP;
+                }
+            } else {
+                printf("fail: too many options\n");
+                options = M_OPTIONS_HELP;
             }
             break;
 
@@ -422,6 +444,7 @@ int main(int argc, char *argv[])
         printf("\t\t-p <payment.conf>,<paymenet_hash> : payment(don't put a space before or after the comma)\n");
         printf("\t\t-r <BOLT#11 invoice>(,<additional amount_msat>)(,<additional min_filnal_cltv_expiry>) : payment(don't put a space before or after the comma)\n");
         printf("\t\t-m : show payment_hashs\n");
+        printf("\t\t-s<1 or 0> : 1=stop auto channel connect\n");
         printf("\t\t-c <peer.conf> : connect node\n");
         printf("\t\t-c <peer node_id> OR <peer.conf> -f <fund.conf> : funding\n");
         printf("\t\t-c <peer node_id> OR <peer.conf> -x : mutual close channel\n");
@@ -683,6 +706,15 @@ static void getcommittx_rpc(char *pJson)
             mPeerNodeId, mPeerAddr, mPeerPort);
 }
 
+
+static void disable_autoconnect_rpc(char *pJson, const char *pDisable)
+{
+    snprintf(pJson, BUFFER_SIZE,
+        "{"
+            M_STR("method", "disautoconn") M_NEXT
+            M_QQ("params") ":[ %s ]"
+        "}", pDisable);
+}
 
 static int msg_send(char *pRecv, const char *pSend, const char *pAddr, uint16_t Port, bool bSend)
 {

--- a/ucoincli/ucoincli.c
+++ b/ucoincli/ucoincli.c
@@ -712,7 +712,7 @@ static void disable_autoconnect_rpc(char *pJson, const char *pDisable)
     snprintf(pJson, BUFFER_SIZE,
         "{"
             M_STR("method", "disautoconn") M_NEXT
-            M_QQ("params") ":[ %s ]"
+            M_QQ("params") ":[ \"%s\" ]"
         "}", pDisable);
 }
 

--- a/ucoind/cmd_json.c
+++ b/ucoind/cmd_json.c
@@ -984,12 +984,16 @@ static cJSON *cmd_disautoconn(jrpc_context *ctx, cJSON *params, cJSON *id)
             monitor_disable_autoconn(false);
             p_str = "enable auto connect";
         } else {
-            ctx->error_code = RPCERR_PARSE;
-            ctx->error_message = strdup(RPCERR_PARSE_STR);
+            //none
         }
     }
-
-    return (p_str) ? cJSON_CreateString(p_str) : NULL;
+    if (p_str != NULL) {
+        return cJSON_CreateString(p_str);
+    } else {
+        ctx->error_code = RPCERR_PARSE;
+        ctx->error_message = strdup(RPCERR_PARSE_STR);
+        return NULL;
+    }
 }
 
 

--- a/ucoind/cmd_json.c
+++ b/ucoind/cmd_json.c
@@ -76,6 +76,7 @@ static cJSON *cmd_routepay(jrpc_context *ctx, cJSON *params, cJSON *id);
 static cJSON *cmd_getinfo(jrpc_context *ctx, cJSON *params, cJSON *id);
 static cJSON *cmd_stop(jrpc_context *ctx, cJSON *params, cJSON *id);
 static cJSON *cmd_getlasterror(jrpc_context *ctx, cJSON *params, cJSON *id);
+static cJSON *cmd_disautoconn(jrpc_context *ctx, cJSON *params, cJSON *id);
 static cJSON *cmd_debug(jrpc_context *ctx, cJSON *params, cJSON *id);
 static cJSON *cmd_getcommittx(jrpc_context *ctx, cJSON *params, cJSON *id);
 static lnapp_conf_t *search_connected_lnapp_node(const uint8_t *p_node_id);
@@ -100,6 +101,7 @@ void cmd_json_start(uint16_t Port)
     jrpc_register_procedure(&mJrpc, cmd_getinfo,     "getinfo", NULL);
     jrpc_register_procedure(&mJrpc, cmd_stop,        "stop", NULL);
     jrpc_register_procedure(&mJrpc, cmd_getlasterror,"getlasterror", NULL);
+    jrpc_register_procedure(&mJrpc, cmd_disautoconn, "disautoconn", NULL);
     jrpc_register_procedure(&mJrpc, cmd_debug,       "debug", NULL);
     jrpc_register_procedure(&mJrpc, cmd_getcommittx, "getcommittx", NULL);
     jrpc_server_run(&mJrpc);
@@ -964,6 +966,30 @@ static cJSON *cmd_getlasterror(jrpc_context *ctx, cJSON *params, cJSON *id)
 
 LABEL_EXIT:
     return NULL;
+}
+
+
+static cJSON *cmd_disautoconn(jrpc_context *ctx, cJSON *params, cJSON *id)
+{
+    (void)id;
+
+    const char *p_str = NULL;
+
+    cJSON *json = cJSON_GetArrayItem(params, 0);
+    if (json && (json->type == cJSON_String)) {
+        if (json->valuestring[0] == '1') {
+            monitor_disable_autoconn(true);
+            p_str = "disable auto connect";
+        } else if (json->valuestring[0] == '0') {
+            monitor_disable_autoconn(false);
+            p_str = "enable auto connect";
+        } else {
+            ctx->error_code = RPCERR_PARSE;
+            ctx->error_message = strdup(RPCERR_PARSE_STR);
+        }
+    }
+
+    return (p_str) ? cJSON_CreateString(p_str) : NULL;
 }
 
 

--- a/ucoind/inc/monitoring.h
+++ b/ucoind/inc/monitoring.h
@@ -48,6 +48,13 @@ void *monitor_thread_start(void *pArg);
 void monitor_stop(void);
 
 
+/** チャネルありnodeへの自動接続停止設定
+ * 
+ * @param[in]   bDisable        true:自動接続停止
+ */
+void monitor_disable_autoconn(bool bDisable);
+
+
 /** Unilateral Close(自分が展開)
  *
  * @param[in,out]       self        チャネル情報

--- a/ucoind/monitoring.c
+++ b/ucoind/monitoring.c
@@ -55,6 +55,7 @@
  **************************************************************************/
 
 static volatile bool        mMonitoring;
+static bool                 mDisableAutoConn;           ///< true:channelのある他nodeへの自動接続停止
 
 
 /********************************************************************
@@ -115,6 +116,12 @@ void *monitor_thread_start(void *pArg)
 void monitor_stop(void)
 {
     mMonitoring = false;
+}
+
+
+void monitor_disable_autoconn(bool bDisable)
+{
+    mDisableAutoConn = bDisable;
 }
 
 
@@ -256,10 +263,10 @@ static bool monfunc(ln_self_t *self, void *p_db_param, void *p_param)
             del = funding_spent(self, confm, p_db_param);
         } else {
             //funding_tx未使用
-            if (LN_DBG_NODE_AUTO_CONNECT()) {
+            if (LN_DBG_NODE_AUTO_CONNECT() && !mDisableAutoConn) {
                 del = funding_unspent(self, confm, p_db_param);
             } else {
-                DBG_PRINTF("[DBG]no Auto connect mode\n");
+                DBG_PRINTF("No Auto connect mode\n");
             }
         }
         if (del) {


### PR DESCRIPTION
`ucoincli -s1` : stop auto channel connect
`ucoincli -s0` : start auto channel connect(default)

`ucoincli -c xxx -q`でチャネル切断しても再接続されてしまうので、それを避けるのに利用できる。