### PR TITLE
Fix 337

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -1,5 +1,6 @@
 {
-    "configurations": [{
+    "configurations": [
+        {
             "name": "Mac",
             "includePath": [
                 "/usr/include",
@@ -17,7 +18,7 @@
             "defines": [
                 "UCOIN_DEBUG",
                 "UCOIN_DEBUG_MEM",
-                "NETKIND=1"                
+                "NETKIND=1"
             ],
             "intelliSenseMode": "clang-x64",
             "browse": {
@@ -112,7 +113,9 @@
                 ],
                 "limitSymbolsToIncludedHeaders": true,
                 "databaseFilename": ""
-            }
+            },
+            "cStandard": "c11",
+            "cppStandard": "c++17"
         },
         {
             "name": "Win32",

--- a/routing/routing.cpp
+++ b/routing/routing.cpp
@@ -354,7 +354,7 @@ static bool loaddb(const char *pDbPath, const uint8_t *p1, const uint8_t *p2, bo
     ln_lmdb_setenv(pDbSelf, pDbNode);
 
     if (clear_skip_db) {
-        bret = ln_db_annoskip_drop();
+        bret = ln_db_annoskip_drop(false);
         fprintf(fp_err, "%s: clear routing skip DB\n", (bret) ? "OK" : "fail");
         if (stop_after_dbclear) {
             return false;

--- a/showdb/showdb.c
+++ b/showdb/showdb.c
@@ -503,11 +503,11 @@ static void dumpit_annoskip(MDB_txn *txn, MDB_dbi dbi)
             uint64_t short_channel_id = *(uint64_t *)key.mv_data;
             printf("[\"%016" PRIx64 "\",", short_channel_id);
             if (data.mv_size == 0) {
-                printf(M_QQ("type") ": \"perm\"]");
+                printf(M_QQ("perm") "]");
             } else if ((data.mv_size == 1) && (*(uint8_t *)data.mv_data == 0x01)) {
-                printf(M_QQ("type") ": \"temp\"]");
+                printf(M_QQ("temp") "]");
             } else {
-                printf(M_QQ("type") ": \"unknown\"]");
+                printf(M_QQ("unknown") "]");
             }
             cnt++;
         }

--- a/showdb/showdb.c
+++ b/showdb/showdb.c
@@ -501,7 +501,14 @@ static void dumpit_annoskip(MDB_txn *txn, MDB_dbi dbi)
                 printf(",\n");
             }
             uint64_t short_channel_id = *(uint64_t *)key.mv_data;
-            printf("\"%016" PRIx64 "\"", short_channel_id);
+            printf("[\"%016" PRIx64 "\",", short_channel_id);
+            if (data.mv_size == 0) {
+                printf(M_QQ("type") ": \"perm\"]");
+            } else if ((data.mv_size == 1) && (*(uint8_t *)data.mv_data == 0x01)) {
+                printf(M_QQ("type") ": \"temp\"]");
+            } else {
+                printf(M_QQ("type") ": \"unknown\"]");
+            }
             cnt++;
         }
         mdb_cursor_close(cursor);

--- a/ucoin/include/ln.h
+++ b/ucoin/include/ln.h
@@ -754,6 +754,15 @@ typedef struct {
     uint32_t            outgoing_cltv_value;            ///< update_add_htlcのcltv-expiry
 } ln_hop_dataout_t;
 
+
+/** @struct     ln_onion_err_t
+ *  @brief      ONIONエラーreason解析
+ */
+typedef struct {
+    uint16_t            reason;
+    void                *p_data;
+} ln_onion_err_t;
+
 /// @}
 
 
@@ -2006,11 +2015,21 @@ void ln_onion_failure_forward(ucoin_buf_t *pNextPacket,
  * @param[out]      pHop                エラー元までのノード数(0は相手ノード)
  * @param[in]       pSharedSecrets      ONIONパケット生成自の全shared secret(#ln_onion_create_packet())
  * @param[in]       pPacket             受信したONION failureパケット
+ * @retval  true    成功
  */
 bool ln_onion_failure_read(ucoin_buf_t *pReason,
             int *pHop,
             const ucoin_buf_t *pSharedSecrets,
             const ucoin_buf_t *pPacket);
+
+
+/** ONION failure reason解析
+ * 
+ * @param[out]      pOnionErr
+ * @param[in]       pReason
+ * @retval  true    成功
+ */
+bool ln_onion_read_err(ln_onion_err_t *pOnionErr, const ucoin_buf_t *pReason);
 
 
 /********************************************************************

--- a/ucoin/include/ln_db.h
+++ b/ucoin/include/ln_db.h
@@ -272,9 +272,10 @@ bool ln_db_annocnl_cur_get(void *pCur, uint64_t *pShortChannelId, char *pType, u
 /** "route_skip" short_channel_id登録
  *
  * @param[in]   ShortChannelId      登録するshort_channel_id
+ * @param[in]   bTemp               true:一時的なskip
  * @retval  true    成功
  */
-bool ln_db_annoskip_save(uint64_t ShortChannelId);
+bool ln_db_annoskip_save(uint64_t ShortChannelId, bool bTemp);
 
 
 /** "route_skip" short_channel_id検索
@@ -288,8 +289,9 @@ bool ln_db_annoskip_search(void *pDb, uint64_t ShortChannelId);
 
 /** "route_skip" DB削除
  *
+ * @param[in]   bTemp               true:一時的なskipのみ削除 / false:全削除
  */
-bool ln_db_annoskip_drop(void);
+bool ln_db_annoskip_drop(bool bTemp);
 
 
 /** "routepay" invoice保存

--- a/ucoin/src/ln/ln.c
+++ b/ucoin/src/ln/ln.c
@@ -3969,9 +3969,9 @@ static bool create_to_remote_spent(ln_self_t *self,
                     memcpy(&pClose->p_tx[LN_CLOSE_IDX_TOREMOTE], &tx, sizeof(tx));
                     ucoin_tx_init(&tx);     //txはfreeさせない
                 } else {
-                    DBG_PRINTF("fail: to_remote output\n");
+                    DBG_PRINTF("no to_remote output\n");
                     ucoin_tx_free(&tx);
-                    break;
+                    ret = true;     //継続する
                 }
             }
         } else {

--- a/ucoin/src/ln/ln_db_lmdb.c
+++ b/ucoin/src/ln/ln_db_lmdb.c
@@ -1553,7 +1553,7 @@ bool ln_db_annoskip_drop(bool bTemp)
                     }
             }
         }
-
+        retval = 0;
     } else {
         retval = mdb_drop(txn, dbi, 1);
         if (retval != 0) {

--- a/ucoin/src/ln/ln_db_lmdb.c
+++ b/ucoin/src/ln/ln_db_lmdb.c
@@ -80,6 +80,8 @@
 #define M_KEY_SHAREDSECRET      "shared_secret"
 #define M_SZ_SHAREDSECRET       (sizeof(M_KEY_SHAREDSECRET) - 1)
 
+#define M_SKIP_TEMP             ((uint8_t)1)
+
 #define M_DB_VERSION_VAL        ((int32_t)-17)      ///< DBバージョン
 /*
     -1 : first
@@ -1453,7 +1455,7 @@ int ln_lmdb_annocnl_cur_load(MDB_cursor *cur, uint64_t *pShortChannelId, char *p
  ********************************************************************/
 
 
-bool ln_db_annoskip_save(uint64_t ShortChannelId)
+bool ln_db_annoskip_save(uint64_t ShortChannelId, bool bTemp)
 {
     int         retval;
     MDB_txn     *txn;
@@ -1475,7 +1477,13 @@ bool ln_db_annoskip_save(uint64_t ShortChannelId)
     //keyだけを使う
     key.mv_size = sizeof(ShortChannelId);
     key.mv_data = &ShortChannelId;
-    data.mv_size = 0;
+    uint8_t data_temp = M_SKIP_TEMP;
+    if (bTemp) {
+        data.mv_size = sizeof(data_temp);
+        data.mv_data = &data_temp;
+    } else {
+        data.mv_size = 0;
+    }
     retval = mdb_put(txn, dbi, &key, &data, 0);
     if (retval != 0) {
         DBG_PRINTF("ERR: %s\n", mdb_strerror(retval));
@@ -1505,7 +1513,7 @@ bool ln_db_annoskip_search(void *pDb, uint64_t ShortChannelId)
 }
 
 
-bool ln_db_annoskip_drop(void)
+bool ln_db_annoskip_drop(bool bTemp)
 {
     int         retval;
     MDB_txn     *txn;
@@ -1524,9 +1532,29 @@ bool ln_db_annoskip_drop(void)
         goto LABEL_EXIT;
     }
 
-    retval = mdb_drop(txn, dbi, 1);
-    if (retval != 0) {
-        DBG_PRINTF("ERR: %s\n", mdb_strerror(retval));
+    if (bTemp) {
+        MDB_cursor  *cursor;
+        MDB_val     key, data;
+
+        retval = mdb_cursor_open(txn, dbi, &cursor);
+        if (retval != 0) {
+            DBG_PRINTF("ERR: %s\n", mdb_strerror(retval));
+        }
+        while ((retval = mdb_cursor_get(cursor, &key, &data, MDB_NEXT)) == 0) {
+            if ( (data.mv_size == sizeof(uint8_t)) &&
+                 (*(uint8_t *)data.mv_data == M_SKIP_TEMP) ) {
+                    int ret = mdb_cursor_del(cursor, 0);
+                    if (ret != 0) {
+                        DBG_PRINTF("ERR: %s\n", mdb_strerror(ret));
+                    }
+            }
+        }
+
+    } else {
+        retval = mdb_drop(txn, dbi, 1);
+        if (retval != 0) {
+            DBG_PRINTF("ERR: %s\n", mdb_strerror(retval));
+        }
     }
 
     MDB_TXN_COMMIT(txn);

--- a/ucoin/src/ln/ln_db_lmdb.c
+++ b/ucoin/src/ln/ln_db_lmdb.c
@@ -1485,7 +1485,9 @@ bool ln_db_annoskip_save(uint64_t ShortChannelId, bool bTemp)
         data.mv_size = 0;
     }
     retval = mdb_put(txn, dbi, &key, &data, 0);
-    if (retval != 0) {
+    if (retval == 0) {
+        DBG_PRINTF("add skip[%d]: %016" PRIx64 "\n", bTemp, ShortChannelId);
+    } else {
         DBG_PRINTF("ERR: %s\n", mdb_strerror(retval));
     }
 
@@ -1544,7 +1546,9 @@ bool ln_db_annoskip_drop(bool bTemp)
             if ( (data.mv_size == sizeof(uint8_t)) &&
                  (*(uint8_t *)data.mv_data == M_SKIP_TEMP) ) {
                     int ret = mdb_cursor_del(cursor, 0);
-                    if (ret != 0) {
+                    if (ret == 0) {
+                        DBG_PRINTF("del skip: %016" PRIx64 "\n", *(uint64_t *)key.mv_data);
+                    } else {
                         DBG_PRINTF("ERR: %s\n", mdb_strerror(ret));
                     }
             }
@@ -1560,6 +1564,7 @@ bool ln_db_annoskip_drop(bool bTemp)
     MDB_TXN_COMMIT(txn);
 
 LABEL_EXIT:
+    DBG_PRINTF("");
     return retval == 0;
 }
 

--- a/ucoin/src/ln/ln_db_lmdb.c
+++ b/ucoin/src/ln/ln_db_lmdb.c
@@ -1564,7 +1564,7 @@ bool ln_db_annoskip_drop(bool bTemp)
     MDB_TXN_COMMIT(txn);
 
 LABEL_EXIT:
-    DBG_PRINTF("");
+    DBG_PRINTF("skip drop=%d\n", retval);
     return retval == 0;
 }
 

--- a/ucoin/src/ln/ln_msg_anno.c
+++ b/ucoin/src/ln/ln_msg_anno.c
@@ -42,8 +42,8 @@
  * macros
  ********************************************************************/
 
-#define DBG_PRINT_CREATE
-#define DBG_PRINT_READ
+//#define DBG_PRINT_CREATE
+//#define DBG_PRINT_READ
 
 
 /********************************************************************
@@ -657,10 +657,10 @@ bool HIDDEN ln_msg_node_announce_read(ln_node_announce_t *pMsg, const uint8_t *p
         DUMPBIN(pData + pos, Len - pos);
     }
 
-//#ifdef DBG_PRINT_READ
-//   DBG_PRINTF("\n@@@@@ %s @@@@@\n", __func__);
-//   node_announce_print(pMsg);
-//#endif  //DBG_PRINT_READ
+#ifdef DBG_PRINT_READ
+  DBG_PRINTF("\n@@@@@ %s @@@@@\n", __func__);
+  node_announce_print(pMsg);
+#endif  //DBG_PRINT_READ
 
     bool ret = true;
     if (pMsg->p_node_id != NULL) {

--- a/ucoin/src/ln/ln_msg_anno.c
+++ b/ucoin/src/ln/ln_msg_anno.c
@@ -78,8 +78,11 @@ static const uint8_t M_ADDRLEN2[] = { 0, 6, 18, 12, 37 };    //port考慮
  **************************************************************************/
 
 static bool cnl_announce_ptr(cnl_announce_ptr_t *pPtr, const uint8_t *pData, uint16_t Len);
+
+#if defined(DBG_PRINT_CREATE) || defined(DBG_PRINT_READ)
 static void node_announce_print(const ln_node_announce_t *pMsg);
 static void announce_signs_print(const ln_announce_signs_t *pMsg);
+#endif
 
 
 /********************************************************************
@@ -649,12 +652,6 @@ bool HIDDEN ln_msg_node_announce_read(ln_node_announce_t *pMsg, const uint8_t *p
     //assert(Len == pos);
     if (Len != pos) {
         DBG_PRINTF("length not match: Len=%d, pos=%d\n", Len, pos);
-        DBG_PRINTF("addrlen=%" PRIu16 "\n", addrlen);
-        node_announce_print(pMsg);
-        DBG_PRINTF("raw=");
-        DUMPBIN(pData + sizeof(uint16_t), Len - sizeof(uint16_t));
-        DBG_PRINTF("over=");
-        DUMPBIN(pData + pos, Len - pos);
     }
 
 #ifdef DBG_PRINT_READ
@@ -684,7 +681,7 @@ bool HIDDEN ln_msg_node_announce_read(ln_node_announce_t *pMsg, const uint8_t *p
 }
 
 
-#if 1
+#if defined(DBG_PRINT_CREATE) || defined(DBG_PRINT_READ)
 static void node_announce_print(const ln_node_announce_t *pMsg)
 {
 #ifdef UCOIN_DEBUG
@@ -1020,6 +1017,7 @@ bool HIDDEN ln_msg_announce_signs_read(ln_announce_signs_t *pMsg, const uint8_t 
 }
 
 
+#if defined(DBG_PRINT_CREATE) || defined(DBG_PRINT_READ)
 static void announce_signs_print(const ln_announce_signs_t *pMsg)
 {
 #ifdef UCOIN_DEBUG
@@ -1034,4 +1032,4 @@ static void announce_signs_print(const ln_announce_signs_t *pMsg)
     DBG_PRINTF2("--------------------------------\n\n\n");
 #endif  //UCOIN_DEBUG
 }
-
+#endif

--- a/ucoin/src/ln/ln_onion.c
+++ b/ucoin/src/ln/ln_onion.c
@@ -509,6 +509,13 @@ bool ln_onion_failure_read(ucoin_buf_t *pReason,
 }
 
 
+bool ln_onion_read_err(ln_onion_err_t *pOnionErr, const ucoin_buf_t *pReason)
+{
+    pOnionErr->reason = ((uint16_t)pReason->buf[0] << 8) | pReason->buf[1];
+    pOnionErr->p_data = NULL;   //TODO:reasonに応じた結果をmallocして代入
+}
+
+
 /**************************************************************************
  * private functions
  **************************************************************************/

--- a/ucoin/src/ln/ln_onion.c
+++ b/ucoin/src/ln/ln_onion.c
@@ -513,6 +513,7 @@ bool ln_onion_read_err(ln_onion_err_t *pOnionErr, const ucoin_buf_t *pReason)
 {
     pOnionErr->reason = ((uint16_t)pReason->buf[0] << 8) | pReason->buf[1];
     pOnionErr->p_data = NULL;   //TODO:reasonに応じた結果をmallocして代入
+    return true;
 }
 
 

--- a/ucoind/cmd_json.c
+++ b/ucoind/cmd_json.c
@@ -756,6 +756,9 @@ LABEL_EXIT:
     if (ctx->error_code != 0) {
         ln_db_annoskip_invoice_del(payconf.payment_hash);
     }
+    //一時的なスキップは削除する
+    ln_db_annoskip_drop(true);
+
     return result;
 }
 

--- a/ucoind/cmd_json.c
+++ b/ucoind/cmd_json.c
@@ -758,7 +758,7 @@ LABEL_EXIT:
     }
     //一時的なスキップは削除する
     ln_db_annoskip_drop(true);
-    DBG_PRINTF("result=%d\n", result);
+    DBG_PRINTF("\n");
 
     return result;
 }

--- a/ucoind/cmd_json.c
+++ b/ucoind/cmd_json.c
@@ -758,6 +758,7 @@ LABEL_EXIT:
     }
     //一時的なスキップは削除する
     ln_db_annoskip_drop(true);
+    DBG_PRINTF("result=%d\n", result);
 
     return result;
 }

--- a/ucoind/lnapp.c
+++ b/ucoind/lnapp.c
@@ -2607,7 +2607,7 @@ static void cb_htlc_changed(lnapp_conf_t *p_conf, void *p_param)
                     if (ret) {
                         DBG_PRINTF("invoice:%s\n", p_invoice);
                         char *json = (char *)APP_MALLOC(8192);      //APP_FREE: この中
-                        strcpy(json, "{\"method\":\"routepay\",\"params\":");
+                        strcpy(json, "{\"method\":\"routepay_cont\",\"params\":");
                         strcat(json, p_invoice);
                         strcat(json, "}");
                         int retval = misc_sendjson(json, "127.0.0.1", cmd_json_get_port());
@@ -3396,7 +3396,7 @@ static void pay_retry(const uint8_t *pPayHash)
     if (ret) {
         DBG_PRINTF("invoice:%s\n", p_invoice);
         char *json = (char *)APP_MALLOC(8192);      //APP_FREE: この中
-        strcpy(json, "{\"method\":\"routepay\",\"params\":");
+        strcpy(json, "{\"method\":\"routepay_cont\",\"params\":");
         strcat(json, p_invoice);
         strcat(json, "}");
         int retval = misc_sendjson(json, "127.0.0.1", cmd_json_get_port());

--- a/ucoind/lnapp.c
+++ b/ucoind/lnapp.c
@@ -343,7 +343,6 @@ bool lnapp_payment(lnapp_conf_t *pAppConf, payment_conf_t *pPay)
     DBGTRACE_BEGIN
 
     bool ret = false;
-    bool retry = false;
     ucoin_buf_t buf_bolt;
     uint8_t session_key[UCOIN_SZ_PRIVKEY];
     ln_self_t *p_self = pAppConf->p_self;
@@ -355,7 +354,6 @@ bool lnapp_payment(lnapp_conf_t *pAppConf, payment_conf_t *pPay)
         fprintf(PRINTOUT, "    hop  : %" PRIx64 "\n", pPay->hop_datain[0].short_channel_id);
         fprintf(PRINTOUT, "    mine : %" PRIx64 "\n", ln_short_channel_id(p_self));
         ln_db_annoskip_save(pPay->hop_datain[0].short_channel_id);
-        retry = true;
         goto LABEL_EXIT;
     }
 
@@ -441,9 +439,7 @@ LABEL_EXIT:
         call_script(M_EVT_PAYMENT, param);
     } else {
         DBG_PRINTF("fail\n");
-        if (retry) {
-            pay_retry(pPay->payment_hash);
-        }
+        pay_retry(pPay->payment_hash);
         mMuxTiming = 0;
     }
 
@@ -3389,6 +3385,8 @@ static void pay_retry(const uint8_t *pPayHash)
         DBG_PRINTF("retval=%d\n", retval);
         APP_FREE(json);     //APP_MALLOC: この中
         free(p_invoice);
+    } else {
+        DBG_PRINTF("fail: invoice not found\n");
     }
 
 }

--- a/ucoind/lnapp.c
+++ b/ucoind/lnapp.c
@@ -442,6 +442,7 @@ LABEL_EXIT:
         ln_db_annoskip_save(ln_short_channel_id(pAppConf->p_self), true);   //一時的
         pay_retry(pPay->payment_hash);
         mMuxTiming = 0;
+        ret = true;         //再送はtrue
     }
 
     DBG_PRINTF("mux_proc: end\n");

--- a/ucoind/lnapp.c
+++ b/ucoind/lnapp.c
@@ -267,7 +267,7 @@ static void wait_mutex_unlock(uint8_t Flag);
 static void push_queue(lnapp_conf_t *p_conf, queue_fulfill_t *pFulfill);
 static queue_fulfill_t *pop_queue(lnapp_conf_t *p_conf);
 static void call_script(event_t event, const char *param);
-static void set_onionerr_str(char *pStr, const ucoin_buf_t *pBuf);
+static void set_onionerr_str(char *pStr, const ln_onion_err_t *pOnionErr);
 static void set_lasterror(lnapp_conf_t *p_conf, int Err, const char *pErrStr);
 static void show_self_param(const ln_self_t *self, FILE *fp, int line);
 
@@ -353,7 +353,7 @@ bool lnapp_payment(lnapp_conf_t *pAppConf, payment_conf_t *pPay)
         fprintf(PRINTOUT, "fail: short_channel_id mismatch\n");
         fprintf(PRINTOUT, "    hop  : %" PRIx64 "\n", pPay->hop_datain[0].short_channel_id);
         fprintf(PRINTOUT, "    mine : %" PRIx64 "\n", ln_short_channel_id(p_self));
-        ln_db_annoskip_save(pPay->hop_datain[0].short_channel_id);
+        ln_db_annoskip_save(pPay->hop_datain[0].short_channel_id, false);   //恒久的
         goto LABEL_EXIT;
     }
 
@@ -439,6 +439,7 @@ LABEL_EXIT:
         call_script(M_EVT_PAYMENT, param);
     } else {
         DBG_PRINTF("fail\n");
+        ln_db_annoskip_save(ln_short_channel_id(pAppConf->p_self), true);   //一時的
         pay_retry(pPay->payment_hash);
         mMuxTiming = 0;
     }
@@ -2431,6 +2432,22 @@ static void cb_fail_htlc_recv(lnapp_conf_t *p_conf, void *p_param)
 
             print_routelist(p_conf);
 
+            ln_onion_err_t onionerr;
+            ret = ln_onion_read_err(&onionerr, &reason);  //onionerr.p_dataはmallocされる
+            bool btemp = false;
+            if (ret) {
+                switch (onionerr.reason) {
+                case LNONION_TMP_NODE_FAIL:
+                case LNONION_TMP_CHAN_FAIL:
+                case LNONION_AMT_BELOW_MIN:
+                    DBG_PRINTF("add skip route: temporary\n");
+                    btemp = true;
+                    break;
+                default:
+                    break;
+                }
+            }
+
             //失敗したと思われるshort_channel_idを登録
             //      route.hop_datain[0]は自分、[1]が相手
             //      hopの0は相手
@@ -2449,7 +2466,7 @@ static void cb_fail_htlc_recv(lnapp_conf_t *p_conf, void *p_param)
 
                     uint64_t short_channel_id = p_payconf->hop_datain[hop + 1].short_channel_id;
                     sprintf(suggest, "%016" PRIx64, short_channel_id);
-                    ln_db_annoskip_save(short_channel_id);
+                    ln_db_annoskip_save(short_channel_id, btemp);
                     retry = true;
                 } else {
                     strcpy(suggest, "invalid");
@@ -2461,9 +2478,11 @@ static void cb_fail_htlc_recv(lnapp_conf_t *p_conf, void *p_param)
 
             char errstr[512];
             char reasonstr[128];
-            set_onionerr_str(reasonstr, &reason);
+            set_onionerr_str(reasonstr, &onionerr);
             sprintf(errstr, "fail reason:%s (hop=%d)(suggest:%s)", reasonstr, hop, suggest);
             set_lasterror(p_conf, RPCERR_PAYFAIL, errstr);
+
+            free(onionerr.p_data);
         } else {
             //デコード失敗
             set_lasterror(p_conf, RPCERR_PAYFAIL, "fail result cannot decode");
@@ -3099,7 +3118,7 @@ static void call_script(event_t event, const char *param)
  *
  *
  */
-static void set_onionerr_str(char *pStr, const ucoin_buf_t *pBuf)
+static void set_onionerr_str(char *pStr, const ln_onion_err_t *pOnionErr)
 {
     const struct {
         uint16_t err;
@@ -3128,10 +3147,9 @@ static void set_onionerr_str(char *pStr, const ucoin_buf_t *pBuf)
         { LNONION_CHAN_DISABLE, "channel_disabled" },
     };
 
-    uint16_t err_reason = ((uint16_t)pBuf->buf[0] << 8) | pBuf->buf[1];
     const char *p_str = NULL;
     for (size_t lp = 0; lp < ARRAY_SIZE(ONIONERR); lp++) {
-        if (err_reason == ONIONERR[lp].err) {
+        if (pOnionErr->reason == ONIONERR[lp].err) {
             p_str = ONIONERR[lp].str;
             break;
         }
@@ -3139,7 +3157,7 @@ static void set_onionerr_str(char *pStr, const ucoin_buf_t *pBuf)
     if (p_str != NULL) {
         strcpy(pStr, p_str);
     } else {
-        sprintf(pStr, "unknown reason[%04x]", err_reason);
+        sprintf(pStr, "unknown reason[%04x]", pOnionErr->reason);
     }
 }
 


### PR DESCRIPTION
fix #337

一時的に使用できない経路は、一時的skip用DBで別管理するようにした。

https://github.com/nayutaco/ptarmigan/blob/fix_337/ucoind/lnapp.c#L2440
* LNONION_TMP_NODE_FAIL
* LNONION_TMP_CHAN_FAIL
* LNONION_AMT_BELOW_MIN