### PR TITLE
Work/fix 32bit

### DIFF
--- a/ucoin/src/ln/ln_db_lmdb.c
+++ b/ucoin/src/ln/ln_db_lmdb.c
@@ -49,10 +49,11 @@
  ********************************************************************/
 
 #define M_LMDB_MAXDBS           (2 * 10)        ///< 同時オープンできるDB数
-#define M_LMDB_MAPSIZE          ((uint64_t)10485760)         // DB最大長[byte](LMDBのデフォルト値)
+#define M_LMDB_MAPSIZE          ((size_t)10485760)          // DB最大長[byte](LMDBのデフォルト値)
 
 #define M_LMDB_NODE_MAXDBS      (2 * 10)        ///< 同時オープンできるDB数
-#define M_LMDB_NODE_MAPSIZE     ((uint64_t)4294967296)      // DB最大長[byte](mdb_txn_commit()でMDB_MAP_FULLになったため拡張)
+#define M_LMDB_NODE_MAPSIZE     ((size_t)4294967295)        // DB最大長[byte](mdb_txn_commit()でMDB_MAP_FULLになったため拡張)
+                                                            // 32bit環境ではsize_tが4byteになるため、4294967295が最大になる
 
 #define M_SELF_BUFS             (3)             ///< DB保存する可変長データ数
 

--- a/ucoin/src/ln/ln_db_lmdb.c
+++ b/ucoin/src/ln/ln_db_lmdb.c
@@ -52,7 +52,7 @@
 #define M_LMDB_MAPSIZE          ((size_t)10485760)          // DB最大長[byte](LMDBのデフォルト値)
 
 #define M_LMDB_NODE_MAXDBS      (2 * 10)        ///< 同時オープンできるDB数
-#define M_LMDB_NODE_MAPSIZE     ((size_t)4294967295)        // DB最大長[byte](mdb_txn_commit()でMDB_MAP_FULLになったため拡張)
+#define M_LMDB_NODE_MAPSIZE     ((size_t)134217728)         // DB最大長[byte](mdb_txn_commit()でMDB_MAP_FULLになったため拡張)
                                                             // 32bit環境ではsize_tが4byteになるため、4294967295が最大になる
 
 #define M_SELF_BUFS             (3)             ///< DB保存する可変長データ数

--- a/ucoin/src/ucoin_util.c
+++ b/ucoin/src/ucoin_util.c
@@ -864,7 +864,7 @@ bool HIDDEN ucoin_util_create_tx(ucoin_buf_t *pBuf, const ucoin_tx_t *pTx, bool 
     //locktime
     p += set_le32(p, pTx->locktime);
 
-    return (p - pBuf->buf == pBuf->len);
+    return ((uint32_t)(p - pBuf->buf) == pBuf->len);
 }
 
 


### PR DESCRIPTION
#420 

32bit OSでも動作するよう、暫定としてmapsizeを変更する。
この値は、lmdbが使用するRAM容量にも影響を与え、大きすぎると起動できなくなってしまう。

Raspberry Pi3でbitcoindを動かしている環境ではこの値で動作したが、最適かどうかや、そもそもlmdbでよいのかどうかは未検討。