### PR TITLE
preimage don't remove before related channel close

### DIFF
--- a/showdb/showdb.c
+++ b/showdb/showdb.c
@@ -695,14 +695,19 @@ static void dumpit_preimage(MDB_txn *txn, MDB_dbi dbi)
         while (ret) {
             uint8_t preimage[LN_SZ_PREIMAGE];
             uint64_t amount;
-            ret = ln_db_preimg_cur_get(&cur, preimage, &amount);
+            uint32_t expiry;
+            ret = ln_db_preimg_cur_get(&cur, preimage, &amount, &expiry);
             if (ret) {
                 if (cnt4) {
                     printf(",");
                 }
-                printf("[\"");
+                printf("{\n");
+                printf(INDENT1 "\"");
                 ucoin_util_dumpbin(stdout, preimage, LN_SZ_PREIMAGE, false);
-                printf("\", %" PRIu64 "]", amount);
+                printf("\",\n");
+                printf(INDENT1 M_QQ("amount") ": %" PRIu64 ",\n", amount);
+                printf(INDENT1 M_QQ("expiry") ": %" PRIu32 "\n", expiry);
+                printf("}");
                 cnt4++;
             }
         }

--- a/ucoin/include/segwit_addr.h
+++ b/ucoin/include/segwit_addr.h
@@ -96,6 +96,7 @@ typedef struct ln_invoice_t {
     uint8_t     hrp_type;
     uint64_t    amount_msat;
     uint64_t    timestamp;
+    uint32_t    expiry;
     uint32_t    min_final_cltv_expiry;
     uint8_t     pubkey[UCOIN_SZ_PUBKEY];
     uint8_t     payment_hash[LN_SZ_HASH];
@@ -128,11 +129,12 @@ bool ln_invoice_decode(ln_invoice_t **pp_invoice_data, const char* invoice);
  * @param[in]       Type            LN_INVOICE_xxx
  * @param[in]       pPayHash
  * @param[in]       Amount
+ * @param[in]       Expiry          invoice expiry
  * @retval      true        成功
  * @attention
  *      - ppInoviceはmalloc()で確保するため、、使用後にfree()すること
  */
-bool ln_invoice_create(char **ppInvoice, uint8_t Type, const uint8_t *pPayHash, uint64_t Amount);
+bool ln_invoice_create(char **ppInvoice, uint8_t Type, const uint8_t *pPayHash, uint64_t Amount, uint32_t Expiry);
 
 #ifdef __cplusplus
 }

--- a/ucoin/src/bech32/segwit_addr.c
+++ b/ucoin/src/bech32/segwit_addr.c
@@ -514,6 +514,9 @@ bool ln_invoice_decode(ln_invoice_t **pp_invoice_data, const char* invoice) {
     uint8_t sig[65];
     size_t sig_len = 0;
     ln_invoice_t *p_invoice_data = (ln_invoice_t *)malloc(sizeof(ln_invoice_t));
+
+    //TODO: 固定値
+    p_invoice_data->expiry = LN_INVOICE_EXPIRY;
     if (!bech32_decode(hrp_actual, data, &data_len, invoice, true)) {
         goto LABEL_EXIT;
     }
@@ -629,12 +632,13 @@ LABEL_EXIT:
 }
 
 
-bool ln_invoice_create(char **ppInvoice, uint8_t Type, const uint8_t *pPayHash, uint64_t Amount)
+bool ln_invoice_create(char **ppInvoice, uint8_t Type, const uint8_t *pPayHash, uint64_t Amount, uint32_t Expiry)
 {
     ln_invoice_t invoice_data;
 
     invoice_data.hrp_type = Type;
     invoice_data.amount_msat = Amount;
+    invoice_data.expiry = Expiry;   //TODO: 未使用
     invoice_data.min_final_cltv_expiry = LN_MIN_FINAL_CLTV_EXPIRY;
     memcpy(invoice_data.pubkey, ln_node_getid(), UCOIN_SZ_PUBKEY);
     memcpy(invoice_data.payment_hash, pPayHash, LN_SZ_HASH);

--- a/ucoind/lnapp.c
+++ b/ucoind/lnapp.c
@@ -3010,8 +3010,8 @@ static bool send_channel_anno(lnapp_conf_t *p_conf)
                 }
             } else if ((type == LN_DB_CNLANNO_UPD1) || (type == LN_DB_CNLANNO_UPD2)) {
                 //BOLT#7: Pruning the Network View
-                time_t now = time(NULL);
-                if (ln_db_annocnlupd_is_prune((uint32_t)now, timestamp)) {
+                uint64_t now = (uint64_t)time(NULL);
+                if (ln_db_annocnlupd_is_prune(now, timestamp)) {
                     //古いため、DBから削除
                     char tmstr[UCOIN_SZ_DTSTR + 1];
                     ucoin_util_strftime(tmstr, timestamp);

--- a/ucoind/monitoring.c
+++ b/ucoind/monitoring.c
@@ -233,7 +233,8 @@ bool monitor_close_unilateral_local(ln_self_t *self, void *pDbParam)
                     LOGD("code=%d\n", code);
                     ucoin_buf_free(&buf);
                     if (ret) {
-                        LOGD("broadcast txid[%d]\n", lp);
+                        LOGD("broadcast txid[%d]: ", lp);
+                        TXIDD(txid);
                         LOGD("-->OK\n");
                     } else {
                         del = false;
@@ -256,7 +257,8 @@ bool monitor_close_unilateral_local(ln_self_t *self, void *pDbParam)
             LOGD("code=%d\n", code);
             ucoin_buf_free(&buf);
             if (ret) {
-                LOGD("broadcast after tx[%d]\n", lp);
+                LOGD("broadcast after tx[%d]: ", lp);
+                TXIDD(txid);
                 LOGD("-->OK\n");
             } else if ((code == BTCRPC_ERR_MISSING_INPUT) || (code == BTCRPC_ERR_ALREADY_BLOCK)) {
                 LOGD("through[%d]: already spent vin\n", lp);
@@ -444,7 +446,7 @@ static bool close_unilateral_local_offered(ln_self_t *self, bool *pDel, bool spe
                     if (p_buf != NULL) {
                         LOGD("backwind preimage: ");
                         DUMPD(p_buf->buf, p_buf->len);
-                        ln_db_preimg_save(p_buf->buf, 0, pDbParam);
+                        ln_db_preimg_save(p_buf->buf, 0, UINT32_MAX, pDbParam);
                     } else {
                         assert(0);
                     }
@@ -638,7 +640,7 @@ static bool close_unilateral_remote_received(ln_self_t *self, bool *pDel, bool s
                     if (p_buf != NULL) {
                         LOGD("backwind preimage: ");
                         DUMPD(p_buf->buf, p_buf->len);
-                        ln_db_preimg_save(p_buf->buf, 0, pDbParam);
+                        ln_db_preimg_save(p_buf->buf, 0, UINT32_MAX, pDbParam);
                     } else {
                         assert(0);
                     }
@@ -842,6 +844,10 @@ static bool close_revoked_tolocal(const ln_self_t *self, const ucoin_tx_t *pTx, 
         ucoin_tx_create(&buf, &tx);
         ucoin_tx_free(&tx);
         ret = btcrpc_sendraw_tx(txid, NULL, buf.buf, buf.len);
+        if (ret) {
+            LOGD("broadcast OK: ");
+            TXIDD(txid);
+        }
         ucoin_buf_free(&buf);
     }
 
@@ -864,6 +870,10 @@ static bool close_revoked_toremote(const ln_self_t *self, const ucoin_tx_t *pTx,
         ucoin_tx_create(&buf, &tx);
         ucoin_tx_free(&tx);
         ret = btcrpc_sendraw_tx(txid, NULL, buf.buf, buf.len);
+        if (ret) {
+            LOGD("broadcast OK: ");
+            TXIDD(txid);
+        }
         ucoin_buf_free(&buf);
     }
 
@@ -884,6 +894,10 @@ static bool close_revoked_htlc(const ln_self_t *self, const ucoin_tx_t *pTx, int
     ucoin_tx_create(&buf, &tx);
     ucoin_tx_free(&tx);
     bool ret = btcrpc_sendraw_tx(txid, NULL, buf.buf, buf.len);
+    if (ret) {
+        LOGD("broadcast OK: ");
+        TXIDD(txid);
+    }
     ucoin_buf_free(&buf);
 
     return ret;


### PR DESCRIPTION
fix #570

received HTLCが自分のpreimageを参照しているので、invoiceの期限が来ても削除しないようにする。