### PR TITLE
Fix funding

### DIFF
--- a/ucoin/src/ln/ln.c
+++ b/ucoin/src/ln/ln.c
@@ -3082,6 +3082,8 @@ static bool recv_channel_update(ln_self_t *self, const uint8_t *pData, uint16_t 
  */
 static void start_funding_wait(ln_self_t *self, bool bSendTx)
 {
+    DBG_PRINTF("\n");
+    
     ln_cb_funding_t funding;
 
     //commitment numberは0から始まる

--- a/ucoin/src/ln/ln.c
+++ b/ucoin/src/ln/ln.c
@@ -96,17 +96,17 @@
 // ln_self_t.init_flag
 #define M_INIT_FLAG_SEND                    (0x01)
 #define M_INIT_FLAG_RECV                    (0x02)
-#define M_INIT_FLAG_INITED(flag)            (((flag) & (M_INIT_FLAG_SEND | M_INIT_FLAG_RECV)) == (M_INIT_FLAG_SEND | M_INIT_FLAG_RECV))
+#define M_INIT_FLAG_EXCHNAGED(flag)         (((flag) & (M_INIT_FLAG_SEND | M_INIT_FLAG_RECV)) == (M_INIT_FLAG_SEND | M_INIT_FLAG_RECV))
 
 // ln_self_t.anno_flag
 #define M_ANNO_FLAG_SEND                    (0x01)          ///< 1:announcement_signatures送信あり
 #define M_ANNO_FLAG_RECV                    (0x02)          ///< 1:announcement_signatures受信あり
-#define M_ANNO_FLAG_END                     (0x80)
+#define M_ANNO_FLAG_END                     (0x80)          ///< 送受信完了後の処理済み
 
 // ln_self_t.shutdown_flag
 #define M_SHDN_FLAG_SEND                    (0x01)          ///< 1:shutdown送信あり
 #define M_SHDN_FLAG_RECV                    (0x02)          ///< 1:shutdown受信あり
-#define M_SHDN_FLAG_END                     (M_SHDN_FLAG_SEND | M_SHDN_FLAG_RECV)
+#define M_SHDN_FLAG_EXCHANGED(flag)         (((flag) & (M_SHDN_FLAG_SEND | M_SHDN_FLAG_RECV)) == (M_SHDN_FLAG_SEND | M_SHDN_FLAG_RECV))
 
 #define M_PONG_MISSING                      (50)            ///< pongが返ってこないエラー上限
 
@@ -369,7 +369,11 @@ bool ln_set_funding_wif(ln_self_t *self, const char *pWif)
 
 void ln_set_short_channel_id_param(ln_self_t *self, uint32_t Height, uint32_t Index, uint32_t FundingIndex)
 {
-    self->short_channel_id = ln_misc_calc_short_channel_id(Height, Index, FundingIndex);
+    uint64_t short_channel_id = ln_misc_calc_short_channel_id(Height, Index, FundingIndex);
+    if (self->short_channel_id == 0) {
+        self->short_channel_id = short_channel_id;
+        ln_db_self_save(self);
+    }
 }
 
 
@@ -474,14 +478,14 @@ bool ln_recv(ln_self_t *self, const uint8_t *pData, uint16_t Len)
     uint16_t type = ln_misc_get16be(pData);
 
     //DBG_PRINTF("short_channel_id= %" PRIx64 "\n", self->short_channel_id);
-    if ((type != MSGTYPE_INIT) && (!M_INIT_FLAG_INITED(self->init_flag))) {
+    if ((type != MSGTYPE_INIT) && (!M_INIT_FLAG_EXCHNAGED(self->init_flag))) {
         self->err = LNERR_INV_STATE;
         DBG_PRINTF("fail: no init received : %04x\n", type);
         return false;
     }
     if ( (type != MSGTYPE_CLOSING_SIGNED) &&
          !MSGTYPE_IS_ANNOUNCE(type) && !MSGTYPE_IS_PINGPONG(type) &&
-         ((self->shutdown_flag & M_SHDN_FLAG_END) == M_SHDN_FLAG_END) ) {
+         M_SHDN_FLAG_EXCHANGED(self->shutdown_flag) ) {
         self->err = LNERR_INV_STATE;
         DBG_PRINTF("fail: not closing_signed received : %04x\n", type);
         return false;
@@ -606,7 +610,7 @@ bool ln_create_funding_locked(ln_self_t *self, ucoin_buf_t *pLocked)
 bool ln_create_open_channel(ln_self_t *self, ucoin_buf_t *pOpen,
             const ln_fundin_t *pFundin, uint64_t FundingSat, uint64_t PushSat, uint32_t FeeRate)
 {
-    if (!M_INIT_FLAG_INITED(self->init_flag)) {
+    if (!M_INIT_FLAG_EXCHNAGED(self->init_flag)) {
         self->err = LNERR_INV_STATE;
         DBG_PRINTF("fail: no init finished\n");
         return false;
@@ -782,7 +786,7 @@ bool ln_create_shutdown(ln_self_t *self, ucoin_buf_t *pShutdown)
 {
     DBG_PRINTF("BEGIN\n");
 
-    if (!M_INIT_FLAG_INITED(self->init_flag)) {
+    if (!M_INIT_FLAG_EXCHNAGED(self->init_flag)) {
         self->err = LNERR_INV_STATE;
         DBG_PRINTF("fail: no init finished\n");
         return false;
@@ -1083,7 +1087,7 @@ bool ln_create_add_htlc(ln_self_t *self,
 {
     DBG_PRINTF("BEGIN\n");
 
-    if (!M_INIT_FLAG_INITED(self->init_flag)) {
+    if (!M_INIT_FLAG_EXCHNAGED(self->init_flag)) {
         self->err = LNERR_INV_STATE;
         DBG_PRINTF("fail: no init finished\n");
         return false;
@@ -1179,7 +1183,7 @@ bool ln_create_fulfill_htlc(ln_self_t *self, ucoin_buf_t *pFulfill, uint64_t id,
 {
     DBG_PRINTF("BEGIN\n");
 
-    if (!M_INIT_FLAG_INITED(self->init_flag)) {
+    if (!M_INIT_FLAG_EXCHNAGED(self->init_flag)) {
         self->err = LNERR_INV_STATE;
         DBG_PRINTF("fail: no init finished\n");
         return false;
@@ -1241,7 +1245,7 @@ bool ln_create_fail_htlc(ln_self_t *self, ucoin_buf_t *pFail, uint64_t id, const
 {
     DBG_PRINTF("BEGIN\n");
 
-    if (!M_INIT_FLAG_INITED(self->init_flag)) {
+    if (!M_INIT_FLAG_EXCHNAGED(self->init_flag)) {
         self->err = LNERR_INV_STATE;
         DBG_PRINTF("fail: no init finished\n");
         return false;
@@ -1294,7 +1298,7 @@ bool ln_create_commit_signed(ln_self_t *self, ucoin_buf_t *pCommSig)
 
     bool ret;
 
-    if (!M_INIT_FLAG_INITED(self->init_flag)) {
+    if (!M_INIT_FLAG_EXCHNAGED(self->init_flag)) {
         self->err = LNERR_INV_STATE;
         DBG_PRINTF("fail: no init finished\n");
         return false;
@@ -2262,7 +2266,7 @@ static bool recv_closing_signed(ln_self_t *self, const uint8_t *pData, uint16_t 
 {
     DBG_PRINTF("BEGIN\n");
 
-    if ((self->shutdown_flag & M_SHDN_FLAG_END) != M_SHDN_FLAG_END) {
+    if (!M_SHDN_FLAG_EXCHANGED(self->shutdown_flag)) {
         self->err = LNERR_INV_STATE;
         DBG_PRINTF("bad status : %02x\n", self->shutdown_flag);
         return false;

--- a/ucoin/src/ln/ln_signer.c
+++ b/ucoin/src/ln/ln_signer.c
@@ -142,7 +142,7 @@ void HIDDEN ln_signer_get_prevkey(const ln_self_t *self, uint8_t *pSecret)
     DBG_PRINTF("prev_secret(%" PRIx64 "): ", self->storage_index + 2);
     DUMPBIN(pSecret, UCOIN_SZ_PRIVKEY);
     DBG_PRINTF("       pub: ");
-    uint8_t pub[UCOIN_SZ_PUBKEY);
+    uint8_t pub[UCOIN_SZ_PUBKEY];
     ucoin_keys_priv2pub(pub, pSecret);
     DUMPBIN(pub, UCOIN_SZ_PUBKEY);
 }

--- a/ucoin/src/ln/ln_signer.c
+++ b/ucoin/src/ln/ln_signer.c
@@ -52,7 +52,8 @@ bool ln_signer_sign_nodekey(uint8_t *pRS, const uint8_t *pHash)
 
 void HIDDEN ln_signer_init(ln_self_t *self, const uint8_t *pSeed)
 {
-    self->storage_index = LN_SECINDEX_INIT;
+    DBG_PRINTF("\n");
+
     if (pSeed) {
         memcpy(self->storage_seed, pSeed, LN_SZ_SEED);
         ln_derkey_storage_init(&self->peer_storage);
@@ -62,12 +63,16 @@ void HIDDEN ln_signer_init(ln_self_t *self, const uint8_t *pSeed)
 
 void HIDDEN ln_signer_term(ln_self_t *self)
 {
+    DBG_PRINTF("\n");
+
     memset(self->storage_seed, 0, UCOIN_SZ_PRIVKEY);
 }
 
 
 void HIDDEN ln_signer_create_nodekey(ucoin_util_keys_t *pKeys)
 {
+    DBG_PRINTF("\n");
+
     ucoin_util_createkeys(pKeys);
 }
 
@@ -75,6 +80,8 @@ void HIDDEN ln_signer_create_nodekey(ucoin_util_keys_t *pKeys)
 bool HIDDEN ln_signer_create_channelkeys(ln_self_t *self)
 {
     DBG_PRINTF("\n");
+
+    self->storage_index = LN_SECINDEX_INIT;
 
     //鍵生成
     //  open_channel/accept_channelの鍵は ln_signer_update_percommit_secret()で生成
@@ -93,10 +100,11 @@ bool HIDDEN ln_signer_create_channelkeys(ln_self_t *self)
 
 void HIDDEN ln_signer_update_percommit_secret(ln_self_t *self)
 {
+    DBG_PRINTF("\n");
+
     ln_signer_keys_update(self, 0);
 
     self->storage_index--;
-    DBG_PRINTF("\n");
 
     ln_misc_update_scriptkeys(&self->funding_local, &self->funding_remote);
 }
@@ -104,12 +112,16 @@ void HIDDEN ln_signer_update_percommit_secret(ln_self_t *self)
 
 void HIDDEN ln_signer_keys_update(ln_self_t *self, int64_t Offset)
 {
+    DBG_PRINTF("\n");
+
     ln_signer_keys_update_force(self, self->storage_index + Offset);
 }
 
 
 void HIDDEN ln_signer_keys_update_force(ln_self_t *self, uint64_t Index)
 {
+    DBG_PRINTF("\n");
+
     ln_derkey_create_secret(self->funding_local.keys[MSG_FUNDIDX_PER_COMMIT].priv, self->storage_seed, Index);
     ucoin_keys_priv2pub(self->funding_local.keys[MSG_FUNDIDX_PER_COMMIT].pub, self->funding_local.keys[MSG_FUNDIDX_PER_COMMIT].priv);
 
@@ -120,18 +132,26 @@ void HIDDEN ln_signer_keys_update_force(ln_self_t *self, uint64_t Index)
 
 void HIDDEN ln_signer_get_prevkey(const ln_self_t *self, uint8_t *pSecret)
 {
+    DBG_PRINTF("\n");
+
     //  現在の funding_local.keys[MSG_FUNDIDX_PER_COMMIT]はself->storage_indexから生成されていて、「次のper_commitment_secret」になる。
     //  最後に使用した値は self->storage_index + 1で、これが「現在のper_commitment_secret」になる。
     //  そのため、「1つ前のper_commitment_secret」は self->storage_index + 2 となる。
     ln_derkey_create_secret(pSecret, self->storage_seed, self->storage_index + 2);
 
-    //DBG_PRINTF("prev self->storage_index = %" PRIx64 "\n", self->storage_index + 2);
-    //DUMPBIN(pSecret, UCOIN_SZ_PRIVKEY);
+    DBG_PRINTF("prev_secret(%" PRIx64 "): ", self->storage_index + 2);
+    DUMPBIN(pSecret, UCOIN_SZ_PRIVKEY);
+    DBG_PRINTF("       pub: ");
+    uint8_t pub[UCOIN_SZ_PUBKEY);
+    ucoin_keys_priv2pub(pub, pSecret);
+    DUMPBIN(pub, UCOIN_SZ_PUBKEY);
 }
 
 
 void HIDDEN ln_signer_get_secret(const ln_self_t *self, ucoin_util_keys_t *pKeys, int MsgFundIdx, const uint8_t *pPerCommit)
 {
+    DBG_PRINTF("\n");
+
     ln_derkey_privkey(pKeys->priv,
                 self->funding_local.keys[MsgFundIdx].pub,
                 pPerCommit,
@@ -142,6 +162,8 @@ void HIDDEN ln_signer_get_secret(const ln_self_t *self, ucoin_util_keys_t *pKeys
 
 void HIDDEN ln_signer_get_revokesec(const ln_self_t *self, ucoin_util_keys_t *pKeys, const uint8_t *pPerCommit, const uint8_t *pRevokedSec)
 {
+    DBG_PRINTF("\n");
+
     ln_derkey_revocationprivkey(pKeys->priv,
                 self->funding_local.keys[MSG_FUNDIDX_REVOCATION].pub,
                 pPerCommit,
@@ -153,12 +175,16 @@ void HIDDEN ln_signer_get_revokesec(const ln_self_t *self, ucoin_util_keys_t *pK
 
 bool HIDDEN ln_signer_p2wsh_2(ucoin_buf_t *pSig, const uint8_t *pTxHash, const ucoin_util_keys_t *pKeys)
 {
+    DBG_PRINTF("\n");
+
     return ucoin_tx_sign(pSig, pTxHash, pKeys->priv);
 }
 
 
 bool HIDDEN ln_signer_p2wpkh(ucoin_tx_t *pTx, int Index, uint64_t Value, const ucoin_util_keys_t *pKeys)
 {
+    DBG_PRINTF("\n");
+
     bool ret;
     uint8_t txhash[UCOIN_SZ_HASH256];
     ucoin_buf_t sigbuf;
@@ -184,6 +210,8 @@ bool HIDDEN ln_signer_p2wpkh(ucoin_tx_t *pTx, int Index, uint64_t Value, const u
 
 void HIDDEN ln_signer_generate_shared_secret(uint8_t *pResult, const uint8_t *pPubKey)
 {
+    DBG_PRINTF("\n");
+
     uint8_t pub[UCOIN_SZ_PUBKEY];
     ucoin_util_mul_pubkey(pub, pPubKey, ln_node_getprivkey(), UCOIN_SZ_PRIVKEY);
     ucoin_util_sha256(pResult, pub, sizeof(pub));

--- a/ucoind/lnapp.c
+++ b/ucoind/lnapp.c
@@ -1259,6 +1259,8 @@ static bool exchange_funding_locked(lnapp_conf_t *p_conf)
     }
     DBG_PRINTF("exchange: funding_locked\n");
 
+    check_short_channel_id(p_conf);
+
     // method: established
     // $1: short_channel_id
     // $2: node_id


### PR DESCRIPTION
一度fundingに失敗(feerate_per_kwがあわないなどで、`open_channel`後に失敗)すると、funding後の初回送金で`revoke_and_ack`の`per_commitment_secret`が不一致になる。