### PR TITLE
wait_minimum_depth: channel_id

### DIFF
--- a/ucoind/lnapp.c
+++ b/ucoind/lnapp.c
@@ -720,6 +720,9 @@ void lnapp_show_self(const lnapp_conf_t *pAppConf, cJSON *pResult, const char *p
         //peer node_id
         ucoin_util_bin2str(str, p_self->peer_node_id, UCOIN_SZ_PUBKEY);
         cJSON_AddItemToObject(result, "node_id", cJSON_CreateString(str));
+        //channel_id
+        ucoin_util_bin2str(str, ln_channel_id(pAppConf->p_self), LN_SZ_CHANNEL_ID);
+        cJSON_AddItemToObject(result, "channel_id", cJSON_CreateString(str));
         //funding_tx
         ucoin_util_bin2str_rev(str, ln_funding_txid(pAppConf->p_self), UCOIN_SZ_TXID);
         cJSON_AddItemToObject(result, "funding_tx", cJSON_CreateString(str));


### PR DESCRIPTION
`ucoincli -l` : wait_minimum_depthでもchannel_idを出力する