### PR TITLE
Fix 388

### DIFF
--- a/include/ucoind.h
+++ b/include/ucoind.h
@@ -106,6 +106,8 @@ static inline int tid() {
 #define RPCERR_NOROUTE              (-26001)
 #define RPCERR_NOROUTE_STR          "fail routing"
 #define RPCERR_PAYFAIL              (-26002)
+#define RPCERR_PAY_RETRY            (-26003)
+#define RPCERR_PAY_RETRY_STR        "retry payment"
 
 
 #define PREIMAGE_NUM        (10)        ///< 保持できるpreimage数

--- a/routing/routing_main.c
+++ b/routing/routing_main.c
@@ -242,9 +242,8 @@ int main(int argc, char* argv[])
 
     if ((options & OPT_CLEARSDB) == 0) {
         ln_routing_result_t result;
-        ret = ln_routing_calculate(&result, send_nodeid, recv_nodeid, cltv_expiry,
-                        amtmsat);
-        if (ret == 0) {
+        bret = ln_routing_calculate(&result, send_nodeid, recv_nodeid, cltv_expiry, amtmsat);
+        if (bret) {
             //pay.conf形式の出力
             if (payment_hash == NULL) {
                 //CSV形式
@@ -274,9 +273,11 @@ int main(int argc, char* argv[])
                 }
                 printf("]]}\n");
             }
+            ret = 0;
         } else {
             //error
-            fprintf(fp_err, "fail: %d\n", ret);
+            fprintf(fp_err, "fail\n");
+            ret = -1;
         }
 
         free(dbdir);

--- a/ucoin/include/ln.h
+++ b/ucoin/include/ln.h
@@ -2111,9 +2111,9 @@ bool ln_onion_read_err(ln_onion_err_t *pOnionErr, const ucoin_buf_t *pReason);
  * @param[in]   pPayeeId
  * @param[in]   CltvExpiry
  * @param[in]   AmountMsat
- * @retval  0   成功
+ * @retval  true   成功
  */
-int ln_routing_calculate(
+bool ln_routing_calculate(
         ln_routing_result_t *pResult,
         const uint8_t *pPayerId,
         const uint8_t *pPayeeId,

--- a/ucoin/src/routing/ln_routing.cpp
+++ b/ucoin/src/routing/ln_routing.cpp
@@ -305,7 +305,7 @@ static graph_t::vertex_descriptor ver_add(graph_t& g, const uint8_t *pNodeId)
 }
 
 
-int ln_routing_calculate(
+bool ln_routing_calculate(
         ln_routing_result_t *pResult,
         const uint8_t *pPayerId,
         const uint8_t *pPayeeId,
@@ -320,13 +320,13 @@ int ln_routing_calculate(
 
     if ((pPayerId == NULL) || (pPayeeId == NULL)) {
         DBG_PRINTF("fail: null input\n");
-        return -1;
+        return false;
     }
 
     bool ret = loaddb(&rt_res, pPayerId);
     if (!ret) {
         DBG_PRINTF("fail: loaddb\n");
-        return -1;
+        return false;
     }
 
     DBG_PRINTF("start nodeid : ");
@@ -403,11 +403,11 @@ int ln_routing_calculate(
     //DBG_PRINTF("pnt_start=%d, pnt_goal=%d\n", (int)pnt_start, (int)pnt_goal);
     if (!set_start) {
         DBG_PRINTF("fail: no start node\n");
-        return -2;
+        return false;
     }
     if (!set_goal) {
         DBG_PRINTF("fail: no goal node\n");
-        return -3;
+        return false;
     }
 
     std::vector<vertex_descriptor> p(num_vertices(g));      //parent
@@ -420,7 +420,7 @@ int ln_routing_calculate(
     if (p[pnt_goal] == pnt_goal) {
         DBG_PRINTF("fail: cannot find route\n");
         free(rt_res.p_nodes);
-        return -4;
+        return false;
     }
 
     //逆順に入っているので、並べ直す
@@ -455,7 +455,7 @@ int ln_routing_calculate(
         //先頭に自ノードが入るため+1
         DBG_PRINTF("fail: too many hops\n");
         free(rt_res.p_nodes);
-        return -5;
+        return false;
     }
 
     //戻り値の作成
@@ -505,7 +505,7 @@ int ln_routing_calculate(
 
     free(rt_res.p_nodes);
 
-    return 0;
+    return true;
 }
 
 

--- a/ucoind/cmd_json.c
+++ b/ucoind/cmd_json.c
@@ -813,6 +813,7 @@ static cJSON *cmd_routepay(jrpc_context *ctx, cJSON *params, cJSON *id)
     uint64_t amount_msat = 0;
     uint32_t min_final_cltv_expiry = LN_MIN_FINAL_CLTV_EXPIRY;
     uint8_t payhash[LN_SZ_HASH];
+    bool ret = false;
     bool retry = false;
 
     if (params == NULL) {
@@ -868,25 +869,32 @@ static cJSON *cmd_routepay(jrpc_context *ctx, cJSON *params, cJSON *id)
 
     SYSLOG_INFO("routepay");
 
-    bool bret;
     uint8_t node_payee[UCOIN_SZ_PUBKEY];
 
-    bret = misc_str2bin(node_payee, sizeof(node_payee), str_payee);
-    if (!bret) {
+    ret = misc_str2bin(node_payee, sizeof(node_payee), str_payee);
+    if (!ret) {
         DBG_PRINTF("invalid arg: payee node id\n");
         ctx->error_code = RPCERR_ERROR;
         ctx->error_message = strdup(RPCERR_ERROR_STR);
         goto LABEL_EXIT;
     }
     ln_routing_result_t rt_ret;
-    int ret = ln_routing_calculate(&rt_ret, ln_node_getid(), node_payee,
+    ret = ln_routing_calculate(&rt_ret, ln_node_getid(), node_payee,
                    min_final_cltv_expiry, amount_msat);
-    if (ret != 0) {
+    if (!ret) {
         DBG_PRINTF("fail: routing\n");
         ctx->error_code = RPCERR_ERROR;
         ctx->error_message = strdup(RPCERR_ERROR_STR);
         goto LABEL_EXIT;
     }
+
+    // 送金開始
+    //      これ以降は失敗してもリトライする
+    ret = false;
+
+    //再送のためにinvoice保存
+    char *p_invoice = cJSON_PrintUnformatted(params);
+    (void)ln_db_annoskip_invoice_save(p_invoice, payhash);
 
     DBG_PRINTF("-----------------------------------\n");
     for (int lp = 0; lp < rt_ret.hop_num; lp++) {
@@ -902,59 +910,48 @@ static cJSON *cmd_routepay(jrpc_context *ctx, cJSON *params, cJSON *id)
     if (p_appconf != NULL) {
         bool inited = lnapp_is_inited(p_appconf);
         if (inited) {
-            bool ret;
             payment_conf_t payconf;
 
             memcpy(payconf.payment_hash, payhash, LN_SZ_HASH);
             payconf.hop_num = rt_ret.hop_num;
             memcpy(payconf.hop_datain, rt_ret.hop_datain, sizeof(ln_hop_datain_t) * (1 + LN_HOP_MAX));
 
-            //再送のためにinvoice保存
-            char *p_invoice = cJSON_PrintUnformatted(params);
-            (void)ln_db_annoskip_invoice_save(p_invoice, payhash);
-            free(p_invoice);
-
             ret = lnapp_payment(p_appconf, &payconf);
             if (ret) {
-                if (mPayTryCount == 0) {
-                    result = cJSON_CreateString("Progressing");
-                    misc_save_event(NULL, "payment: payment_hash=%s payee=%s amount_msat=%" PRIu64, str_payhash, str_payee, amount_msat);
-                    DBG_PRINTF("start payment\n");
-                }
-                mPayTryCount++;
+                DBG_PRINTF("start payment\n");
             } else {
-                ctx->error_code = RPCERR_PAY_RETRY;
-                ctx->error_message = strdup(RPCERR_PAY_RETRY_STR);
                 DBG_PRINTF("fail: lnapp_payment\n");
             }
         } else {
             //BOLTメッセージとして初期化が完了していない(init/channel_reestablish交換できていない)
-            ctx->error_code = RPCERR_NOINIT;
-            ctx->error_message = strdup(RPCERR_NOINIT_STR);
             DBG_PRINTF("fail: not inited\n");
         }
     } else {
-        ctx->error_code = RPCERR_PAY_RETRY;
-        ctx->error_message = strdup(RPCERR_PAY_RETRY_STR);
         DBG_PRINTF("fail: not connect\n");
     }
 
-    if (ctx->error_code != 0) {
+    mPayTryCount++;
+    result = cJSON_CreateString("start payment");
+    if (mPayTryCount == 1) {
+        misc_save_event(NULL, "payment: payment_hash=%s payee=%s amount_msat=%" PRIu64, str_payhash, str_payee, amount_msat);
+    }
+    if (!ret) {
+        //送金リトライ
         ln_db_annoskip_save(rt_ret.hop_datain[0].short_channel_id, true);
 
-        char *p_invoice = cJSON_PrintUnformatted(params);
         cmd_json_pay_retry(payhash, p_invoice);
-        free(p_invoice);
         DBG_PRINTF("retry: %" PRIx64 "\n", rt_ret.hop_datain[0].short_channel_id);
         retry = true;
     }
+    free(p_invoice);
 
 LABEL_EXIT:
     if (index < 0) {
         ctx->error_code = RPCERR_PARSE;
         ctx->error_message = strdup(RPCERR_PARSE_STR);
     }
-    if ((ctx->error_code != 0) && !retry) {
+    if (!retry) {
+        //送金失敗
         ln_db_annoskip_invoice_del(payhash);
         ln_db_annoskip_drop(true);
 

--- a/ucoind/cmd_json.c
+++ b/ucoind/cmd_json.c
@@ -871,7 +871,6 @@ static cJSON *cmd_routepay(jrpc_context *ctx, cJSON *params, cJSON *id)
 
     lnapp_conf_t *p_appconf = search_connected_lnapp_node(rt_ret.hop_datain[1].pubkey);
     if (p_appconf != NULL) {
-
         bool inited = lnapp_is_inited(p_appconf);
         if (inited) {
             bool ret;
@@ -905,8 +904,10 @@ static cJSON *cmd_routepay(jrpc_context *ctx, cJSON *params, cJSON *id)
     } else {
         ln_db_annoskip_save(rt_ret.hop_datain[0].short_channel_id, true);
 
-        int retval = misc_sendjson(params->string, "127.0.0.1", cmd_json_get_port());
-        DBG_PRINTF("retval=%d(%s)\n", retval, params->string);
+        char *p_invoice = cJSON_PrintUnformatted(params);
+        int retval = misc_sendjson(p_invoice, "127.0.0.1", cmd_json_get_port());
+        DBG_PRINTF("retval=%d(%s)\n", retval, p_invoice);
+        free(p_invoice);
     }
 
 LABEL_EXIT:

--- a/ucoind/cmd_json.c
+++ b/ucoind/cmd_json.c
@@ -934,7 +934,8 @@ static cJSON *cmd_routepay(jrpc_context *ctx, cJSON *params, cJSON *id)
     result = cJSON_CreateString("start payment");
     if (mPayTryCount == 1) {
         //初回ログ
-        misc_save_event(NULL, "payment: payment_hash=%s payee=%s our_msat=%" PRIu64" amount_msat=%" PRIu64, str_payhash, str_payee, ln_our_msat(p_appconf->p_self), amount_msat);
+        uint64_t total_amount = ln_node_total_msat();
+        misc_save_event(NULL, "payment: payment_hash=%s payee=%s total_msat=%" PRIu64" amount_msat=%" PRIu64, str_payhash, str_payee, total_amount, amount_msat);
     }
     if (!ret) {
         //送金リトライ

--- a/ucoind/cmd_json.c
+++ b/ucoind/cmd_json.c
@@ -922,8 +922,8 @@ static cJSON *cmd_routepay(jrpc_context *ctx, cJSON *params, cJSON *id)
                 }
                 mPayTryCount++;
             } else {
-                ctx->error_code = RPCERR_PAY_STOP;
-                ctx->error_message = strdup(RPCERR_PAY_STOP_STR);
+                ctx->error_code = RPCERR_PAY_RETRY;
+                ctx->error_message = strdup(RPCERR_PAY_RETRY_STR);
                 DBG_PRINTF("fail: lnapp_payment\n");
             }
         } else {
@@ -933,12 +933,18 @@ static cJSON *cmd_routepay(jrpc_context *ctx, cJSON *params, cJSON *id)
             DBG_PRINTF("fail: not inited\n");
         }
     } else {
+        ctx->error_code = RPCERR_PAY_RETRY;
+        ctx->error_message = strdup(RPCERR_PAY_RETRY_STR);
+        DBG_PRINTF("fail: not connect\n");
+    }
+
+    if (ctx->error_code != 0) {
         ln_db_annoskip_save(rt_ret.hop_datain[0].short_channel_id, true);
 
         char *p_invoice = cJSON_PrintUnformatted(params);
         cmd_json_pay_retry(payhash, p_invoice);
         free(p_invoice);
-        DBG_PRINTF("retry: not connected: %" PRIx64 "\n", rt_ret.hop_datain[0].short_channel_id);
+        DBG_PRINTF("retry: %" PRIx64 "\n", rt_ret.hop_datain[0].short_channel_id);
     }
 
 LABEL_EXIT:

--- a/ucoind/cmd_json.c
+++ b/ucoind/cmd_json.c
@@ -933,7 +933,8 @@ static cJSON *cmd_routepay(jrpc_context *ctx, cJSON *params, cJSON *id)
     mPayTryCount++;
     result = cJSON_CreateString("start payment");
     if (mPayTryCount == 1) {
-        misc_save_event(NULL, "payment: payment_hash=%s payee=%s amount_msat=%" PRIu64, str_payhash, str_payee, amount_msat);
+        //初回ログ
+        misc_save_event(NULL, "payment: payment_hash=%s payee=%s our_msat=%" PRIu64" amount_msat=%" PRIu64, str_payhash, str_payee, ln_our_msat(p_appconf->p_self), amount_msat);
     }
     if (!ret) {
         //送金リトライ
@@ -950,7 +951,7 @@ LABEL_EXIT:
         ctx->error_code = RPCERR_PARSE;
         ctx->error_message = strdup(RPCERR_PARSE_STR);
     }
-    if (!retry) {
+    if (!ret && !retry) {
         //送金失敗
         ln_db_annoskip_invoice_del(payhash);
         ln_db_annoskip_drop(true);
@@ -960,7 +961,7 @@ LABEL_EXIT:
         misc_datetime(date, sizeof(date));
         sprintf(mLastPayErr, "[%s]payment fail", date);
         DBG_PRINTF("%s\n", mLastPayErr);
-        misc_save_event(NULL, "payment fail: payment_hash=%s, try=%d", str_payhash, mPayTryCount);
+        misc_save_event(NULL, "payment fail: payment_hash=%s try=%d", str_payhash, mPayTryCount);
     }
 
     return result;

--- a/ucoind/cmd_json.c
+++ b/ucoind/cmd_json.c
@@ -124,6 +124,26 @@ uint16_t cmd_json_get_port(void)
 }
 
 
+void cmd_json_pay_retry(const uint8_t *pPayHash)
+{
+    char *p_invoice;
+    bool ret = ln_db_annoskip_invoice_load(&p_invoice, pPayHash);     //p_invoiceはmalloc()される
+    if (ret) {
+        DBG_PRINTF("invoice:%s\n", p_invoice);
+        char *json = (char *)APP_MALLOC(8192);      //APP_FREE: この中
+        strcpy(json, "{\"method\":\"routepay_cont\",\"params\":");
+        strcat(json, p_invoice);
+        strcat(json, "}");
+        int retval = misc_sendjson(json, "127.0.0.1", cmd_json_get_port());
+        DBG_PRINTF("retval=%d\n", retval);
+        APP_FREE(json);     //APP_MALLOC: この中
+        free(p_invoice);
+    } else {
+        DBG_PRINTF("fail: invoice not found\n");
+    }
+}
+
+
 /********************************************************************
  * private functions
  ********************************************************************/
@@ -890,7 +910,7 @@ static cJSON *cmd_routepay(jrpc_context *ctx, cJSON *params, cJSON *id)
                 if (mPayTryCount == 0) {
                     result = cJSON_CreateString("Progressing");
                     misc_save_event(NULL, "payment: payment_hash=%s payee=%s amount_msat=%" PRIu64, str_payhash, str_payee, amount_msat);
-                   DBG_PRINTF("start payment\n");
+                    DBG_PRINTF("start payment\n");
                 }
                 mPayTryCount++;
             } else {
@@ -906,12 +926,8 @@ static cJSON *cmd_routepay(jrpc_context *ctx, cJSON *params, cJSON *id)
         }
     } else {
         ln_db_annoskip_save(rt_ret.hop_datain[0].short_channel_id, true);
-
-        char *p_invoice = cJSON_PrintUnformatted(params);
-        int retval = misc_sendjson(p_invoice, "127.0.0.1", cmd_json_get_port());
-        DBG_PRINTF("retval=%d(%s)\n", retval, p_invoice);
-        free(p_invoice);
-        DBG_PRINTF("fail: not connected: %" PRIx64 "\n", rt_ret.hop_datain[0].short_channel_id);
+        cmd_json_pay_retry(payhash);
+        DBG_PRINTF("retry: not connected: %" PRIx64 "\n", rt_ret.hop_datain[0].short_channel_id);
     }
 
 LABEL_EXIT:

--- a/ucoind/cmd_json.c
+++ b/ucoind/cmd_json.c
@@ -890,16 +890,19 @@ static cJSON *cmd_routepay(jrpc_context *ctx, cJSON *params, cJSON *id)
                 if (mPayTryCount == 0) {
                     result = cJSON_CreateString("Progressing");
                     misc_save_event(NULL, "payment: payment_hash=%s payee=%s amount_msat=%" PRIu64, str_payhash, str_payee, amount_msat);
+                   DBG_PRINTF("start payment\n");
                 }
                 mPayTryCount++;
             } else {
                 ctx->error_code = RPCERR_PAY_STOP;
                 ctx->error_message = strdup(RPCERR_PAY_STOP_STR);
+                DBG_PRINTF("fail: lnapp_payment\n");
             }
         } else {
             //BOLTメッセージとして初期化が完了していない(init/channel_reestablish交換できていない)
             ctx->error_code = RPCERR_NOINIT;
             ctx->error_message = strdup(RPCERR_NOINIT_STR);
+            DBG_PRINTF("fail: not inited\n");
         }
     } else {
         ln_db_annoskip_save(rt_ret.hop_datain[0].short_channel_id, true);
@@ -908,6 +911,7 @@ static cJSON *cmd_routepay(jrpc_context *ctx, cJSON *params, cJSON *id)
         int retval = misc_sendjson(p_invoice, "127.0.0.1", cmd_json_get_port());
         DBG_PRINTF("retval=%d(%s)\n", retval, p_invoice);
         free(p_invoice);
+        DBG_PRINTF("fail: not connected: %" PRIx64 "\n", rt_ret.hop_datain[0].short_channel_id);
     }
 
 LABEL_EXIT:

--- a/ucoind/cmd_json.c
+++ b/ucoind/cmd_json.c
@@ -903,8 +903,10 @@ static cJSON *cmd_routepay(jrpc_context *ctx, cJSON *params, cJSON *id)
             ctx->error_message = strdup(RPCERR_NOINIT_STR);
         }
     } else {
-        ctx->error_code = RPCERR_NOCONN;
-        ctx->error_message = strdup(RPCERR_NOCONN_STR);
+        ln_db_annoskip_save(rt_ret.hop_datain[0].short_channel_id, true);
+
+        int retval = misc_sendjson(params->string, "127.0.0.1", cmd_json_get_port());
+        DBG_PRINTF("retval=%d(%s)\n", retval, params->string);
     }
 
 LABEL_EXIT:

--- a/ucoind/inc/cmd_json.h
+++ b/ucoind/inc/cmd_json.h
@@ -40,6 +40,6 @@ void cmd_json_start(uint16_t Port);
 uint16_t cmd_json_get_port(void);
 
 
-void cmd_json_pay_retry(const uint8_t *pPayHash);
+void cmd_json_pay_retry(const uint8_t *pPayHash, const char *pInvoice);
 
 #endif  //CMD_JSON_H__

--- a/ucoind/inc/cmd_json.h
+++ b/ucoind/inc/cmd_json.h
@@ -39,4 +39,7 @@ void cmd_json_start(uint16_t Port);
  */
 uint16_t cmd_json_get_port(void);
 
+
+void cmd_json_pay_retry(const uint8_t *pPayHash);
+
 #endif  //CMD_JSON_H__

--- a/ucoind/lnapp.c
+++ b/ucoind/lnapp.c
@@ -459,7 +459,7 @@ LABEL_EXIT:
 
         //ルートが見つからなくなるまでリトライする
         ln_db_annoskip_save(ln_short_channel_id(pAppConf->p_self), true);   //一時的
-        cmd_json_pay_retry(pPay->payment_hash);
+        cmd_json_pay_retry(pPay->payment_hash, NULL);
         ret = true;         //再送はtrue
         nodeflag_unset(~FLAGNODE_NONE);
     }
@@ -3177,7 +3177,7 @@ static void revack_pop_and_exec(lnapp_conf_t *p_conf)
         }
         break;
     case TRANSCMD_PAYRETRY:
-        cmd_json_pay_retry(p_revack->buf.buf);
+        cmd_json_pay_retry(p_revack->buf.buf, NULL);
         break;
     default:
         break;

--- a/ucoind/lnapp.c
+++ b/ucoind/lnapp.c
@@ -2655,7 +2655,7 @@ static void stop_threads(lnapp_conf_t *p_conf)
         p_conf->loop = false;
         //mainloop待ち合わせ解除(*2)
         pthread_cond_signal(&p_conf->cond);
-        DBG_PRINTF("disconnect channel: %" PRIx64, ln_short_channel_id(p_conf->p_self));
+        DBG_PRINTF("disconnect channel: %" PRIx64 "\n", ln_short_channel_id(p_conf->p_self));
         DBG_PRINTF("===================================\n");
         DBG_PRINTF("=  CHANNEL THREAD END             =\n");
         DBG_PRINTF("===================================\n");

--- a/ucoind/lnapp.c
+++ b/ucoind/lnapp.c
@@ -450,17 +450,17 @@ LABEL_EXIT:
                     hashstr);
         call_script(M_EVT_PAYMENT, param);
     } else {
-        DBG_PRINTF("fail --> retry\n");
-        char errstr[512];
-        sprintf(errstr, M_ERRSTR_CANNOTSTART,
-                    ln_our_msat(pAppConf->p_self),
-                    pPay->hop_datain[0].amt_to_forward);
-        set_lasterror(pAppConf, RPCERR_PAYFAIL, errstr);
+        // DBG_PRINTF("fail --> retry\n");
+        // char errstr[512];
+        // sprintf(errstr, M_ERRSTR_CANNOTSTART,
+        //             ln_our_msat(pAppConf->p_self),
+        //             pPay->hop_datain[0].amt_to_forward);
+        // set_lasterror(pAppConf, RPCERR_PAYFAIL, errstr);
 
-        //ルートが見つからなくなるまでリトライする
-        ln_db_annoskip_save(ln_short_channel_id(pAppConf->p_self), true);   //一時的
-        cmd_json_pay_retry(pPay->payment_hash, NULL);
-        ret = true;         //再送はtrue
+        // //ルートが見つからなくなるまでリトライする
+        // ln_db_annoskip_save(ln_short_channel_id(pAppConf->p_self), true);   //一時的
+        // cmd_json_pay_retry(pPay->payment_hash, NULL);
+        // ret = true;         //再送はtrue
         nodeflag_unset(~FLAGNODE_NONE);
     }
 

--- a/ucoind/p2p_cli.c
+++ b/ucoind/p2p_cli.c
@@ -140,6 +140,9 @@ void p2p_cli_start(const daemon_connect_t *pConn, jrpc_context *ctx)
             fclose(fp);
         }
 
+        //ノード接続失敗リストに追加
+        ucoind_nodefail_add(pConn->node_id, pConn->ipaddr, pConn->port, LN_NODEDESC_IPV4);
+
         goto LABEL_EXIT;
     }
     DBG_PRINTF("connected: sock=%d\n", mAppConf[idx].sock);


### PR DESCRIPTION
fix #388 

> ルート作成前に「一時的使用不可ルート」とする。

`"routepay"` で送金開始に失敗した場合に一時的使用不可とするようにした。

途中で #229 をマージしている