### PR TITLE
#430 part 1

### DIFF
--- a/showdb/showdb.c
+++ b/showdb/showdb.c
@@ -444,7 +444,6 @@ static void dumpit_annoinfo(MDB_txn *txn, MDB_dbi dbi, ln_lmdb_dbtype_t dbtype)
 
     MDB_val key, data;
     while ((retval = mdb_cursor_get(cursor, &key, &data, MDB_NEXT_NODUP)) == 0) {
-        size_t len;
         if ((dbtype == LN_LMDB_DBTYPE_CHANNEL_ANNOINFO) && (key.mv_size == M_SZ_ANNOINFO_CNL)) {
             const uint8_t *keyname = (const uint8_t *)key.mv_data;
             switch (keyname[M_SZ_ANNOINFO_CNL - 1]) {
@@ -461,15 +460,16 @@ static void dumpit_annoinfo(MDB_txn *txn, MDB_dbi dbi, ln_lmdb_dbtype_t dbtype)
                 fprintf(stderr, "keyname=%02x: %d\n", keyname[M_SZ_ANNOINFO_CNL - 1], __LINE__);
                 exit(-1);
             }
-            len = M_SZ_ANNOINFO_CNL - 1;
+
+            uint64_t short_channel_id = *(uint64_t *)key.mv_data;
+            printf("%0" PRIx64 "\n", short_channel_id);
         } else if ((dbtype == LN_LMDB_DBTYPE_NODE_ANNOINFO) && (key.mv_size == M_SZ_ANNOINFO_NODE)) {
             printf("node_announcement: ");
-            len = M_SZ_ANNOINFO_NODE;
+            ucoin_util_dumpbin(stdout, key.mv_data, M_SZ_ANNOINFO_NODE, true);
         } else {
             //skip
             continue;
         }
-        ucoin_util_dumpbin(stdout, key.mv_data, len, true);
 
         int nums = data.mv_size / UCOIN_SZ_PUBKEY;
         const uint8_t *p_data = (const uint8_t *)data.mv_data;

--- a/ucoin/include/ln_db.h
+++ b/ucoin/include/ln_db.h
@@ -216,18 +216,20 @@ bool ln_db_annocnlupd_load(ucoin_buf_t *pCnlUpd, uint32_t *pTimeStamp, uint64_t 
 bool ln_db_annocnlupd_save(const ucoin_buf_t *pCnlUpd, const ln_cnl_update_t *pUpd, const uint8_t *pSendId);
 
 
-/** channel_announcement削除
+/** channel_announcement系の送受信情報削除
  *
- * @param[in]       short_channel_id
+ * channel_announcement/channel_updateの送信先・受信元ノードIDを削除する。
+ *
+ * @param[in]       short_channel_id(0の場合、全削除)
  * @retval      true    成功
  */
 bool ln_db_annocnlall_del(uint64_t short_channel_id);
 
 
-/** channel_announcement系の送信元/先ノード追加
+/** channel_announcement系の送受信情報追加
  *
- * 
- * 
+ * channel_announcement/channel_updateの送信先・受信元ノードIDを追加する。
+ *
  * @param[in,out]   pDb
  * @param[in]       ShortChannelId
  * @param[in]       Type
@@ -283,6 +285,13 @@ bool ln_db_annocnls_search_nodeid(void *pDb, uint64_t ShortChannelId, char Type,
  * @retval  true    成功
  */
 bool ln_db_annocnl_cur_get(void *pCur, uint64_t *pShortChannelId, char *pType, uint32_t *pTimeStamp, ucoin_buf_t *pBuf);
+
+
+/** channel_announcementのないchannel_update削除
+ *
+ * 
+ */
+void ln_db_annocnl_del_orphan(void);
 
 
 ////////////////////
@@ -410,6 +419,17 @@ void ln_db_annonod_cur_close(void *pCur);
  * @retval      true    成功
  */
 bool ln_db_annonod_cur_get(void *pCur, ucoin_buf_t *pBuf, uint32_t *pTimeStamp, uint8_t *pNodeId);
+
+
+////////////////////
+// annocnl, annonod共通
+////////////////////
+
+/** channel_announcement/channel_update/node_announcement送受信ノード情報削除
+ *
+ * @param[in]       pNodeId     削除対象のnode_id(NULL時は全削除)
+ */
+bool ln_db_annoinfo_del(const uint8_t *pNodeId);
 
 
 ////////////////////

--- a/ucoin/src/ln/ln_node.c
+++ b/ucoin/src/ln/ln_node.c
@@ -162,6 +162,7 @@ bool ln_node_init(uint8_t Features)
     }
 
     if (ret) {
+        ln_db_annoinfo_del(NULL);
         print_node();
     }
 


### PR DESCRIPTION
#430 対応 その1

* `channel_announcment` `channel_update` /`node_announcement`の送受信node_idを、起動時にDBから全クリア
  * 個別クリアもするので、不要かもしれない
* `channel_announcment` `channel_update` /`node_announcement`の送受信node_idを、channel接続時にDBからクリア
* `channel_announcement`のない`channel_update`は起動時にDBからクリア
* 未送信の`channel_announcment` `channel_update` /`node_announcement`がない場合、次のチェックを30秒後にする(通常は1秒間隔)

#435 のため、対策できたかどうかか確認が取れないため、一度本編にmergeする。