### PR TITLE
test_reconnect issues

### DIFF
--- a/include/ucoind.h
+++ b/include/ucoind.h
@@ -161,8 +161,8 @@ typedef enum {
 } trans_cmd_t;
 
 
-/** @struct     daemon_connect_t
- *  @brief      daemon接続情報
+/** @struct     peer_conn_t
+ *  @brief      peer接続情報
  *  @note
  *      - #peer_conf_t と同じ構造だが、別にしておく(統合する可能性あり)
  */
@@ -171,7 +171,7 @@ typedef struct {
     char        ipaddr[SZ_IPV4_LEN + 1];
     uint16_t    port;
     uint8_t     node_id[UCOIN_SZ_PUBKEY];
-} daemon_connect_t;
+} peer_conn_t;
 
 
 /** @struct     funding_conf_t
@@ -210,7 +210,7 @@ typedef struct {
 /** @struct     peer_conf_t
  *  @brief      peer node接続情報
  *  @note
- *      - #daemon_connect_t と同じ構造だが、別にしておく
+ *      - #peer_conn_t と同じ構造だが、別にしておく
  */
 typedef struct {
     char            ipaddr[SZ_IPV4_LEN + 1];

--- a/ucoind/Makefile
+++ b/ucoind/Makefile
@@ -63,6 +63,9 @@ CFLAGS += -W -Wall -Wextra
 CFLAGS += -ffunction-sections -fdata-sections -fno-strict-aliasing
 #CFLAGS += -flto -fno-builtin
 
+# for syscall() and others
+CFLAGS += -D_GNU_SOURCE
+
 # others
 CFLAGS += $(INC_PATHS)
 CFLAGS += -DNETKIND=$(NETKIND)

--- a/ucoind/cmd_json.c
+++ b/ucoind/cmd_json.c
@@ -104,7 +104,7 @@ static cJSON *cmd_disautoconn(jrpc_context *ctx, cJSON *params, cJSON *id);
 static cJSON *cmd_removechannel(jrpc_context *ctx, cJSON *params, cJSON *id);
 static cJSON *cmd_setfeerate(jrpc_context *ctx, cJSON *params, cJSON *id);
 
-static int cmd_connect_proc(const daemon_connect_t *pConn, jrpc_context *ctx);
+static int cmd_connect_proc(const peer_conn_t *pConn, jrpc_context *ctx);
 static int cmd_disconnect_proc(const uint8_t *pNodeId);
 static int cmd_stop_proc(void);
 static int cmd_fund_proc(const uint8_t *pNodeId, const funding_conf_t *pFund);
@@ -120,7 +120,7 @@ static int cmd_routepay_proc2(
                 const char *pInvoiceStr, uint64_t AddAmountMsat);
 static int cmd_close_proc(bool *bMutual, const uint8_t *pNodeId);
 
-static bool json_connect(cJSON *params, int *pIndex, daemon_connect_t *pConn);
+static bool json_connect(cJSON *params, int *pIndex, peer_conn_t *pConn);
 static char *create_bolt11(const uint8_t *pPayHash, uint64_t Amount, uint32_t Expiry, const ln_fieldr_t *pFieldR, uint8_t FieldRNum);
 static void create_bolt11_rfield(ln_fieldr_t **ppFieldR, uint8_t *pFieldRNum);
 static bool comp_func_cnl(ln_self_t *self, void *p_db_param, void *p_param);
@@ -220,7 +220,7 @@ static cJSON *cmd_connect(jrpc_context *ctx, cJSON *params, cJSON *id)
     (void)id;
 
     int err = RPCERR_PARSE;
-    daemon_connect_t conn;
+    peer_conn_t conn;
     cJSON *result = NULL;
     int index = 0;
 
@@ -306,7 +306,7 @@ static cJSON *cmd_disconnect(jrpc_context *ctx, cJSON *params, cJSON *id)
     (void)id;
 
     int err = RPCERR_PARSE;
-    daemon_connect_t conn;
+    peer_conn_t conn;
     cJSON *result = NULL;
     int index = 0;
 
@@ -360,7 +360,7 @@ static cJSON *cmd_fund(jrpc_context *ctx, cJSON *params, cJSON *id)
 
     int err = RPCERR_PARSE;
     cJSON *json;
-    daemon_connect_t conn;
+    peer_conn_t conn;
     funding_conf_t fundconf;
     cJSON *result = NULL;
     int index = 0;
@@ -839,7 +839,7 @@ static cJSON *cmd_close(jrpc_context *ctx, cJSON *params, cJSON *id)
     (void)id;
 
     int err = RPCERR_PARSE;
-    daemon_connect_t conn;
+    peer_conn_t conn;
     cJSON *result = NULL;
     int index = 0;
     bool b_mutual;
@@ -877,7 +877,7 @@ static cJSON *cmd_getlasterror(jrpc_context *ctx, cJSON *params, cJSON *id)
 {
     (void)id;
 
-    daemon_connect_t conn;
+    peer_conn_t conn;
     int index = 0;
 
     //connect parameter
@@ -967,7 +967,7 @@ static cJSON *cmd_getcommittx(jrpc_context *ctx, cJSON *params, cJSON *id)
 {
     (void)id;
 
-    daemon_connect_t conn;
+    peer_conn_t conn;
     cJSON *result = cJSON_CreateObject();
     int index = 0;
 
@@ -1101,7 +1101,7 @@ LABEL_EXIT:
  * @param[in,out]   ctx
  * @retval  エラーコード
  */
-static int cmd_connect_proc(const daemon_connect_t *pConn, jrpc_context *ctx)
+static int cmd_connect_proc(const peer_conn_t *pConn, jrpc_context *ctx)
 {
     LOGD("connect\n");
 
@@ -1444,7 +1444,7 @@ static int cmd_close_proc(bool *bMutual, const uint8_t *pNodeId)
 /** ucoincli -c解析
  *
  */
-static bool json_connect(cJSON *params, int *pIndex, daemon_connect_t *pConn)
+static bool json_connect(cJSON *params, int *pIndex, peer_conn_t *pConn)
 {
     cJSON *json;
 

--- a/ucoind/inc/p2p_cli.h
+++ b/ucoind/inc/p2p_cli.h
@@ -49,7 +49,7 @@ void p2p_cli_init(void);
 /** [p2p_cli]開始
  *
  */
-bool p2p_cli_start(const daemon_connect_t *pConn, jrpc_context *ctx);
+bool p2p_cli_start(const peer_conn_t *pConn, jrpc_context *ctx);
 
 
 /** [p2p_cli]全停止
@@ -85,12 +85,12 @@ bool p2p_cli_is_looping(void);
 /** [p2p_cli] 接続情報を保存
  *
  */
-bool p2p_cli_store_peer_conn(const daemon_connect_t* pPeerConn);
+bool p2p_cli_store_peer_conn(const peer_conn_t* pPeerConn);
 
 /** [p2p_cli] 接続情報を復元
  *
  */
-bool p2p_cli_load_peer_conn(daemon_connect_t* pPeerConn, const uint8_t *pNodeId);
+bool p2p_cli_load_peer_conn(peer_conn_t* pPeerConn, const uint8_t *pNodeId);
 
 
 #ifdef __cplusplus

--- a/ucoind/inc/p2p_cli.h
+++ b/ucoind/inc/p2p_cli.h
@@ -82,6 +82,17 @@ void p2p_cli_show_self(cJSON *pResult);
 bool p2p_cli_is_looping(void);
 
 
+/** [p2p_cli] 接続情報を保存
+ *
+ */
+bool p2p_cli_store_peer_conn(const daemon_connect_t* pPeerConn);
+
+/** [p2p_cli] 接続情報を復元
+ *
+ */
+bool p2p_cli_load_peer_conn(daemon_connect_t* pPeerConn, const uint8_t *pNodeId);
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/ucoind/monitoring.c
+++ b/ucoind/monitoring.c
@@ -391,7 +391,7 @@ static bool channel_reconnect(ln_self_t *self, uint32_t confm, void *p_db_param)
     const uint8_t *p_node_id = ln_their_node_id(self);
 
     //clientとして接続したときの接続先情報があれば、そこに接続する
-    daemon_connect_t last_peer_conn;
+    peer_conn_t last_peer_conn;
     if (p2p_cli_load_peer_conn(&last_peer_conn, p_node_id)) {
         bool ret = ucoind_nodefail_get(last_peer_conn.node_id, last_peer_conn.ipaddr, last_peer_conn.port, LN_NODEDESC_IPV4);
         if (!ret) {

--- a/ucoind/monitoring.c
+++ b/ucoind/monitoring.c
@@ -390,6 +390,21 @@ static bool channel_reconnect(ln_self_t *self, uint32_t confm, void *p_db_param)
 
     const uint8_t *p_node_id = ln_their_node_id(self);
 
+    //clientとして接続したときの接続先情報があれば、そこに接続する
+    daemon_connect_t last_peer_conn;
+    if (p2p_cli_load_peer_conn(&last_peer_conn, p_node_id)) {
+        bool ret = ucoind_nodefail_get(last_peer_conn.node_id, last_peer_conn.ipaddr, last_peer_conn.port, LN_NODEDESC_IPV4);
+        if (!ret) {
+            misc_msleep(10 + rand() % 2000);
+            int retval = cmd_json_connect(last_peer_conn.node_id, last_peer_conn.ipaddr, last_peer_conn.port);
+            LOGD("retval=%d\n", retval);
+            if (retval == 0) {
+                return false;
+            }
+        }
+    }
+
+    //node_announcementで通知されたアドレスに接続する
     ln_node_announce_t anno;
     bool ret = ln_node_search_nodeanno(&anno, p_node_id);
     if (ret) {

--- a/ucoind/p2p_cli.c
+++ b/ucoind/p2p_cli.c
@@ -48,7 +48,7 @@
 
 static lnapp_conf_t     mAppConf[SZ_SOCK_CLIENT_MAX];
 
-static daemon_connect_t mLastPeerConn;
+static peer_conn_t mLastPeerConn;
 pthread_mutex_t mMuxLastPeerConn = PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP;
 
 
@@ -70,7 +70,7 @@ void p2p_cli_init(void)
 }
 
 
-bool p2p_cli_start(const daemon_connect_t *pConn, jrpc_context *ctx)
+bool p2p_cli_start(const peer_conn_t *pConn, jrpc_context *ctx)
 {
     bool bret = false;
     int ret;
@@ -244,7 +244,7 @@ bool p2p_cli_is_looping(void)
 }
 
 
-bool p2p_cli_store_peer_conn(const daemon_connect_t* pPeerConn)
+bool p2p_cli_store_peer_conn(const peer_conn_t* pPeerConn)
 {
     pthread_mutex_lock(&mMuxLastPeerConn);
     mLastPeerConn = *pPeerConn;
@@ -254,7 +254,7 @@ bool p2p_cli_store_peer_conn(const daemon_connect_t* pPeerConn)
 }
 
 
-bool p2p_cli_load_peer_conn(daemon_connect_t* pPeerConn, const uint8_t *pNodeId)
+bool p2p_cli_load_peer_conn(peer_conn_t* pPeerConn, const uint8_t *pNodeId)
 {
     bool ret = false;
 


### PR DESCRIPTION
lightning-integrationのtest_reconnect[ucoind_lightning]がpassしなかった件に関する修正。
- 対向の`node_announcement`に`addresses`がなかった場合でも、自分がclientであれば前回アプリから渡された接続先に接続する。実際には後者の試行を先に行なっている（ref. `channel_reconnect()`）
- TCPのコネクション確立ができなくても、対向nodeをブラックリストに入れない。`noise_handshake()`が失敗したらブラックリスト入りだったのを、その前に`wait_peer_connected()`を行い、それに失敗したときはブラックリストに入れない。