### PR TITLE
Error unicode

### DIFF
--- a/install/script/error.sh
+++ b/install/script/error.sh
@@ -6,6 +6,6 @@
 DATE=`date +"%Y-%m-%dT%H:%M:%S.%N"`
 echo "{ \"method\": \"error\", \"short_channel_id\": \"$1\", \"node_id\": \"$2\", \"date\": \"$DATE\", \"err_str\": \"$3\" }" | jq -c .
 
-echo "from $2($1):" >> err_$1.log
-echo "$3" >> err_$1.log
-echo "" >> err_$1.log
+# echo "from $2($1):" >> err_$1.log
+# echo "$3" >> err_$1.log
+# echo "" >> err_$1.log

--- a/routing/routing_main.c
+++ b/routing/routing_main.c
@@ -135,7 +135,7 @@ int main(int argc, char* argv[])
         case 'c':
             //clear skip DB
             options |= OPT_CLEARSDB;
-            return 0;
+            break;
         case 'h':
         default:
             //help

--- a/ucoin/include/ln.h
+++ b/ucoin/include/ln.h
@@ -546,8 +546,11 @@ typedef struct {
 
 /** @struct     ln_error_t
  *  @brief      error
+ *  @note
+ *      - p_dataはMALLOC()で確保するため、呼び出し元がMFREE()で解放すること
  */
 typedef struct {
+    uint8_t     channel_id[LN_SZ_CHANNEL_ID];       ///< 32: channel-id
     uint16_t    len;                                ///< 2: byteslen
     char        *p_data;                            ///< エラー文字列(\0あり)
 } ln_error_t;

--- a/ucoin/src/ln/ln_msg_setupctl.c
+++ b/ucoin/src/ln/ln_msg_setupctl.c
@@ -199,6 +199,8 @@ bool HIDDEN ln_msg_error_read(ln_error_t *pMsg, const uint8_t *pData, uint16_t L
         pMsg->p_data = (char *)M_MALLOC(len + 1);
         memcpy(pMsg->p_data, pData + pos, len);
         pMsg->p_data[len] = '\0';
+        DBG_PRINTF("data: ");
+        DUMPBIN((const uint8_t *)pMsg->p_data, len);
     }
 
     pos += len;

--- a/ucoin/src/ln/ln_msg_setupctl.c
+++ b/ucoin/src/ln/ln_msg_setupctl.c
@@ -187,6 +187,9 @@ bool HIDDEN ln_msg_error_read(ln_error_t *pMsg, const uint8_t *pData, uint16_t L
     int pos = sizeof(uint16_t);
 
     //        [32:channel-id]
+    memcpy(pMsg->channel_id, pData + pos, LN_SZ_CHANNEL_ID);
+    DBG_PRINTF("channld_id: ");
+    DUMPBIN(pMsg->channel_id, LN_SZ_CHANNEL_ID);
     pos += LN_SZ_CHANNEL_ID;
 
     //        [2:len]


### PR DESCRIPTION
fix #394 

`isprint()`がfalseの文字が入っている場合はダンプ出力する