### PR TITLE
signrawtransaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,17 +84,17 @@ make distclean
 * [bitcoind](https://github.com/bitcoin/bitcoin)
   * bitcoin-cli
     * `getnewaddress`
-    * `addwitnessaddress`
+    * `addwitnessaddress` (bitcoind v0.15.x)
     * `sendtoaddress`
     * `gettxout`
   * JSON-RPC
     * `getblockcount`
     * `getrawtransaction`
+    * `signrawtransaction`
     * `sendrawtransaction`
     * `gettxout`
     * `getblock`
     * `getnewaddress`
-    * `dumpprivkey` (for funding)
     * `estimatesmartfee`
 
 ## Implement status

--- a/cmn/btcrpc.c
+++ b/cmn/btcrpc.c
@@ -76,6 +76,7 @@ typedef struct {
 static size_t write_response(void *ptr, size_t size, size_t nmemb, void *stream);
 static bool getraw_txstr(ucoin_tx_t *pTx, const char *txid);
 static bool getrawtransaction_rpc(char *pJson, const char *pTxid, bool detail);
+static bool signrawtransaction_rpc(char *pJson, const char *pTransaction);
 static bool sendrawtransaction_rpc(char *pJson, const char *pTransaction);
 static bool gettxout_rpc(char *pJson, const char *pTxid, int idx);
 static bool getblock_rpc(char *pJson, const char *pBlock);
@@ -716,6 +717,68 @@ LABEL_EXIT:
 }
 
 
+bool btcprc_signraw_tx(ucoin_tx_t *pTx, const uint8_t *pData, size_t Len)
+{
+    bool ret = false;
+    bool retval;
+    char *p_json;
+    char *transaction;
+
+    pthread_mutex_lock(&mMux);
+
+    transaction = (char *)APP_MALLOC(Len * 2 + 1);
+    misc_bin2str(transaction, pData, Len);
+
+    p_json = (char *)APP_MALLOC(BUFFER_SIZE);
+    retval = signrawtransaction_rpc(p_json, transaction);
+DBG_PRINTF("%s\n", p_json);
+    APP_FREE(transaction);
+    if (retval) {
+        json_t *p_root;
+        json_t *p_result;
+        json_t *p_hex;
+        json_error_t error;
+
+        p_root = json_loads(p_json, 0, &error);
+        if (!p_root) {
+            DBG_PRINTF("error: on line %d: %s\n", error.line, error.text);
+            goto LABEL_EXIT;
+        }
+
+        //これ以降は終了時に json_decref()で参照を減らすこと
+        p_result = json_object_get(p_root, M_RESULT);
+        if (!p_result) {
+            DBG_PRINTF("error: M_RESULT\n");
+            goto LABEL_DECREF;
+        }
+        p_hex = json_object_get(p_result, M_HEX);
+        if (json_is_string(p_hex)) {
+            const char *p_sigtx = (const char *)json_string_value(p_hex);
+            size_t len = strlen(p_sigtx) / 2;
+            uint8_t *p_buf = APP_MALLOC(len);
+            misc_str2bin(p_buf, len, p_sigtx);
+            ucoin_tx_free(pTx);
+            ret = ucoin_tx_read(pTx, p_buf, len);
+            APP_FREE(p_buf);
+        } else {
+            int code = error_result(p_root);
+            DBG_PRINTF("err code=%d\n", code);
+        }
+LABEL_DECREF:
+        json_decref(p_root);
+    } else {
+        DBG_PRINTF("fail: signrawtransaction_rpc()\n");
+    }
+
+LABEL_EXIT:
+    APP_FREE(p_json);
+
+    pthread_mutex_unlock(&mMux);
+
+    return ret;
+}
+
+
 bool btcprc_sendraw_tx(uint8_t *pTxid, int *pCode, const uint8_t *pData, uint32_t Len)
 {
     bool ret = false;
@@ -1119,6 +1182,35 @@ static bool getrawtransaction_rpc(char *pJson, const char *pTxid, bool detail)
                 M_1("method", "getrawtransaction") M_NEXT
                 M_QQ("params") ":[" M_QQ("%s") ", %s]"
             "}", pTxid, (detail) ? "true" : "false");
+
+        retval = rpc_proc(curl, pJson, data);
+        APP_FREE(data);
+    }
+
+    return retval == 0;
+}
+
+
+/** [cURL]signrawtransaction
+ *
+ */
+static bool signrawtransaction_rpc(char *pJson, const char *pTransaction)
+{
+    int retval = -1;
+    CURL *curl = curl_easy_init();
+
+    if (curl) {
+        char *data = (char *)APP_MALLOC(BUFFER_SIZE);
+        snprintf(data, BUFFER_SIZE,
+            "{"
+                ///////////////////////////////////////////
+                M_1("jsonrpc", "1.0") M_NEXT
+                M_1("id", RPCID) M_NEXT
+
+                ///////////////////////////////////////////
+                M_1("method", "signrawtransaction") M_NEXT
+                M_QQ("params") ":[" M_QQ("%s") "]"
+            "}", pTransaction);
 
         retval = rpc_proc(curl, pJson, data);
         APP_FREE(data);

--- a/cmn/btcrpc.c
+++ b/cmn/btcrpc.c
@@ -84,7 +84,7 @@ static bool getblockhash_rpc(char *pJson, int BHeight);
 static bool getblockcount_rpc(char *pJson);
 static bool getnewaddress_rpc(char *pJson);
 static bool estimatefee_rpc(char *pJson, int nBlock);
-static bool dumpprivkey_rpc(char *pJson, const char *pAddr);
+//static bool dumpprivkey_rpc(char *pJson, const char *pAddr);
 static int rpc_proc(CURL *curl, char *pJson, char *pData);
 static int error_result(json_t *p_root);
 
@@ -966,50 +966,50 @@ LABEL_EXIT:
 }
 
 
-bool btcprc_dumpprivkey(char *pWif, const char *pAddr)
-{
-    bool ret = false;
-    bool retval;
-    char *p_json;
+// bool btcprc_dumpprivkey(char *pWif, const char *pAddr)
+// {
+//     bool ret = false;
+//     bool retval;
+//     char *p_json;
 
-    pthread_mutex_lock(&mMux);
+//     pthread_mutex_lock(&mMux);
 
-    p_json = (char *)APP_MALLOC(BUFFER_SIZE);
-    retval = dumpprivkey_rpc(p_json, pAddr);
-    if (retval) {
-        json_t *p_root;
-        json_t *p_result;
-        json_error_t error;
+//     p_json = (char *)APP_MALLOC(BUFFER_SIZE);
+//     retval = dumpprivkey_rpc(p_json, pAddr);
+//     if (retval) {
+//         json_t *p_root;
+//         json_t *p_result;
+//         json_error_t error;
 
-        p_root = json_loads(p_json, 0, &error);
-        if (!p_root) {
-            DBG_PRINTF("error: on line %d: %s\n", error.line, error.text);
-            goto LABEL_EXIT;
-        }
+//         p_root = json_loads(p_json, 0, &error);
+//         if (!p_root) {
+//             DBG_PRINTF("error: on line %d: %s\n", error.line, error.text);
+//             goto LABEL_EXIT;
+//         }
 
-        //これ以降は終了時に json_decref()で参照を減らすこと
-        p_result = json_object_get(p_root, M_RESULT);
-        if (!p_result) {
-            DBG_PRINTF("error: M_RESULT\n");
-            goto LABEL_DECREF;
-        }
-        if (json_is_string(p_result)) {
-            strcpy(pWif,  (const char *)json_string_value(p_result));
-            ret = true;
-        }
-LABEL_DECREF:
-        json_decref(p_root);
-    } else {
-        DBG_PRINTF("fail: dumpprivkey_rpc()\n");
-    }
+//         //これ以降は終了時に json_decref()で参照を減らすこと
+//         p_result = json_object_get(p_root, M_RESULT);
+//         if (!p_result) {
+//             DBG_PRINTF("error: M_RESULT\n");
+//             goto LABEL_DECREF;
+//         }
+//         if (json_is_string(p_result)) {
+//             strcpy(pWif,  (const char *)json_string_value(p_result));
+//             ret = true;
+//         }
+// LABEL_DECREF:
+//         json_decref(p_root);
+//     } else {
+//         DBG_PRINTF("fail: dumpprivkey_rpc()\n");
+//     }
 
-LABEL_EXIT:
-    APP_FREE(p_json);
+// LABEL_EXIT:
+//     APP_FREE(p_json);
 
-    pthread_mutex_unlock(&mMux);
+//     pthread_mutex_unlock(&mMux);
 
-    return ret;
-}
+//     return ret;
+// }
 
 
 bool btcprc_estimatefee(uint64_t *pFeeSatoshi, int nBlocks)
@@ -1411,29 +1411,29 @@ static bool estimatefee_rpc(char *pJson, int nBlock)
 /** [cURL]dumpprivkey
  *
  */
-static bool dumpprivkey_rpc(char *pJson, const char *pAddr)
-{
-    int retval = -1;
-    CURL *curl = curl_easy_init();
+// static bool dumpprivkey_rpc(char *pJson, const char *pAddr)
+// {
+//     int retval = -1;
+//     CURL *curl = curl_easy_init();
 
-    if (curl) {
-        char data[512];
-        snprintf(data, sizeof(data),
-            "{"
-                ///////////////////////////////////////////
-                M_1("jsonrpc", "1.0") M_NEXT
-                M_1("id", RPCID) M_NEXT
+//     if (curl) {
+//         char data[512];
+//         snprintf(data, sizeof(data),
+//             "{"
+//                 ///////////////////////////////////////////
+//                 M_1("jsonrpc", "1.0") M_NEXT
+//                 M_1("id", RPCID) M_NEXT
 
-                ///////////////////////////////////////////
-                M_1("method", "dumpprivkey") M_NEXT
-                M_QQ("params") ":[" M_QQ("%s") "]"
-            "}", pAddr);
+//                 ///////////////////////////////////////////
+//                 M_1("method", "dumpprivkey") M_NEXT
+//                 M_QQ("params") ":[" M_QQ("%s") "]"
+//             "}", pAddr);
 
-        retval = rpc_proc(curl, pJson, data);
-    }
+//         retval = rpc_proc(curl, pJson, data);
+//     }
 
-    return retval == 0;
-}
+//     return retval == 0;
+// }
 
 
 static int rpc_proc(CURL *curl, char *pJson, char *pData)

--- a/include/btcrpc.h
+++ b/include/btcrpc.h
@@ -119,6 +119,9 @@ bool btcprc_search_txid_block(ucoin_tx_t *pTx, int BHeight, const uint8_t *pTxid
 bool btcprc_search_vout_block(ucoin_buf_t *pTxBuf, int BHeight, const ucoin_buf_t *pVout);
 
 
+bool btcprc_signraw_tx(ucoin_tx_t *pTx, const uint8_t *pData, size_t Len);
+
+
 /** [bitcoin rpc]sendrawtransaction
  *
  * @param[out]  pTxid       取得したTXID(戻り値がtrue時)
@@ -169,15 +172,6 @@ bool btcprc_getxout(bool *pUnspent, uint64_t *pSat, const uint8_t *pTxid, int Tx
 bool btcprc_getnewaddress(char *pAddr);
 
 
-/** [bitcoin rpc]estimatefee
- *
- * @param[out]  pFeeSatoshi estimated fee-per-kilobytes[satoshi]
- * @param[in]   予想するブロック数
- * @retval  true        取得成功
- */
-bool btcprc_estimatefee(uint64_t *pFeeSatoshi, int nBlocks);
-
-
 /** [bitcoin rpc]dumpprivkey
  *
  * @param[out]  pWif        取得したWIF形式
@@ -185,5 +179,14 @@ bool btcprc_estimatefee(uint64_t *pFeeSatoshi, int nBlocks);
  * @retval  true        取得成功
  */
 bool btcprc_dumpprivkey(char *pWif, const char *pAddr);
+
+
+/** [bitcoin rpc]estimatefee
+ *
+ * @param[out]  pFeeSatoshi estimated fee-per-kilobytes[satoshi]
+ * @param[in]   予想するブロック数
+ * @retval  true        取得成功
+ */
+bool btcprc_estimatefee(uint64_t *pFeeSatoshi, int nBlocks);
 
 #endif /* BTCRPC_H__ */

--- a/include/btcrpc.h
+++ b/include/btcrpc.h
@@ -178,7 +178,7 @@ bool btcprc_getnewaddress(char *pAddr);
  * @param[in]   pAddr       アドレス
  * @retval  true        取得成功
  */
-bool btcprc_dumpprivkey(char *pWif, const char *pAddr);
+//bool btcprc_dumpprivkey(char *pWif, const char *pAddr);
 
 
 /** [bitcoin rpc]estimatefee

--- a/ucoin/include/ln.h
+++ b/ucoin/include/ln.h
@@ -369,10 +369,7 @@ typedef struct {
     uint8_t                     txid[UCOIN_SZ_TXID];            ///< 2-of-2へ入金するTXID
     int32_t                     index;                          ///< 未設定時(channelを開かれる方)は-1
     uint64_t                    amount;                         ///< 2-of-2へ入金するtxのvout amount
-    uint8_t                     *p_change_pubkey;               ///< 2-of-2へ入金したお釣りの送金先アドレス(未使用時:NULL)
-    char                        *p_change_addr;                 ///< 2-of-2へ入金したお釣りの送金先アドレス(未使用時:NULL)
-    ucoin_util_keys_t           keys;                           ///< 2-of-2へ入金するtxの鍵(署名用)
-    bool                        b_native;                       ///< true:fundinがnative segwit output
+    char                        change_addr[UCOIN_SZ_ADDR_MAX]; ///< 2-of-2へ入金したお釣りの送金先アドレス(未使用時:NULL)
 } ln_fundin_t;
 
 

--- a/ucoin/include/ln.h
+++ b/ucoin/include/ln.h
@@ -169,7 +169,7 @@ typedef enum {
     LN_CB_ERROR,                ///< エラー通知
     LN_CB_INIT_RECV,            ///< init受信通知
     LN_CB_REESTABLISH_RECV,     ///< channel_reestablish受信通知
-    LN_CB_FINDINGWIF_REQ,       ///< funding鍵設定要求
+    LN_CB_SIGN_FUNDINGTX_REQ,   ///< funding_tx署名要求
     LN_CB_FUNDINGTX_WAIT,       ///< funding_tx安定待ち要求
     LN_CB_ESTABLISHED,          ///< Establish完了通知
     LN_CB_CHANNEL_ANNO_RECV,    ///< channel_announcement受信通知
@@ -767,6 +767,15 @@ typedef struct {
  * typedefs : コールバック用
  **************************************************************************/
 
+/** @struct ln_cb_funding_sign_t
+ *  @brief  funding_tx署名要求(#LN_CB_SIGN_FUNDINGTX_REQ)
+ */
+typedef struct {
+    ucoin_tx_t              *p_tx;
+    bool                    ret;        //署名結果
+} ln_cb_funding_sign_t;
+
+
 /** @struct ln_cb_funding_t
  *  @brief  funding_tx安定待ち要求(#LN_CB_FUNDINGTX_WAIT) / Establish完了通知(#LN_CB_ESTABLISHED)
  */
@@ -1099,17 +1108,6 @@ const uint8_t* ln_get_genesishash(void);
  *      - pEstablishは接続完了まで保持すること
  */
 bool ln_set_establish(ln_self_t *self, const uint8_t *pNodeId, const ln_establish_prm_t *pEstPrm);
-
-
-/** funding鍵設定
- *
- * @param[in,out]       self        channel情報
- * @param[in]           pWif        funding鍵
- * @retval      true    成功
- * @attention
- *      - コールバックで #LN_CB_FINDINGWIF_REQ が要求された場合のみ呼び出すこと
- */
-bool ln_set_funding_wif(ln_self_t *self, const char *pWif);
 
 
 /** short_channel_id情報設定

--- a/ucoin/src/ln/ln.c
+++ b/ucoin/src/ln/ln.c
@@ -2942,9 +2942,8 @@ static bool recv_update_fee(ln_self_t *self, const uint8_t *pData, uint16_t Len)
         goto LABEL_EXIT;
     }
 
-    uint32_t fee_per_kw = self->feerate_per_kw;
+    DBG_PRINTF("change fee: %" PRIu32 " --> %" PRIu32 "\n", self->feerate_per_kw, upfee.feerate_per_kw);
     self->feerate_per_kw = upfee.feerate_per_kw;
-    DBG_PRINTF("change fee: %" PRIu32 " --> %" PRIu32 "\n", fee_per_kw, upfee.feerate_per_kw);
 
 LABEL_EXIT:
     DBG_PRINTF("END\n");

--- a/ucoin/src/ln/ln.c
+++ b/ucoin/src/ln/ln.c
@@ -630,7 +630,7 @@ bool ln_create_open_channel(ln_self_t *self, ucoin_buf_t *pOpen,
         return false;
     }
 
-    //TODO: 仮チャネルID
+    //仮チャネルID
     ucoin_util_random(self->channel_id, LN_SZ_CHANNEL_ID);
 
     //鍵生成
@@ -640,19 +640,6 @@ bool ln_create_open_channel(ln_self_t *self, ucoin_buf_t *pOpen,
         DBG_PRINTF("fail: create_channelkeys\n");
         return false;
     }
-
-    //funding鍵設定要求
-    //アプリからの設定漏れがチェックできるように、funding鍵を0で初期化
-    memset(&self->funding_local.keys[MSG_FUNDIDX_FUNDING], 0, sizeof(self->funding_local.keys[MSG_FUNDIDX_FUNDING]));
-    (*self->p_callback)(self, LN_CB_FINDINGWIF_REQ, NULL);
-    ret = ucoin_keys_chkpriv(self->funding_local.keys[MSG_FUNDIDX_FUNDING].priv);
-    if (!ret) {
-        self->err = LNERR_INV_PRIVKEY;
-        DBG_PRINTF("fail: no funding key\n");
-        return false;
-    }
-
-    ln_print_keys(PRINTOUT, &self->funding_local, &self->funding_remote);
 
     //funding_tx作成用に保持
     assert(self->p_establish->p_fundin == NULL);
@@ -1901,17 +1888,6 @@ static bool recv_open_channel(ln_self_t *self, const uint8_t *pData, uint16_t Le
     ret = create_channelkeys(self);
     if (!ret) {
         DBG_PRINTF("fail: create_channelkeys\n");
-        return false;
-    }
-
-    //funding鍵設定要求
-    //アプリからの設定漏れがチェックできるように、funding鍵を0で初期化
-    memset(&self->funding_local.keys[MSG_FUNDIDX_FUNDING], 0, sizeof(self->funding_local.keys[MSG_FUNDIDX_FUNDING]));
-    (*self->p_callback)(self, LN_CB_FINDINGWIF_REQ, NULL);
-    ret = ucoin_keys_chkpriv(self->funding_local.keys[MSG_FUNDIDX_FUNDING].priv);
-    if (!ret) {
-        self->err = LNERR_INV_PRIVKEY;
-        DBG_PRINTF("fail: no funding key\n");
         return false;
     }
 
@@ -3289,9 +3265,16 @@ static bool create_funding_tx(ln_self_t *self)
         return false;
     }
     ucoin_buf_free(&txbuf);
+    self->funding_local.txindex = M_FUNDING_INDEX;      //TODO: vout#0は2-of-2、vout#1はchangeにしている
 
     //署名
-    self->funding_local.txindex = M_FUNDING_INDEX;      //TODO: vout#0は2-of-2、vout#1はchangeにしている
+    bool ret;
+#if 1
+    ln_cb_funding_sign_t sig;
+    sig.p_tx =  &self->tx_funding;
+    (*self->p_callback)(self, LN_CB_SIGN_FUNDINGTX_REQ, &sig);
+    ret = sig.ret;
+#else
     sign_p2wpkh(&self->tx_funding, self->funding_local.txindex,
             self->p_establish->p_fundin->amount, &self->p_establish->p_fundin->keys);
     if (!self->p_establish->p_fundin->b_native) {
@@ -3308,9 +3291,11 @@ static bool create_funding_tx(ln_self_t *self)
         p_buf->buf[2] = (uint8_t)UCOIN_SZ_PUBKEYHASH;
         ucoin_util_hash160(&p_buf->buf[3], self->p_establish->p_fundin->keys.pub, UCOIN_SZ_PUBKEY);
     }
+    ret = true;
+#endif
     ucoin_tx_txid(self->funding_local.txid, &self->tx_funding);
 
-    return true;
+    return ret;
 }
 
 
@@ -4042,7 +4027,7 @@ static bool create_channelkeys(ln_self_t *self)
 {
     //鍵生成
     //  open_channel/accept_channelの鍵は update_percommit_secret()で生成
-    for (int lp = MSG_FUNDIDX_REVOCATION; lp < LN_FUNDIDX_MAX; lp++) {
+    for (int lp = MSG_FUNDIDX_FUNDING; lp < LN_FUNDIDX_MAX; lp++) {
         if (lp != MSG_FUNDIDX_PER_COMMIT) {
             ucoin_util_createkeys(&self->funding_local.keys[lp]);
         }

--- a/ucoin/src/ln/ln.c
+++ b/ucoin/src/ln/ln.c
@@ -3228,18 +3228,7 @@ static bool create_funding_tx(ln_self_t *self)
     ucoin_sw_add_vout_p2wsh(&self->tx_funding, self->p_establish->cnl_open.funding_sat, &self->redeem_fund);
 
     //vout#1:P2WPKH - change(amountは後で代入)
-    if (self->p_establish->p_fundin->p_change_pubkey != NULL) {
-        ucoin_sw_add_vout_p2wpkh_pub(&self->tx_funding, (uint64_t)-1, self->p_establish->p_fundin->p_change_pubkey);
-        free(self->p_establish->p_fundin->p_change_pubkey);       //APP
-        self->p_establish->p_fundin->p_change_pubkey = NULL;
-    } else if (self->p_establish->p_fundin->p_change_addr != NULL) {
-        ucoin_tx_add_vout_addr(&self->tx_funding, (uint64_t)-1, self->p_establish->p_fundin->p_change_addr);
-        free(self->p_establish->p_fundin->p_change_addr);         //APP
-        self->p_establish->p_fundin->p_change_addr = NULL;
-    } else {
-        DBG_PRINTF("fail: no change address\n");
-        return false;
-    }
+    ucoin_tx_add_vout_addr(&self->tx_funding, (uint64_t)-1, self->p_establish->p_fundin->change_addr);
 
     //input
     //vin#0
@@ -4323,8 +4312,6 @@ static void free_establish(ln_self_t *self)
 {
     if (self->p_establish != NULL) {
         if (self->p_establish->p_fundin != NULL) {
-            free(self->p_establish->p_fundin->p_change_pubkey);       //APP
-            free(self->p_establish->p_fundin->p_change_addr);         //APP
             M_FREE(self->p_establish->p_fundin);  //M_MALLOC: ln_create_open_channel()
         }
         M_FREE(self->p_establish);        //M_MALLOC: ln_set_establish()

--- a/ucoin/src/ucoin.c
+++ b/ucoin/src/ucoin.c
@@ -141,5 +141,5 @@ void ucoin_term(void)
 
 ucoin_chain_t ucoin_get_chain(void)
 {
-    return mPref[UCOIN_PREF];
+    return (ucoin_chain_t)mPref[UCOIN_PREF];
 }


### PR DESCRIPTION
fix #297 

`dumpprivkey`を削除し、`signrawtransaction`に置き換える。