### PR TITLE
ignore received `node_announcement` not receiving `channel_announcement`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 2018/06/19
+
+* DB version : -18
+  * add "annoinfo_chan" for skip `node_announcement` from unknown node_id
+
 ## 2018/05/30
 
 * remove zlog
@@ -23,7 +28,7 @@
 
 ## 2018/04/09
 
-* DB version : -18
+* DB version : -18 --> not changed !! -17
   * privkey move other database
 * bugfix
 

--- a/ucoin/include/ln_db.h
+++ b/ucoin/include/ln_db.h
@@ -190,9 +190,12 @@ bool ln_db_annocnl_load(ucoin_buf_t *pCnlAnno, uint64_t ShortChannelId);
  * @param[in]       pCnlAnno
  * @param[in]       ShortChannelId  pCnlAnnoのshort_channel_id
  * @param[in]       pSendId         pCnlAnnoの送信元/先node_id
+ * @param[in]       pChan1          channel_announcementのnode1
+ * @param[in]       pChan2          channel_announcementのnode2
  * @retval      true    成功
  */
-bool ln_db_annocnl_save(const ucoin_buf_t *pCnlAnno, uint64_t ShortChannelId, const uint8_t *pSendId);
+bool ln_db_annocnl_save(const ucoin_buf_t *pCnlAnno, uint64_t ShortChannelId, const uint8_t *pSendId,
+                        const uint8_t *pChan1, const uint8_t *pChan2);
 
 
 /** channel_update読込み

--- a/ucoin/src/ln/ln.c
+++ b/ucoin/src/ln/ln.c
@@ -3088,7 +3088,8 @@ static bool recv_announcement_signatures(ln_self_t *self, const uint8_t *pData, 
         LOGD("fail\n");
         goto LABEL_EXIT;
     }
-    ret = ln_db_annocnl_save(&self->cnl_anno, ln_short_channel_id(self), ln_their_node_id(self));
+    ret = ln_db_annocnl_save(&self->cnl_anno, ln_short_channel_id(self), ln_their_node_id(self),
+                            ln_their_node_id(self), ln_node_getid());
     if (!ret) {
         LOGD("fail: ln_db_annocnl_save\n");
         //goto LABEL_EXIT;
@@ -3138,7 +3139,8 @@ static bool recv_channel_announcement(ln_self_t *self, const uint8_t *pData, uin
 
     if (param.is_unspent) {
         //DB保存
-        ret = ln_db_annocnl_save(&buf, ann.short_channel_id, ln_their_node_id(self));
+        ret = ln_db_annocnl_save(&buf, ann.short_channel_id, ln_their_node_id(self),
+                                    ann.node_id1, ann.node_id2);
         if (!ret) {
             LOGD("fail: db save\n");
         }

--- a/ucoind/lnapp.c
+++ b/ucoind/lnapp.c
@@ -2321,6 +2321,16 @@ static void cb_anno_signsed(lnapp_conf_t *p_conf, void *p_param)
     }
     ucoin_buf_free(&buf_bolt);
 
+    //node_announcement
+    ret = ln_db_annonod_load(&buf_bolt, NULL, ln_node_getid());
+    if (ret) {
+        LOGD("send: my node_announcement\n");
+        send_peer_noise(p_conf, &buf_bolt);
+    } else {
+        LOGD("err\n");
+    }
+    ucoin_buf_free(&buf_bolt);
+
     DBGTRACE_END
 }
 


### PR DESCRIPTION
BOLT#07: `channel_announcement`でnode_idを受信していない`node_announcement`は、無視してよい。

Squashed commit of the following:

commit db6361137221589af49943287450844f8c394464
Author: ueno <ueno@nayuta.co>
Date:   Tue Jun 19 17:50:48 2018 +0900

    update readme

commit 2dc1a050f6a449d2494818b6927ae7a3348d557f
Author: ueno <ueno@nayuta.co>
Date:   Tue Jun 19 17:45:34 2018 +0900

    send my node_announcement

commit 981f48ea7188e8f8c32ae746ba683838ecd200d7
Author: ueno <ueno@nayuta.co>
Date:   Tue Jun 19 16:41:46 2018 +0900

    lmdb: add "annoinfo_chan"

    * channel_announcement保存時に、node1, node2を保存
    * node_announcement保存時に"annoinfo_chan"になければ保存しない