### PR TITLE
BOLT11 rfield

### DIFF
--- a/routing/routing_main.c
+++ b/routing/routing_main.c
@@ -242,7 +242,8 @@ int main(int argc, char* argv[])
 
     if ((options & OPT_CLEARSDB) == 0) {
         ln_routing_result_t result;
-        bret = ln_routing_calculate(&result, send_nodeid, recv_nodeid, cltv_expiry, amtmsat);
+        bret = ln_routing_calculate(&result, send_nodeid,
+                    recv_nodeid, cltv_expiry, amtmsat, 0, NULL);
         if (bret) {
             //pay.conf形式の出力
             if (payment_hash == NULL) {

--- a/ucoin/gtests/test_ucoin.cpp
+++ b/ucoin/gtests/test_ucoin.cpp
@@ -27,6 +27,7 @@ extern "C" {
 #include "ln_script.c"
 #include "ln_enc_auth.c"
 #include "ln_signer.c"
+#include "bech32/segwit_addr.c"
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -100,5 +101,5 @@ TEST_F(ucoin, ucoin_setnet_mainnet)
 #include "testinc_ln_bolt4.cpp"
 #include "testinc_ln_bolt8.cpp"
 #include "testinc_ln_misc.cpp"
-
 #include "testinc_recoverpub.cpp"
+#include "testinc_bech32.cpp"

--- a/ucoin/include/ln.h
+++ b/ucoin/include/ln.h
@@ -153,6 +153,7 @@ extern "C" {
 //forward definition
 struct ln_self_t;
 typedef struct ln_self_t ln_self_t;
+typedef struct ln_fieldr_t ln_fieldr_t;
 
 
 // node_announcement address descriptor
@@ -2149,6 +2150,8 @@ bool ln_onion_read_err(ln_onion_err_t *pOnionErr, const ucoin_buf_t *pReason);
  * @param[in]   pPayeeId
  * @param[in]   CltvExpiry
  * @param[in]   AmountMsat
+ * @param[in]   AddNum          追加route数(invoiceのr fieldを想定)
+ * @param[in]   pAddRoute       追加route(invoiceのr fieldを想定)
  * @retval  true   成功
  */
 bool ln_routing_calculate(
@@ -2156,7 +2159,9 @@ bool ln_routing_calculate(
         const uint8_t *pPayerId,
         const uint8_t *pPayeeId,
         uint32_t CltvExpiry,
-        uint64_t AmountMsat);
+        uint64_t AmountMsat,
+        uint8_t AddNum,
+        const ln_fieldr_t *pAddRoute);
 
 
 /** routing skip DB削除

--- a/ucoin/include/segwit_addr.h
+++ b/ucoin/include/segwit_addr.h
@@ -77,6 +77,21 @@ bool segwit_addr_decode(
 );
 
 
+/** @struct ln_fieldr_t;
+ *  @brief  r field
+ */
+typedef struct ln_fieldr_t {
+    uint8_t     node_id[UCOIN_SZ_PUBKEY];           ///< node_id
+    uint64_t    short_channel_id;                   ///< short_channel_id
+    uint32_t    fee_base_msat;                      ///< fee_base_msat
+    uint32_t    fee_prop_millionths;                ///< fee_proportional_millionths
+    uint16_t    cltv_expiry_delta;                  ///< cltv_expiry_delta
+} ln_fieldr_t;
+
+
+/** @struct ln_invoice_t;
+ *  @brief  BOLT#11 invoice
+ */
 typedef struct ln_invoice_t {
     uint8_t     hrp_type;
     uint64_t    amount_msat;
@@ -84,6 +99,8 @@ typedef struct ln_invoice_t {
     uint32_t    min_final_cltv_expiry;
     uint8_t     pubkey[UCOIN_SZ_PUBKEY];
     uint8_t     payment_hash[LN_SZ_HASH];
+    uint8_t     r_field_num;
+    ln_fieldr_t r_field[];
 } ln_invoice_t;
 
 
@@ -99,11 +116,11 @@ bool ln_invoice_encode(char** pp_invoice, const ln_invoice_t *p_invoice_data);
 
 /** Decode a BOLT11 invoice
  *
- * @param[out]      p_invoice_data
+ * @param[out]      pp_invoice_data
  * @param[in]       invoice
  * @return  true:success
  */
-bool ln_invoice_decode(ln_invoice_t *p_invoice_data, const char* invoice);
+bool ln_invoice_decode(ln_invoice_t **pp_invoice_data, const char* invoice);
 
 /** BOLT11 形式invoice作成
  *

--- a/ucoin/src/ln/ln_msg_anno.c
+++ b/ucoin/src/ln/ln_msg_anno.c
@@ -634,7 +634,7 @@ bool HIDDEN ln_msg_node_announce_read(ln_node_announce_t *pMsg, const uint8_t *p
     //        [addrlen:addresses]
     if (addrlen > 0) {
         //addr type
-        pMsg->addr.type = *(pData + pos);
+        pMsg->addr.type = (ln_nodedesc_t)*(pData + pos);
         if (pMsg->addr.type > LN_NODEDESC_MAX) {
             DBG_PRINTF("fail: unknown address descriptor(%02x)\n", pMsg->addr.type);
             return false;

--- a/ucoin/src/ln/ln_node.c
+++ b/ucoin/src/ln/ln_node.c
@@ -334,7 +334,7 @@ static bool comp_func_cnl(ln_self_t *self, void *p_db_param, void *p_param)
 
 
 /** #ln_node_total_msat()処理関数
- * 
+ *
  * our_msatの総額を求める。
  *
  * @param[in,out]   self            DBから取得したself
@@ -353,7 +353,7 @@ static bool comp_func_total_msat(ln_self_t *self, void *p_db_param, void *p_para
 
 
 /** #ln_node_search_nodeid()処理関数
- * 
+ *
  * short_channel_idが一致した場合のnode_id(相手側)を返す。
  *
  * @param[in,out]   self            DBから取得したself
@@ -436,7 +436,7 @@ static void print_node(void)
 
 
 #ifdef UNITTEST
-static void ln_node_setkey(const uint8_t *pPrivKey)
+void ln_node_setkey(const uint8_t *pPrivKey)
 {
     memcpy(mNode.keys.priv, pPrivKey, UCOIN_SZ_PRIVKEY);
     ucoin_keys_priv2pub(mNode.keys.pub, mNode.keys.priv);

--- a/ucoincli/ucoincli.c
+++ b/ucoincli/ucoincli.c
@@ -505,29 +505,39 @@ static void optfunc_payment(int *pOption, bool *pConn)
 }
 
 
+/* BOLT#11 invoiceによる支払い
+ * 
+ * 
+ * 
+ */
 static void optfunc_routepay(int *pOption, bool *pConn)
 {
     (void)pConn;
 
     M_CHK_INIT
 
-    ln_invoice_t invoice_data;
+    ln_invoice_t *p_invoice_data = NULL;
     const char *invoice = strtok(optarg, ",");
     const char *amount_msat = strtok(NULL, ",");
     const char *cltv_offset = strtok(NULL, ",");
-    bool bret = ln_invoice_decode(&invoice_data, invoice);
+    bool bret = ln_invoice_decode(&p_invoice_data, invoice);
     if (!bret) {
         printf("fail: decode BOLT#11 invoice\n");
         *pOption = M_OPTIONS_ERR;
         return;
     }
+    if ( (p_invoice_data->hrp_type != LN_INVOICE_TESTNET) &&
+         (p_invoice_data->hrp_type != LN_INVOICE_REGTEST) ) {
+        printf("fail: payment not supported type.\n");
+        *pOption = M_OPTIONS_ERR;
+        return;
+    }
 
+    //確認用のログ出力
     printf("---------------------------------\n");
-    switch (invoice_data.hrp_type) {
+    switch (p_invoice_data->hrp_type) {
     case LN_INVOICE_MAINNET:
         printf("blockchain: bitcoin mainnet\n");
-        printf("fail: mainnet payment not supported yet.\n");
-        *pOption = M_OPTIONS_ERR;
         break;
     case LN_INVOICE_TESTNET:
         printf("blockchain: bitcoin testnet\n");
@@ -537,46 +547,70 @@ static void optfunc_routepay(int *pOption, bool *pConn)
         break;
     default:
         printf("unknown hrp_type\n");
-        *pOption = M_OPTIONS_ERR;
     }
-    printf("amount_msat=%" PRIu64 "\n", invoice_data.amount_msat);
-    time_t tm = (time_t)invoice_data.timestamp;
-    printf("timestamp= %" PRIu64 " : %s", (uint64_t)invoice_data.timestamp, ctime(&tm));
-    printf("min_final_cltv_expiry=%u\n", invoice_data.min_final_cltv_expiry);
+    printf("amount_msat=%" PRIu64 "\n", p_invoice_data->amount_msat);
+    time_t tm = (time_t)p_invoice_data->timestamp;
+    printf("timestamp= %" PRIu64 " : %s", (uint64_t)p_invoice_data->timestamp, ctime(&tm));
+    printf("min_final_cltv_expiry=%u\n", p_invoice_data->min_final_cltv_expiry);
     printf("payee=");
     for (int lp = 0; lp < UCOIN_SZ_PUBKEY; lp++) {
-        printf("%02x", invoice_data.pubkey[lp]);
+        printf("%02x", p_invoice_data->pubkey[lp]);
     }
     printf("\n");
     printf("payment_hash=");
     for (int lp = 0; lp < UCOIN_SZ_SHA256; lp++) {
-        printf("%02x", invoice_data.payment_hash[lp]);
+        printf("%02x", p_invoice_data->payment_hash[lp]);
     }
     printf("\n");
+    if (p_invoice_data->r_field_num > 0) {
+        for (int lp = 0; lp < p_invoice_data->r_field_num; lp++) {
+            printf("    ------------------------\n");
+            printf("    ");
+            for (int lp2 = 0; lp2 < UCOIN_SZ_PUBKEY; lp2++) {
+                printf("%02x", p_invoice_data->r_field[lp].node_id[lp2]);
+            }
+            printf("\n");
+            printf("    short_channel_id=%" PRIx64 "\n", p_invoice_data->r_field[lp].short_channel_id);
+            printf("    fee_base_msat=%" PRIu32 "\n", p_invoice_data->r_field[lp].fee_base_msat);
+            printf("    fee_proportional_millionths=%" PRIu32 "\n", p_invoice_data->r_field[lp].fee_prop_millionths);
+            printf("    cltv_expiry_delta=%" PRIu16 "\n", p_invoice_data->r_field[lp].cltv_expiry_delta);
+        }
+        printf("    ------------------------\n");
+    }
     printf("---------------------------------\n");
+
+
     if (amount_msat != NULL) {
+        //additional amount_msat
+        //  invoiceで要求されたamountに追加で支払えるようにしている
         errno = 0;
         uint64_t add_msat = (uint64_t)strtoull(amount_msat, NULL, 10);
         if (errno == 0) {
-            invoice_data.amount_msat += add_msat;
+            p_invoice_data->amount_msat += add_msat;
             printf("additional amount_msat=%" PRIu64 "\n", add_msat);
             printf("---------------------------------\n");
         } else {
             printf("fail: errno=%s\n", strerror(errno));
             *pOption = M_OPTIONS_ERR;
         }
-        if (invoice_data.amount_msat & 0xffffffff00000000ULL) {
-            //BOLT#2
-            //  MUST set the four most significant bytes of amount_msat to 0.
-            printf("fail: amount_msat too large\n");
-            *pOption = M_OPTIONS_ERR;
-        }
+    }
+    if (p_invoice_data->amount_msat & 0xffffffff00000000ULL) {
+        //BOLT#2
+        //  MUST set the four most significant bytes of amount_msat to 0.
+        //  今のところBitcoinのみしか扱わないため、このままとしておく。
+        printf("fail: amount_msat too large\n");
+        *pOption = M_OPTIONS_ERR;
+    } else if (p_invoice_data->amount_msat == 0) {
+        printf("fail: pay amount_msat is 0\n");
+        *pOption = M_OPTIONS_ERR;
+    } else {
+        //チャネルが許容する範囲については、ucoindでチェックする
     }
     if (cltv_offset != NULL) {
         errno = 0;
         uint32_t add_cltv = (uint32_t)strtoull(cltv_offset, NULL, 10);
         if (errno == 0) {
-            invoice_data.min_final_cltv_expiry += add_cltv;
+            p_invoice_data->min_final_cltv_expiry += add_cltv;
             printf("additional min_final_cltv_expiry=%" PRIu32 "\n", add_cltv);
             printf("---------------------------------\n");
         } else {
@@ -585,27 +619,45 @@ static void optfunc_routepay(int *pOption, bool *pConn)
         }
     }
     if (*pOption != M_OPTIONS_ERR) {
-        if (invoice_data.amount_msat > 0) {
-            char payhash[LN_SZ_HASH * 2 + 1];
-            char payee[UCOIN_SZ_PUBKEY * 2 + 1];
+        char payhash[LN_SZ_HASH * 2 + 1];
+        char payee[UCOIN_SZ_PUBKEY * 2 + 1];
 
-            misc_bin2str(payhash, invoice_data.payment_hash, LN_SZ_HASH);
-            misc_bin2str(payee, invoice_data.pubkey, UCOIN_SZ_PUBKEY);
+        misc_bin2str(payhash, p_invoice_data->payment_hash, LN_SZ_HASH);
+        misc_bin2str(payee, p_invoice_data->pubkey, UCOIN_SZ_PUBKEY);
 
-            snprintf(mBuf, BUFFER_SIZE,
-                "{"
-                    M_STR("method", "routepay") M_NEXT
-                    M_QQ("params") ":[ "
-                        //payment_hash, amount_msat, payee, payer
-                        M_QQ("%s") ",%" PRIu64 "," M_QQ("%s") "," M_QQ("") ",%" PRIu32 "]}",
-                    payhash, invoice_data.amount_msat, payee, invoice_data.min_final_cltv_expiry);
+        snprintf(mBuf, BUFFER_SIZE,
+            "{"
+                M_STR("method", "routepay") M_NEXT
+                M_QQ("params") ":[ "
+                    //payment_hash, amount_msat, payee, payer
+                    M_QQ("%s") ",%" PRIu64 "," M_QQ("%s") "," M_QQ("") ",%" PRIu32 ",%d",
+                payhash, p_invoice_data->amount_msat, payee,
+                p_invoice_data->min_final_cltv_expiry, p_invoice_data->r_field_num);
+        if (p_invoice_data->r_field_num > 0) {
+            strcat(mBuf, ",[");
+            for (int lp = 0; lp < p_invoice_data->r_field_num; lp++) {
+                if (lp != 0) {
+                    strcat(mBuf, ",");
+                }
+                char nodeid[UCOIN_SZ_PUBKEY * 2 + 1];
+                misc_bin2str(nodeid, p_invoice_data->r_field[lp].node_id, UCOIN_SZ_PUBKEY);
 
-            *pOption = M_OPTIONS_EXEC;
-        } else {
-            printf("fail: pay amount_msat is 0\n");
-            *pOption = M_OPTIONS_ERR;
+                char rfstr[256];
+                sprintf(rfstr, "[" M_QQ("%s") ",%" PRIu64 ",%" PRIu32 ",%" PRIu32 ",%" PRIu16 "]",
+                        nodeid, //66
+                        p_invoice_data->r_field[lp].short_channel_id, //16
+                        p_invoice_data->r_field[lp].fee_base_msat, //10
+                        p_invoice_data->r_field[lp].fee_prop_millionths, //10
+                        p_invoice_data->r_field[lp].cltv_expiry_delta); //5
+                strcat(mBuf, rfstr);
+            }
+            strcat(mBuf, "]");
         }
+        strcat(mBuf, "]}");
+
+        *pOption = M_OPTIONS_EXEC;
     }
+    free(p_invoice_data);
 }
 
 

--- a/ucoind/monitoring.c
+++ b/ucoind/monitoring.c
@@ -284,8 +284,11 @@ LABEL_EXIT:
  * private functions
  ********************************************************************/
 
-/** 監視処理
+/** 監視処理(#ln_db_self_search()のコールバック)
  *
+ * @param[in,out]   self        チャネル情報
+ * @param[in,out]   p_db_param  DB情報
+ * @param[in,out]   p_param     パラメータ(未使用)
  */
 static bool monfunc(ln_self_t *self, void *p_db_param, void *p_param)
 {
@@ -333,6 +336,13 @@ static bool monfunc(ln_self_t *self, void *p_db_param, void *p_param)
 }
 
 
+/**
+ * 
+ * @param[in,out]   self        チャネル情報
+ * @param[in]       confm       confirmation数
+ * @param[in,out]   p_db_param  DB情報
+ * @retval      true    selfをDB削除可能
+ */
 static bool funding_spent(ln_self_t *self, uint32_t confm, void *p_db_param)
 {
     bool del = false;


### PR DESCRIPTION
fix #410 
support BOLT11 r field.

invoiceの"r" fieldは、private channelなどのannounceされていない`channel_update`情報を載せることができる。
routingとしてr fieldの情報を含めるようにした。

こちらのMLは、相手のchannel_updateをもらえないとr fieldに含めることができないので、`channel_announcement`がない状態で`channel_update`を送信することについてであって、本件とは別の内容となる。
https://lists.linuxfoundation.org/pipermail/lightning-dev/2018-April/001220.html