### PR TITLE
Fix 340

### DIFF
--- a/ucoin/include/ln.h
+++ b/ucoin/include/ln.h
@@ -54,6 +54,9 @@ extern "C" {
 #define LN_SZ_NOISE_HEADER              (sizeof(uint16_t) + 16)     ///< サイズ:noiseパケットヘッダ
 #define LN_SZ_GFLEN_MAX                 (4)         ///< init.gflen最大
 #define LN_SZ_LFLEN_MAX                 (4)         ///< init.lflen最大
+#define LN_SZ_FUNDINGTX_VSIZE           (177 + 10)  ///< funding_txのvsizeはほぼ固定(open_channel時のamountチェック用)
+                                                    //      それに＋αして余裕をもうける
+
 
 #define LN_FUNDIDX_MAX                  (6)         ///< 管理用
 #define LN_SCRIPTIDX_MAX                (5)         ///< 管理用

--- a/ucoin/include/ln.h
+++ b/ucoin/include/ln.h
@@ -1608,6 +1608,18 @@ static inline void ln_set_feerate(ln_self_t *self, uint32_t feerate) {
 }
 
 
+/** funding_txの予想されるfee(+α)取得
+ * 
+ * @param[in]   feerate_per_kw      feerate_per_kw(open_channelのパラメータと同じ)
+ * @retval  estimate fee[satoshis]
+ * @note
+ *      - 現在(2018/04/03)のptarmiganが生成するfunding_txは177byteで、それに+αしている
+ */
+static inline uint64_t ln_estimate_fundingtx_fee(uint32_t feerate_per_kw) {
+    return LN_SZ_FUNDINGTX_VSIZE * ln_calc_feerate_per_byte(feerate_per_kw);
+}
+
+
 /** 初期closing_tx FEE取得
  *
  * @param[in,out]       self            channel情報

--- a/ucoin/include/ln.h
+++ b/ucoin/include/ln.h
@@ -54,7 +54,6 @@ extern "C" {
 #define LN_SZ_NOISE_HEADER              (sizeof(uint16_t) + 16)     ///< サイズ:noiseパケットヘッダ
 #define LN_SZ_GFLEN_MAX                 (4)         ///< init.gflen最大
 #define LN_SZ_LFLEN_MAX                 (4)         ///< init.lflen最大
-#warning issue #344: nested in BIP16 size
 #define LN_SZ_FUNDINGTX_VSIZE           (177)       ///< funding_txのvsize(nested in BIP16 P2SH形式)
 
 

--- a/ucoin/include/ln.h
+++ b/ucoin/include/ln.h
@@ -54,8 +54,8 @@ extern "C" {
 #define LN_SZ_NOISE_HEADER              (sizeof(uint16_t) + 16)     ///< サイズ:noiseパケットヘッダ
 #define LN_SZ_GFLEN_MAX                 (4)         ///< init.gflen最大
 #define LN_SZ_LFLEN_MAX                 (4)         ///< init.lflen最大
-#define LN_SZ_FUNDINGTX_VSIZE           (177 + 10)  ///< funding_txのvsizeはほぼ固定(open_channel時のamountチェック用)
-                                                    //      それに＋αして余裕をもうける
+#warning issue #344: nested in BIP16 size
+#define LN_SZ_FUNDINGTX_VSIZE           (177)       ///< funding_txのvsize(nested in BIP16 P2SH形式)
 
 
 #define LN_FUNDIDX_MAX                  (6)         ///< 管理用

--- a/ucoin/include/ln.h
+++ b/ucoin/include/ln.h
@@ -1578,13 +1578,14 @@ static inline uint32_t ln_calc_feerate_per_kw(uint64_t feerate_kb) {
 }
 
 
-/** feerate_per_kw --> byteあたりのfee
+/** feerate_per_kw --> fee
  *
+ * @param[in]           vsize
  * @param[in]           feerate_per_kw
  * @retval          feerate_per_byte
  */
-static inline uint32_t ln_calc_feerate_per_byte(uint64_t feerate_kw) {
-    return (uint32_t)(feerate_kw * 4 / 1000);
+static inline uint64_t ln_calc_fee(uint32_t vsize, uint64_t feerate_kw) {
+    return vsize * feerate_kw * 4 / 1000;
 }
 
 
@@ -1616,7 +1617,7 @@ static inline void ln_set_feerate(ln_self_t *self, uint32_t feerate) {
  *      - 現在(2018/04/03)のptarmiganが生成するfunding_txは177byteで、それに+αしている
  */
 static inline uint64_t ln_estimate_fundingtx_fee(uint32_t feerate_per_kw) {
-    return LN_SZ_FUNDINGTX_VSIZE * ln_calc_feerate_per_byte(feerate_per_kw);
+    return ln_calc_fee(LN_SZ_FUNDINGTX_VSIZE, feerate_per_kw);
 }
 
 

--- a/ucoin/include/ucoin.h
+++ b/ucoin/include/ucoin.h
@@ -917,6 +917,16 @@ bool ucoin_tx_txid(uint8_t *pTxId, const ucoin_tx_t *pTx);
 bool ucoin_tx_txid_raw(uint8_t *pTxId, const ucoin_buf_t *pTxRaw);
 
 
+/** vsize取得
+ * 
+ * @param[in]   pData
+ * @param[in]   Len
+ * @retval  != 0    vbyte
+ * @retval  == 0    エラー
+ */
+uint32_t ucoin_tx_get_vbyte_raw(const uint8_t *pData, uint32_t Len);
+
+
 //////////////////////
 //SW
 //////////////////////

--- a/ucoin/src/ln/ln.c
+++ b/ucoin/src/ln/ln.c
@@ -1420,7 +1420,7 @@ bool ln_create_tolocal_spent(const ln_self_t *self, ucoin_tx_t *pTx, uint64_t Va
     bool ret;
 
     //to_localのFEE
-    uint64_t fee_tolocal = M_SZ_TO_LOCAL_TX(self->shutdown_scriptpk_local.len) * ln_calc_feerate_per_byte(self->feerate_per_kw);
+    uint64_t fee_tolocal = ln_calc_fee(M_SZ_TO_LOCAL_TX(self->shutdown_scriptpk_local.len), self->feerate_per_kw);
     DBG_PRINTF("fee_tolocal=%" PRIu64 "\n", fee_tolocal);
     if (Value < UCOIN_DUST_LIMIT + fee_tolocal) {
         DBG_PRINTF("fail: vout below dust(value=%" PRIu64 ", fee=%" PRIu64 ")\n", Value, fee_tolocal);
@@ -1445,7 +1445,7 @@ bool ln_create_toremote_spent(const ln_self_t *self, ucoin_tx_t *pTx, uint64_t V
     ucoin_util_keys_t signkey;
 
     //to_remoteのFEE
-    uint64_t fee_toremote = M_SZ_TO_REMOTE_TX(self->shutdown_scriptpk_local.len) * ln_calc_feerate_per_byte(self->feerate_per_kw);
+    uint64_t fee_toremote = ln_calc_fee(M_SZ_TO_REMOTE_TX(self->shutdown_scriptpk_local.len), self->feerate_per_kw);
     if (Value < UCOIN_DUST_LIMIT + fee_toremote) {
         DBG_PRINTF("fail: vout below dust(value=%" PRIu64 ", fee=%" PRIu64 ")\n", Value, fee_toremote);
         ret = false;
@@ -3215,7 +3215,7 @@ static bool create_funding_tx(ln_self_t *self)
     ucoin_tx_create(&txbuf, &self->tx_funding);
 
     uint32_t vbyte = ucoin_tx_get_vbyte_raw(txbuf.buf, txbuf.len);
-    uint64_t fee = vbyte * ln_calc_feerate_per_byte(self->p_establish->cnl_open.feerate_per_kw);
+    uint64_t fee = ln_calc_fee(vbyte, self->p_establish->cnl_open.feerate_per_kw);
     if (self->p_establish->p_fundin->amount >= self->p_establish->cnl_open.funding_sat + fee) {
         self->tx_funding.vout[1].value = self->p_establish->p_fundin->amount - self->p_establish->cnl_open.funding_sat - fee;
     } else {

--- a/ucoin/src/ln/ln.c
+++ b/ucoin/src/ln/ln.c
@@ -3214,7 +3214,27 @@ static bool create_funding_tx(ln_self_t *self)
     ucoin_buf_init(&txbuf);
     ucoin_tx_create(&txbuf, &self->tx_funding);
 
-    uint32_t vbyte = ucoin_tx_get_vbyte_raw(txbuf.buf, txbuf.len);
+    DBG_PRINTF("\n***** funding_tx(no signature) *****\n");
+    M_DBG_PRINT_TX(&self->tx_funding);
+
+    // LEN+署名(72) + LEN+公開鍵(33)
+    //      version:4
+    //      flag:1
+    //      mark:1
+    //      vin_cnt: 1
+    //          txid+index: 36
+    //          scriptSig: 1+23
+    //          sequence: 4
+    //      vout_cnt: 2
+    //          amount: 8
+    //          scriptPubKey: 1+34
+    //          amount: 8
+    //          scriptPubKey: 1+23
+    //      wit_cnt: 2
+    //          sig: 1+72
+    //          pub: 1+33
+    //      locktime: 4
+    uint32_t vbyte = ucoin_tx_get_vbyte_raw(txbuf.buf, txbuf.len) + (1 + 72) + (1 + 33);    //witnessの部分がないため、手動で足している
     uint64_t fee = ln_calc_fee(vbyte, self->p_establish->cnl_open.feerate_per_kw);
     if (self->p_establish->p_fundin->amount >= self->p_establish->cnl_open.funding_sat + fee) {
         self->tx_funding.vout[1].value = self->p_establish->p_fundin->amount - self->p_establish->cnl_open.funding_sat - fee;

--- a/ucoin/src/ln/ln.c
+++ b/ucoin/src/ln/ln.c
@@ -3210,14 +3210,12 @@ static bool create_funding_tx(ln_self_t *self)
 
 
     //FEE計算
-    //      txサイズに署名の中間サイズと公開鍵サイズを加えたサイズにする
-    //          http://bitcoin.stackexchange.com/questions/1195/how-to-calculate-transaction-size-before-sending
     ucoin_buf_t txbuf;
     ucoin_buf_init(&txbuf);
     ucoin_tx_create(&txbuf, &self->tx_funding);
 
-    // LEN+署名(72) + LEN+公開鍵(33)
-    uint64_t fee = (txbuf.len + 1 + 72 + 1 + 33) * 4 * ln_calc_feerate_per_byte(self->p_establish->cnl_open.feerate_per_kw);
+    uint32_t vbyte = ucoin_tx_get_vbyte_raw(txbuf.buf, txbuf.len);
+    uint64_t fee = vbyte * ln_calc_feerate_per_byte(self->p_establish->cnl_open.feerate_per_kw);
     if (self->p_establish->p_fundin->amount >= self->p_establish->cnl_open.funding_sat + fee) {
         self->tx_funding.vout[1].value = self->p_establish->p_fundin->amount - self->p_establish->cnl_open.funding_sat - fee;
     } else {

--- a/ucoin/src/ucoin_tx.c
+++ b/ucoin/src/ucoin_tx.c
@@ -1150,6 +1150,7 @@ uint32_t ucoin_tx_get_vbyte_raw(const uint8_t *pData, uint32_t Len)
         len = Len;
     }
 
+    DBG_PRINTF("vbyte=%" PRIu32 "\n", len);
     return len;
 }
 

--- a/ucoin/src/ucoin_tx.c
+++ b/ucoin/src/ucoin_tx.c
@@ -1138,9 +1138,14 @@ uint32_t ucoin_tx_get_vbyte_raw(const uint8_t *pData, uint32_t Len)
 
         ucoin_buf_init(&txbuf_old);
         bool ret = ucoin_util_create_tx(&txbuf_old, &txold, false);
-        uint32_t fmt_old = txbuf_old.len;
-        uint32_t fmt_new = Len;
-        len = (fmt_old * 3 + fmt_new + 3) / 4;
+        if (ret) {
+            uint32_t fmt_old = txbuf_old.len;
+            uint32_t fmt_new = Len;
+            len = (fmt_old * 3 + fmt_new + 3) / 4;
+        } else {
+            DBG_PRINTF("fail: vbyte\n");
+            len = 0;
+        }
     } else {
         len = Len;
     }

--- a/ucoin/src/ucoin_tx.c
+++ b/ucoin/src/ucoin_tx.c
@@ -1098,6 +1098,57 @@ bool ucoin_tx_txid_raw(uint8_t *pTxId, const ucoin_buf_t *pTxRaw)
 }
 
 
+// uint32_t ucoin_tx_get_vbyte(const ucoin_tx_t *pTx)
+// {
+//     //segwit判定
+//     bool segwit = false;
+//     for (uint32_t lp = 0; lp < pTx->vin_cnt; lp++) {
+//         ucoin_vin_t *vin = &(pTx->vin[lp]);
+//         if (vin->wit_cnt) {
+//             segwit = true;
+//         }
+//     }
+//     return 0;
+// }
+
+
+uint32_t ucoin_tx_get_vbyte_raw(const uint8_t *pData, uint32_t Len)
+{
+    //segwit判定
+    bool segwit;
+    uint8_t mark = pData[4];
+    uint8_t flag = pData[5];
+    if ((mark == 0x00) && (flag != 0x01)) {
+        //2017/01/04:BIP-144ではflag==0x01のみ
+        return 0;
+    }
+    segwit = ((mark == 0x00) && (flag == 0x01));
+
+    //https://bitcoincore.org/ja/segwit_wallet_dev/#transaction-fee-estimation
+    uint32_t len;
+    if (segwit) {
+        //(旧format*3 + 新format) / 4を切り上げ
+        //  旧: nVersion            |txins|txouts        |nLockTim
+        //  新: nVersion|marker|flag|txins|txouts|witness|nLockTime
+        ucoin_tx_t txold;
+        ucoin_buf_t txbuf_old;
+
+        ucoin_tx_init(&txold);
+        ucoin_tx_read(&txold, pData, Len);
+
+        ucoin_buf_init(&txbuf_old);
+        bool ret = ucoin_util_create_tx(&txbuf_old, &txold, false);
+        uint32_t fmt_old = txbuf_old.len;
+        uint32_t fmt_new = Len;
+        len = (fmt_old * 3 + fmt_new + 3) / 4;
+    } else {
+        len = Len;
+    }
+
+    return len;
+}
+
+
 #ifdef UCOIN_USE_PRINTFUNC
 void ucoin_print_tx(const ucoin_tx_t *pTx)
 {

--- a/ucoind/lnapp.c
+++ b/ucoind/lnapp.c
@@ -318,9 +318,9 @@ bool lnapp_funding(lnapp_conf_t *pAppConf, const funding_conf_t *pFunding)
     }
 
     DBG_PRINTF("Establish開始\n");
-    send_open_channel(pAppConf, pFunding);
+    bool ret = send_open_channel(pAppConf, pFunding);
 
-    return true;
+    return ret;
 }
 
 
@@ -1336,6 +1336,14 @@ static bool send_open_channel(lnapp_conf_t *p_conf, const funding_conf_t *pFundi
         }
         DBG_PRINTF2("feerate_per_kw=%" PRIu32 "\n", feerate_kw);
 
+        uint64_t estfee = LN_SZ_FUNDINGTX_VSIZE * ln_calc_feerate_per_byte(feerate_kw);
+        if (fundin_sat < pFunding->funding_sat + estfee) {
+            //amountが足りないと思われる
+            DBG_PRINTF("fail: amount too short\n");
+            DBG_PRINTF("  %" PRIu64 " < %" PRIu64 " + %" PRIu64 "\n", fundin_sat, pFunding->funding_sat, estfee);
+            return false;
+        }
+
         ln_fundin_t fundin;
         memcpy(fundin.txid, pFunding->txid, UCOIN_SZ_TXID);
         fundin.index = pFunding->txindex;
@@ -1350,10 +1358,10 @@ static bool send_open_channel(lnapp_conf_t *p_conf, const funding_conf_t *pFundi
                         pFunding->funding_sat,
                         pFunding->push_sat,
                         feerate_kw);
-        assert(ret);
-
-        DBG_PRINTF("SEND: open_channel\n");
-        send_peer_noise(p_conf, &buf_bolt);
+        if (ret) {
+            DBG_PRINTF("SEND: open_channel\n");
+            send_peer_noise(p_conf, &buf_bolt);
+        }
         ucoin_buf_free(&buf_bolt);
     } else {
         SYSLOG_WARN("fail through: btcprc_getxout");

--- a/ucoind/lnapp.c
+++ b/ucoind/lnapp.c
@@ -103,7 +103,7 @@
 
 #define M_ERRSTR_REASON                 "fail: %s (hop=%d)(suggest:%s)"
 #define M_ERRSTR_CANNOTDECODE           "fail: result cannot decode"
-#define M_ERRSTR_CANNOTSTART            "fail: can't start payment(our_msat=% " PRIu64 ", amt_to_forward=%" PRIu64 ")"
+#define M_ERRSTR_CANNOTSTART            "fail: can't start payment(our_msat=%" PRIu64 ", amt_to_forward=%" PRIu64 ")"
 
 //lnapp_conf_t.flag_ope
 #define OPE_COMSIG_SEND         (0x01)      ///< commitment_signed受信済み
@@ -1336,7 +1336,7 @@ static bool send_open_channel(lnapp_conf_t *p_conf, const funding_conf_t *pFundi
         }
         DBG_PRINTF2("feerate_per_kw=%" PRIu32 "\n", feerate_kw);
 
-        uint64_t estfee = LN_SZ_FUNDINGTX_VSIZE * ln_calc_feerate_per_byte(feerate_kw);
+        uint64_t estfee = ln_estimate_fundingtx_fee(feerate_kw);
         if (fundin_sat < pFunding->funding_sat + estfee) {
             //amountが足りないと思われる
             DBG_PRINTF("fail: amount too short\n");
@@ -2128,7 +2128,7 @@ static void cb_funding_tx_wait(lnapp_conf_t *p_conf, void *p_param)
             DBG_PRINTF("OK\n");
         } else {
             DBG_PRINTF("NG\n");
-            exit(-1);
+            stop_threads(p_conf);
         }
         ucoin_buf_free(&buf_tx);
     }

--- a/ucoind/lnapp.c
+++ b/ucoind/lnapp.c
@@ -1337,6 +1337,7 @@ static bool send_open_channel(lnapp_conf_t *p_conf, const funding_conf_t *pFundi
         DBG_PRINTF2("feerate_per_kw=%" PRIu32 "\n", feerate_kw);
 
         uint64_t estfee = ln_estimate_fundingtx_fee(feerate_kw);
+        DBG_PRINTF("estimate funding_tx fee: %" PRIu64 "\n", estfee);
         if (fundin_sat < pFunding->funding_sat + estfee) {
             //amountが足りないと思われる
             DBG_PRINTF("fail: amount too short\n");


### PR DESCRIPTION
fix #340 

funding_txのvsizeは177固定で計算しているが、将来対応する必要あり(#344 )。
`ucoin_tx_get_vbyte_raw()`は使っていない。