### PR TITLE
invoice: min_final_cltv_expiry

### DIFF
--- a/ucoin/include/segwit_addr.h
+++ b/ucoin/include/segwit_addr.h
@@ -132,12 +132,13 @@ bool ln_invoice_decode(ln_invoice_t **pp_invoice_data, const char* invoice);
  * @param[in]       Expiry          invoice expiry
  * @param[in]       pFieldR
  * @param[in]       FieldRNum       pFieldR数
+ * @param[in]       MinFinalCltvExpiry  min_final_cltv_expiry
  * @retval      true        成功
  * @attention
  *      - ppInoviceはmalloc()で確保するため、、使用後にfree()すること
  */
 bool ln_invoice_create(char **ppInvoice, uint8_t Type, const uint8_t *pPayHash, uint64_t Amount, uint32_t Expiry,
-                        const ln_fieldr_t *pFieldR, uint8_t FieldRNum);
+                        const ln_fieldr_t *pFieldR, uint8_t FieldRNum, uint32_t MinFinalCltvExpiry);
 
 #ifdef __cplusplus
 }

--- a/ucoin/src/bech32/segwit_addr.c
+++ b/ucoin/src/bech32/segwit_addr.c
@@ -690,7 +690,7 @@ LABEL_EXIT:
 
 
 bool ln_invoice_create(char **ppInvoice, uint8_t Type, const uint8_t *pPayHash, uint64_t Amount, uint32_t Expiry,
-                        const ln_fieldr_t *pFieldR, uint8_t FieldRNum)
+                        const ln_fieldr_t *pFieldR, uint8_t FieldRNum, uint32_t MinFinalCltvExpiry)
 {
     ln_invoice_t *p_invoice_data;
 
@@ -702,7 +702,7 @@ bool ln_invoice_create(char **ppInvoice, uint8_t Type, const uint8_t *pPayHash, 
     p_invoice_data->hrp_type = Type;
     p_invoice_data->amount_msat = Amount;
     p_invoice_data->expiry = Expiry;
-    p_invoice_data->min_final_cltv_expiry = LN_MIN_FINAL_CLTV_EXPIRY;
+    p_invoice_data->min_final_cltv_expiry = MinFinalCltvExpiry;
     memcpy(p_invoice_data->pubkey, ln_node_getid(), UCOIN_SZ_PUBKEY);
     memcpy(p_invoice_data->payment_hash, pPayHash, LN_SZ_HASH);
     p_invoice_data->r_field_num = FieldRNum;

--- a/ucoincli/ucoincli.c
+++ b/ucoincli/ucoincli.c
@@ -393,17 +393,23 @@ static void optfunc_invoice(int *pOption, bool *pConn)
     M_CHK_INIT
 
     errno = 0;
-    uint64_t amount = (uint64_t)strtoull(optarg, NULL, 10);
+    const char *param = strtok(optarg, ",");
+    uint64_t amount = (uint64_t)strtoull(param, NULL, 10);
+    uint32_t min_final_cltv_expiry = 0;
     if (errno == 0) {
+        param = strtok(NULL, ",");
+        if ((param != NULL) && (*param != '\0')) {
+            min_final_cltv_expiry = (uint32_t)strtoul(param, NULL, 10);
+        }
         snprintf(mBuf, BUFFER_SIZE,
             "{"
                 M_STR("method", "invoice") M_NEXT
                 M_QQ("params") ":[ "
                     //invoice
-                    "%" PRIu64
+                    "%" PRIu64 ",%" PRIu32
                 " ]"
             "}",
-                amount);
+                amount, min_final_cltv_expiry);
 
         *pOption = M_OPTIONS_EXEC;
     } else {


### PR DESCRIPTION
invoice生成の際、min_final_cltv_expiryの設定を可能にする。

`ucoincli -i AMOUNT_MSAT,MIN_FINAL_CLTV_EXPIRY`