### PR TITLE
Use `$(MAKE)` instead of `make`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 _build/
 _ggtest/
-/libs/
+/libs/*/
 /ucoin/libs/
 /install/
 /tests/

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
 INSTALL_DIR = $(CURDIR)/install
 
 default:
-	make -C ucoin
-	make -C ucoind
-	make -C ucoincli
-	make -C showdb
-	make -C routing
+	$(MAKE) -C ucoin
+	$(MAKE) -C ucoind
+	$(MAKE) -C ucoincli
+	$(MAKE) -C showdb
+	$(MAKE) -C routing
 	mkdir -p $(INSTALL_DIR)
 	-@rm -rf $(INSTALL_DIR)/ucoind $(INSTALL_DIR)/ucoincli $(INSTALL_DIR)/showdb
 	cp ucoind/ucoind $(INSTALL_DIR)/
@@ -16,11 +16,11 @@ default:
 all: lib default
 
 clean:
-	make -C ucoin clean
-	make -C ucoind clean
-	make -C ucoincli clean
-	make -C showdb clean
-	make -C routing clean
+	$(MAKE) -C ucoin clean
+	$(MAKE) -C ucoind clean
+	$(MAKE) -C ucoincli clean
+	$(MAKE) -C showdb clean
+	$(MAKE) -C routing clean
 	-@rm -rf $(INSTALL_DIR)/ucoind $(INSTALL_DIR)/ucoincli $(INSTALL_DIR)/showdb $(INSTALL_DIR)/routing GPATH GRTAGS GSYMS GTAGS
 
 full: git_subs lib default
@@ -28,19 +28,19 @@ full: git_subs lib default
 distclean: lib_clean clean
 
 update:
-	make -C ucoin clean
-	make clean
-	make default
+	$(MAKE) -C ucoin clean
+	$(MAKE) clean
+	$(MAKE) default
 
 lib:
-	make -C ucoin/libs
-	make -C libs
-	make -C ucoin
+	$(MAKE) -C ucoin/libs
+	$(MAKE) -C libs
+	$(MAKE) -C ucoin
 
 lib_clean:
-	make -C ucoin/libs clean
-	make -C libs clean
-	make -C ucoin clean
+	$(MAKE) -C ucoin/libs clean
+	$(MAKE) -C libs clean
+	$(MAKE) -C ucoin clean
 
 git_subs:
 	git submodule update --init --recursive

--- a/libs/Makefile
+++ b/libs/Makefile
@@ -10,15 +10,15 @@ mk_install:
 	@mkdir -p $(INSTALL_DIR)/lib
 
 mk_jsonrpc_c:
-	cd jsonrpc-c; autoreconf -i ; ./configure --prefix=$(INSTALL_DIR) --disable-shared ; make CFLAGS=-DCHECK_LOCALHOST LDFLAGS=-lm ; make install ; cd ..
+	cd jsonrpc-c; autoreconf -i ; ./configure --prefix=$(INSTALL_DIR) --disable-shared ; $(MAKE) CFLAGS=-DCHECK_LOCALHOST LDFLAGS=-lm ; $(MAKE) install ; cd ..
 
 mk_inih:
-	cd inih/extra ; EXTRACCFLAGS="-g -O2 -D'INI_INLINE_COMMENT_PREFIXES=\"#\"' -DINI_STOP_ON_FIRST_ERROR=1" make -f Makefile.static ; cd ../..
+	cd inih/extra ; EXTRACCFLAGS="-g -O2 -D'INI_INLINE_COMMENT_PREFIXES=\"#\"' -DINI_STOP_ON_FIRST_ERROR=1" $(MAKE) -f Makefile.static ; cd ../..
 	@cp inih/extra/libinih.a $(INSTALL_DIR)/lib
 	@mkdir -p $(INSTALL_DIR)/include/inih
 	@cp inih/ini.h $(INSTALL_DIR)/include/inih/
 
 clean:
-	-make -C jsonrpc-c clean
-	-make -C inih/extra -f Makefile.static clean
+	-$(MAKE) -C jsonrpc-c clean
+	-$(MAKE) -C inih/extra -f Makefile.static clean
 	-$(RM) -rf $(INSTALL_DIR)

--- a/ucoin/Makefile
+++ b/ucoin/Makefile
@@ -162,7 +162,7 @@ vpath %.cpp $(CPP_PATHS)
 OBJECTS = $(C_OBJECTS) $(CPP_OBJECTS)
 
 lib:
-	make -C libs
+	$(MAKE) -C libs
 
 debug: CFLAGS_CMN += -DDEBUG -DUCOIN_DEBUG
 debug: CFLAGS_CMN += -ggdb3 -O0


### PR DESCRIPTION
GNU make が `gmake` `gnumake` になっているような、推奨ビルド環境外を考慮する"おまじない"です。