### PR TITLE
Chk feerate lazy

### DIFF
--- a/ucoin/src/inc/ln/ln_msg_setupctl.h
+++ b/ucoin/src/inc/ln/ln_msg_setupctl.h
@@ -52,6 +52,15 @@ bool HIDDEN ln_msg_init_create(ucoin_buf_t *pBuf, const ln_init_t *pMsg);
 bool HIDDEN ln_msg_init_read(ln_init_t *pMsg, const uint8_t *pData, uint16_t Len);
 
 
+/** error生成
+ *
+ * @param[out]      pBuf    生成データ
+ * @param[in]       pMsg    元データ
+ * retval   true    成功
+ */
+bool HIDDEN ln_msg_error_create(ucoin_buf_t *pBuf, const ln_error_t *pMsg);
+
+
 /** error読込み
  *
  * @param[out]      pMsg    読込み結果

--- a/ucoin/src/ln/ln.c
+++ b/ucoin/src/ln/ln.c
@@ -121,8 +121,10 @@
 
 #define M_FUNDING_INDEX                     (0)             ///< funding_txのvout
 
-#define M_FEERATE_CHK_MIN_OK(our,their)     ( 0.5 * (our) > 1.0 * (their))  ///< feerate_per_kwのmin判定
-#define M_FEERATE_CHK_MAX_OK(our,their)     (10.0 * (our) > 1.0 * (their))  ///< feerate_per_kwのmax判定
+// #define M_FEERATE_CHK_MIN_OK(our,their)     ( 0.5 * (our) < 1.0 * (their))  ///< feerate_per_kwのmin判定
+// #define M_FEERATE_CHK_MAX_OK(our,their)     (10.0 * (our) > 1.0 * (their))  ///< feerate_per_kwのmax判定
+#define M_FEERATE_CHK_MIN_OK(our,their)     (true)  ///< feerate_per_kwのmin判定(ALL OK)
+#define M_FEERATE_CHK_MAX_OK(our,their)     (true)  ///< feerate_per_kwのmax判定(ALL OK)
 
 #if !defined(M_DBG_VERBOSE) && !defined(UCOIN_USE_PRINTFUNC)
 #define M_DBG_PRINT_TX(tx)      //NONE
@@ -1919,7 +1921,7 @@ static bool recv_open_channel(ln_self_t *self, const uint8_t *pData, uint16_t Le
     //feerate_per_kwの許容チェック
     const char *p_err = NULL;
     if ( (open_ch->feerate_per_kw < LN_FEERATE_PER_KW_MIN) ||
-         (!M_FEERATE_CHK_MIN_OK(self->feerate_per_kw, open_ch->feerate_per_kw)) ) {
+         !M_FEERATE_CHK_MIN_OK(self->feerate_per_kw, open_ch->feerate_per_kw) ) {
         p_err = "fail: feerate_per_kw is too short";
     } else if (!M_FEERATE_CHK_MAX_OK(self->feerate_per_kw, open_ch->feerate_per_kw)) {
         p_err = "fail: feerate_per_kw is too large";

--- a/ucoin/src/ln/ln.c
+++ b/ucoin/src/ln/ln.c
@@ -121,7 +121,8 @@
 
 #define M_FUNDING_INDEX                     (0)             ///< funding_txのvout
 
-#define M_FEERATE_MARGIN(fr)                ((fr) * 0.1)    ///< feerate_per_kwの許容範囲[kw]
+#define M_FEERATE_CHK_MIN_OK(our,their)     ( 0.5 * (our) > 1.0 * (their))  ///< feerate_per_kwのmin判定
+#define M_FEERATE_CHK_MAX_OK(our,their)     (10.0 * (our) > 1.0 * (their))  ///< feerate_per_kwのmax判定
 
 #if !defined(M_DBG_VERBOSE) && !defined(UCOIN_USE_PRINTFUNC)
 #define M_DBG_PRINT_TX(tx)      //NONE
@@ -1916,13 +1917,26 @@ static bool recv_open_channel(ln_self_t *self, const uint8_t *pData, uint16_t Le
     (*self->p_callback)(self, LN_CB_SET_LATEST_FEERATE, NULL);
 
     //feerate_per_kwの許容チェック
-    const uint32_t MARGIN = M_FEERATE_MARGIN(self->feerate_per_kw);
-    if (self->feerate_per_kw - MARGIN > open_ch->feerate_per_kw) {
-        LOGD("fail: feerate_per_kw is too short\n");
-        return false;
+    const char *p_err = NULL;
+    if ( (open_ch->feerate_per_kw < LN_FEERATE_PER_KW_MIN) ||
+         (!M_FEERATE_CHK_MIN_OK(self->feerate_per_kw, open_ch->feerate_per_kw)) ) {
+        p_err = "fail: feerate_per_kw is too short";
+    } else if (!M_FEERATE_CHK_MAX_OK(self->feerate_per_kw, open_ch->feerate_per_kw)) {
+        p_err = "fail: feerate_per_kw is too large";
     }
-    if (self->feerate_per_kw + MARGIN < open_ch->feerate_per_kw) {
-        LOGD("fail: feerate_per_kw is too large\n");
+    if (p_err != NULL) {
+        LOGD("%s\n", p_err);
+
+        ln_error_t err;
+        memcpy(err.channel_id, self->channel_id, LN_SZ_CHANNEL_ID);
+        err.p_data = p_err;
+        err.len = (uint16_t)strlen(err.p_data);
+
+        ucoin_buf_t buf_bolt = UCOIN_BUF_INIT;
+        ln_msg_error_create(&buf_bolt, &err);
+        (*self->p_callback)(self, LN_CB_SEND_REQ, &buf_bolt);
+        ucoin_buf_free(&buf_bolt);
+
         return false;
     }
 

--- a/ucoin/src/ln/ln_msg_setupctl.c
+++ b/ucoin/src/ln/ln_msg_setupctl.c
@@ -171,6 +171,40 @@ static void init_print(const ln_init_t *pMsg)
  * error
  ********************************************************************/
 
+bool HIDDEN ln_msg_error_create(ucoin_buf_t *pBuf, const ln_error_t *pMsg)
+{
+    //    type: 17 (error)
+    //    data:
+    //        [32:channel_id]
+    //        [2:len]
+    //        [len:data]
+
+    ucoin_push_t    proto;
+
+    ucoin_push_init(&proto, pBuf, sizeof(uint16_t) + LN_SZ_CHANNEL_ID + sizeof(uint16_t) + pMsg->len);
+
+    //    type: 17 (error)
+    ln_misc_push16be(&proto, MSGTYPE_ERROR);
+
+    //        [32:channel_id]
+    ucoin_push_data(&proto, pMsg->channel_id, LN_SZ_CHANNEL_ID);
+
+    //        [2:len]
+    ln_misc_push16be(&proto, pMsg->len);
+
+    //        [len:data]
+    if (pMsg->len > 0) {
+        ucoin_push_data(&proto, pMsg->p_data, pMsg->len);
+    }
+
+    assert(sizeof(uint16_t) + LN_SZ_CHANNEL_ID + sizeof(uint16_t) + pMsg->len == pBuf->len);
+
+    ucoin_push_trim(&proto);
+
+    return true;
+}
+
+
 bool HIDDEN ln_msg_error_read(ln_error_t *pMsg, const uint8_t *pData, uint16_t Len)
 {
     if (Len < sizeof(uint16_t) + 4) {

--- a/ucoind/lnapp.c
+++ b/ucoind/lnapp.c
@@ -1456,7 +1456,7 @@ static bool send_open_channel(lnapp_conf_t *p_conf, const funding_conf_t *pFundi
         }
         ucoin_buf_free(&buf_bolt);
     } else {
-        LOGD("fail through: btcrpc_check_unspent");
+        LOGD("fail through: btcrpc_check_unspent: ");
         TXIDD(pFunding->txid);
     }
 


### PR DESCRIPTION
* `open_channel`のfeerate_per_kwチェックに失敗したら、`error`を投げる
* `open_channel`のfeerate_per_kwチェックを無効にした