### PR TITLE
use MbedTLS for HKDF

### DIFF
--- a/ucoin/libs/mbedtls_config/check_config.h
+++ b/ucoin/libs/mbedtls_config/check_config.h
@@ -4,7 +4,7 @@
  * \brief Consistency checks for configuration options
  */
 /*
- *  Copyright (C) 2006-2016, ARM Limited, All Rights Reserved
+ *  Copyright (C) 2006-2018, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
@@ -76,6 +76,10 @@
 
 #if defined(MBEDTLS_DHM_C) && !defined(MBEDTLS_BIGNUM_C)
 #error "MBEDTLS_DHM_C defined, but not all prerequisites"
+#endif
+
+#if defined(MBEDTLS_SSL_TRUNCATED_HMAC_COMPAT) && !defined(MBEDTLS_SSL_TRUNCATED_HMAC)
+#error "MBEDTLS_SSL_TRUNCATED_HMAC_COMPAT defined, but not all prerequisites"
 #endif
 
 #if defined(MBEDTLS_CMAC_C) && \
@@ -185,6 +189,10 @@
 
 #if defined(MBEDTLS_HAVEGE_C) && !defined(MBEDTLS_TIMING_C)
 #error "MBEDTLS_HAVEGE_C defined, but not all prerequisites"
+#endif
+
+#if defined(MBEDTLS_HKDF_C) && !defined(MBEDTLS_MD_C)
+#error "MBEDTLS_HKDF_C defined, but not all prerequisites"
 #endif
 
 #if defined(MBEDTLS_HMAC_DRBG_C) && !defined(MBEDTLS_MD_C)

--- a/ucoin/src/ln/ln_enc_auth.c
+++ b/ucoin/src/ln/ln_enc_auth.c
@@ -386,8 +386,8 @@ static bool noise_hkdf(uint8_t *ck, uint8_t *k, const uint8_t *pSalt, const uint
                     NULL, 0,
                     okm, sizeof(okm));
     if (retval == 0) {
-        memcpy(ck, okm, 32);
-        memcpy(k, okm + 32, 32);
+        memcpy(ck, okm, UCOIN_SZ_SHA256);
+        memcpy(k, okm + UCOIN_SZ_SHA256, UCOIN_SZ_SHA256);
     }
     return retval == 0;
 #else


### PR DESCRIPTION
fix #554 

* update: MbedTLS header file
* enable HKDF

unittestだけは通した。