### PR TITLE
send `node_announcement` after `channel_announcement`

### DIFF
--- a/ucoin/include/ln.h
+++ b/ucoin/include/ln.h
@@ -190,7 +190,6 @@ typedef enum {
     LN_CB_FUNDINGLOCKED_RECV,   ///< funding_locked受信通知
     LN_CB_CHANNEL_ANNO_RECV,    ///< channel_announcement受信通知
     LN_CB_NODE_ANNO_RECV,       ///< node_announcement受信通知
-    LN_CB_ANNO_SIGSED,          ///< announcement_signatures完了通知
     LN_CB_ADD_HTLC_RECV_PREV,   ///< update_add_htlc処理前通知
     LN_CB_ADD_HTLC_RECV,        ///< update_add_htlc受信通知
     LN_CB_FULFILL_HTLC_RECV,    ///< update_fulfill_htlc受信通知
@@ -1223,17 +1222,6 @@ bool ln_noise_dec_msg(ln_self_t *self, ucoin_buf_t *pBuf);
 bool ln_recv(ln_self_t *self, const uint8_t *pData, uint16_t Len);
 
 
-/** 定期フラグ回収処理
- * どこかのタイミングで行う必要があるが、即時行うようなタイミングがないかもしれない処理。
- * 将来的には ln.c で吸収すべきと考えている。
- *      - funding_locked交換
- *      - announcement_signatures交換
- *
- * @param[in,out]       self        channel情報
- */
-void ln_flag_proc(ln_self_t *self);
-
-
 /** initメッセージ作成
  *
  * @param[in,out]       self            channel情報
@@ -1537,6 +1525,28 @@ void ln_calc_preimage_hash(uint8_t *pHash, const uint8_t *pPreImage);
  * @param[out]      pReason
  */
 void ln_create_reason_temp_node(ucoin_buf_t *pReason);
+
+
+/** channel_announcementデータ解析
+ *
+ * @param[out]  p_short_channel_id
+ * @param[out]  pNodeId1
+ * @param[out]  pNodeId2
+ * @param[in]   pData
+ * @param[in]   Len
+ * @retval  true        解析成功
+ */
+bool ln_getids_cnl_anno(uint64_t *p_short_channel_id, uint8_t *pNodeId1, uint8_t *pNodeId2, const uint8_t *pData, uint16_t Len);
+
+
+/** channel_updateデータ解析
+ *
+ * @param[out]  pUpd
+ * @param[in]   pData
+ * @param[in]   Len
+ * @retval  true        解析成功
+ */
+bool ln_getparams_cnl_upd(ln_cnl_update_t *pUpd, const uint8_t *pData, uint16_t Len);
 
 
 /********************************************************************

--- a/ucoin/include/ln_db.h
+++ b/ucoin/include/ln_db.h
@@ -400,7 +400,7 @@ bool ln_db_invoice_drop(void);
  * @param[in]       pNodeId         検索するnode_id
  * @retval      true    成功
  */
-bool ln_db_annonod_load(ucoin_buf_t *pNodeAnno, uint32_t *pTimeStamp, const uint8_t *pNodeId);
+bool ln_db_annonod_load(ucoin_buf_t *pNodeAnno, uint32_t *pTimeStamp, const uint8_t *pNodeId, void *pDb);
 
 
 /** node_announcement書込み
@@ -423,6 +423,7 @@ bool ln_db_annonod_drop(void);
 
 /** node_announcement送信済み検索
  *
+ * @retval  true        送信済み
  */
 bool ln_db_annonod_search_nodeid(void *pDb, const uint8_t *pNodeId, const uint8_t *pSendId);
 

--- a/ucoin/src/ln/ln_node.c
+++ b/ucoin/src/ln/ln_node.c
@@ -117,7 +117,7 @@ bool ln_node_init(uint8_t Features)
 
     ln_node_announce_t anno;
 
-    ret = ln_db_annonod_load(&buf_node, NULL, mNode.keys.pub);
+    ret = ln_db_annonod_load(&buf_node, NULL, mNode.keys.pub, NULL);
     if (ret) {
         //ノード設定が変更されていないかチェック
         //  少なくともnode_idは変更されていない
@@ -198,7 +198,7 @@ bool ln_node_search_nodeanno(ln_node_announce_t *pNodeAnno, const uint8_t *pNode
 {
     ucoin_buf_t buf_anno = UCOIN_BUF_INIT;
 
-    bool ret = ln_db_annonod_load(&buf_anno, NULL, pNodeId);
+    bool ret = ln_db_annonod_load(&buf_anno, NULL, pNodeId, NULL);
     if (ret) {
         pNodeAnno->p_node_id = NULL;
         pNodeAnno->p_alias = NULL;

--- a/ucoind/inc/lnapp.h
+++ b/ucoind/inc/lnapp.h
@@ -107,7 +107,6 @@ typedef struct lnapp_conf_t {
     //last send announcement
     uint64_t        last_anno_cnl;                      ///< [#send_channel_anno()]最後にannouncementしたchannel
     uint64_t        last_annocnl_sci;                   ///< [#send_channel_anno()]最後にcur_getしたchannel_announcementのshort_channel_id
-    uint8_t         last_anno_node[UCOIN_SZ_PUBKEY];    ///< [#send_node_anno()]最後にannouncementしたnode
 
     int             err;            ///< last error
     char            *p_errstr;      ///< last error string


### PR DESCRIPTION
fix #573 

BOLT#07
「受信済み`channel_announcement`のnode_idに含まれていない`node_announcement`は無視してよい」ため、先に`channel_announcement`を送信する。