### PR TITLE
Update mbedtls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 2018/07/28
+
+* library update
+  * MbedTLS v2.12.0
+
 ## 2018/07/27
 
 * DB version : -20

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ git pull
 make
 ```
 
-#### NOTICE
+#### after change DB version
 
 * Updating `ptarmigan` sometimes changes the version of internal DB data.  
   In that case, delete previous `dbptarm` directory(if you need close, execute `ptarmcli -x`).

--- a/ptarm/gtests/test_ptarm.cpp
+++ b/ptarm/gtests/test_ptarm.cpp
@@ -43,6 +43,11 @@ class ptarm: public testing::Test {
 
 ////////////////////////////////////////////////////////////////////////
 
+TEST_F(ptarm, first)
+{
+    //plog_init_stderr();
+}
+
 TEST_F(ptarm, ptarm_setnet_testnet_false)
 {
     bool ret = ptarm_init(PTARM_TESTNET, false);

--- a/ptarm/gtests/testinc_ln_bolt8.cpp
+++ b/ptarm/gtests/testinc_ln_bolt8.cpp
@@ -57,9 +57,10 @@ TEST_F(bolt8test, initiator)
 
     ln_node_setkey(LS_PRIV);
 
+    ln_enc_auth_init(&self);
     ret = ln_enc_auth_handshake_init(&self, RS_PUB);
     ASSERT_TRUE(ret);
-    struct bolt8 *pBolt = (struct bolt8 *)self.p_handshake;
+    struct bolt8_t *pBolt = (struct bolt8_t *)self.p_handshake;
     ASSERT_EQ(START_INITIATOR, pBolt->state);
     ASSERT_TRUE(ln_enc_auth_handshake_state(&self));
 
@@ -157,6 +158,7 @@ TEST_F(bolt8test, initiator)
 
     ret = ln_enc_auth_handshake_recv(&self, &buf);
     ASSERT_FALSE(ret);
+    ln_enc_auth_term(&self);
 }
 
 
@@ -189,9 +191,10 @@ TEST_F(bolt8test, initiator_fail_act2_short_read)
 
     ln_node_setkey(LS_PRIV);
 
+    ln_enc_auth_init(&self);
     ret = ln_enc_auth_handshake_init(&self, RS_PUB);
     ASSERT_TRUE(ret);
-    struct bolt8 *pBolt = (struct bolt8 *)self.p_handshake;
+    struct bolt8_t *pBolt = (struct bolt8_t *)self.p_handshake;
     ASSERT_EQ(START_INITIATOR, pBolt->state);
 
     //ephemeralの差し替え
@@ -252,6 +255,7 @@ TEST_F(bolt8test, initiator_fail_act2_short_read)
 
     ret = ln_enc_auth_handshake_recv(&self, &buf);
     ASSERT_FALSE(ret);
+    ln_enc_auth_term(&self);
 }
 
 
@@ -284,9 +288,10 @@ TEST_F(bolt8test, initiator_fail_act2_bad_version)
 
     ln_node_setkey(LS_PRIV);
 
+    ln_enc_auth_init(&self);
     ret = ln_enc_auth_handshake_init(&self, RS_PUB);
     ASSERT_TRUE(ret);
-    struct bolt8 *pBolt = (struct bolt8 *)self.p_handshake;
+    struct bolt8_t *pBolt = (struct bolt8_t *)self.p_handshake;
     ASSERT_EQ(START_INITIATOR, pBolt->state);
 
     //ephemeralの差し替え
@@ -347,6 +352,7 @@ TEST_F(bolt8test, initiator_fail_act2_bad_version)
 
     ret = ln_enc_auth_handshake_recv(&self, &buf);
     ASSERT_FALSE(ret);
+    ln_enc_auth_term(&self);
 }
 
 
@@ -379,9 +385,10 @@ TEST_F(bolt8test, initiator_fail_act2_bad_key_serialization)
 
     ln_node_setkey(LS_PRIV);
 
+    ln_enc_auth_init(&self);
     ret = ln_enc_auth_handshake_init(&self, RS_PUB);
     ASSERT_TRUE(ret);
-    struct bolt8 *pBolt = (struct bolt8 *)self.p_handshake;
+    struct bolt8_t *pBolt = (struct bolt8_t *)self.p_handshake;
     ASSERT_EQ(START_INITIATOR, pBolt->state);
 
     //ephemeralの差し替え
@@ -442,6 +449,7 @@ TEST_F(bolt8test, initiator_fail_act2_bad_key_serialization)
 
     ret = ln_enc_auth_handshake_recv(&self, &buf);
     ASSERT_FALSE(ret);
+    ln_enc_auth_term(&self);
 }
 
 
@@ -474,9 +482,10 @@ TEST_F(bolt8test, initiator_fail_act2_bad_mac)
 
     ln_node_setkey(LS_PRIV);
 
+    ln_enc_auth_init(&self);
     ret = ln_enc_auth_handshake_init(&self, RS_PUB);
     ASSERT_TRUE(ret);
-    struct bolt8 *pBolt = (struct bolt8 *)self.p_handshake;
+    struct bolt8_t *pBolt = (struct bolt8_t *)self.p_handshake;
     ASSERT_EQ(START_INITIATOR, pBolt->state);
 
     //ephemeralの差し替え
@@ -537,6 +546,7 @@ TEST_F(bolt8test, initiator_fail_act2_bad_mac)
 
     ret = ln_enc_auth_handshake_recv(&self, &buf);
     ASSERT_FALSE(ret);
+    ln_enc_auth_term(&self);
 }
 
 
@@ -555,9 +565,10 @@ TEST_F(bolt8test, responder)
 
     ln_node_setkey(LS_PRIV);
 
+    ln_enc_auth_init(&self);
     ret = ln_enc_auth_handshake_init(&self, NULL);
     ASSERT_TRUE(ret);
-    struct bolt8 *pBolt = (struct bolt8 *)self.p_handshake;
+    struct bolt8_t *pBolt = (struct bolt8_t *)self.p_handshake;
     ASSERT_EQ(WAIT_ACT_ONE, pBolt->state);
     ASSERT_TRUE(ln_enc_auth_handshake_state(&self));
 
@@ -655,6 +666,7 @@ TEST_F(bolt8test, responder)
 
     ret = ln_enc_auth_handshake_recv(&self, &buf);
     ASSERT_FALSE(ret);
+    ln_enc_auth_term(&self);
 }
 
 
@@ -674,9 +686,10 @@ TEST_F(bolt8test, responder_act1_short_read)
 
     ln_node_setkey(LS_PRIV);
 
+    ln_enc_auth_init(&self);
     ret = ln_enc_auth_handshake_init(&self, NULL);
     ASSERT_TRUE(ret);
-    struct bolt8 *pBolt = (struct bolt8 *)self.p_handshake;
+    struct bolt8_t *pBolt = (struct bolt8_t *)self.p_handshake;
     ASSERT_EQ(WAIT_ACT_ONE, pBolt->state);
 
     //ephemeralの差し替え
@@ -717,6 +730,7 @@ TEST_F(bolt8test, responder_act1_short_read)
 
     ret = ln_enc_auth_handshake_recv(&self, &buf);
     ASSERT_FALSE(ret);
+    ln_enc_auth_term(&self);
 }
 
 
@@ -736,9 +750,10 @@ TEST_F(bolt8test, responder_act1_bad_version)
 
     ln_node_setkey(LS_PRIV);
 
+    ln_enc_auth_init(&self);
     ret = ln_enc_auth_handshake_init(&self, NULL);
     ASSERT_TRUE(ret);
-    struct bolt8 *pBolt = (struct bolt8 *)self.p_handshake;
+    struct bolt8_t *pBolt = (struct bolt8_t *)self.p_handshake;
     ASSERT_EQ(WAIT_ACT_ONE, pBolt->state);
 
     //ephemeralの差し替え
@@ -780,6 +795,7 @@ TEST_F(bolt8test, responder_act1_bad_version)
 
     ret = ln_enc_auth_handshake_recv(&self, &buf);
     ASSERT_FALSE(ret);
+    ln_enc_auth_term(&self);
 }
 
 
@@ -799,9 +815,10 @@ TEST_F(bolt8test, responder_act1_bad_key_serialization)
 
     ln_node_setkey(LS_PRIV);
 
+    ln_enc_auth_init(&self);
     ret = ln_enc_auth_handshake_init(&self, NULL);
     ASSERT_TRUE(ret);
-    struct bolt8 *pBolt = (struct bolt8 *)self.p_handshake;
+    struct bolt8_t *pBolt = (struct bolt8_t *)self.p_handshake;
     ASSERT_EQ(WAIT_ACT_ONE, pBolt->state);
 
     //ephemeralの差し替え
@@ -843,6 +860,7 @@ TEST_F(bolt8test, responder_act1_bad_key_serialization)
 
     ret = ln_enc_auth_handshake_recv(&self, &buf);
     ASSERT_FALSE(ret);
+    ln_enc_auth_term(&self);
 }
 
 
@@ -862,9 +880,10 @@ TEST_F(bolt8test, responder_act1_bad_mac)
 
     ln_node_setkey(LS_PRIV);
 
+    ln_enc_auth_init(&self);
     ret = ln_enc_auth_handshake_init(&self, NULL);
     ASSERT_TRUE(ret);
-    struct bolt8 *pBolt = (struct bolt8 *)self.p_handshake;
+    struct bolt8_t *pBolt = (struct bolt8_t *)self.p_handshake;
     ASSERT_EQ(WAIT_ACT_ONE, pBolt->state);
 
     //ephemeralの差し替え
@@ -906,6 +925,7 @@ TEST_F(bolt8test, responder_act1_bad_mac)
 
     ret = ln_enc_auth_handshake_recv(&self, &buf);
     ASSERT_FALSE(ret);
+    ln_enc_auth_term(&self);
 }
 
 
@@ -925,9 +945,10 @@ TEST_F(bolt8test, responder_act3_bad_version)
 
     ln_node_setkey(LS_PRIV);
 
+    ln_enc_auth_init(&self);
     ret = ln_enc_auth_handshake_init(&self, NULL);
     ASSERT_TRUE(ret);
-    struct bolt8 *pBolt = (struct bolt8 *)self.p_handshake;
+    struct bolt8_t *pBolt = (struct bolt8_t *)self.p_handshake;
     ASSERT_EQ(WAIT_ACT_ONE, pBolt->state);
 
     //ephemeralの差し替え
@@ -1003,6 +1024,7 @@ TEST_F(bolt8test, responder_act3_bad_version)
 
     ret = ln_enc_auth_handshake_recv(&self, &buf);
     ASSERT_FALSE(ret);
+    ln_enc_auth_term(&self);
 }
 
 
@@ -1022,9 +1044,10 @@ TEST_F(bolt8test, responder_act3_short_read)
 
     ln_node_setkey(LS_PRIV);
 
+    ln_enc_auth_init(&self);
     ret = ln_enc_auth_handshake_init(&self, NULL);
     ASSERT_TRUE(ret);
-    struct bolt8 *pBolt = (struct bolt8 *)self.p_handshake;
+    struct bolt8_t *pBolt = (struct bolt8_t *)self.p_handshake;
     ASSERT_EQ(WAIT_ACT_ONE, pBolt->state);
 
     //ephemeralの差し替え
@@ -1100,6 +1123,7 @@ TEST_F(bolt8test, responder_act3_short_read)
 
     ret = ln_enc_auth_handshake_recv(&self, &buf);
     ASSERT_FALSE(ret);
+    ln_enc_auth_term(&self);
 }
 
 
@@ -1119,9 +1143,10 @@ TEST_F(bolt8test, responder_act3_bad_mac_cipher)
 
     ln_node_setkey(LS_PRIV);
 
+    ln_enc_auth_init(&self);
     ret = ln_enc_auth_handshake_init(&self, NULL);
     ASSERT_TRUE(ret);
-    struct bolt8 *pBolt = (struct bolt8 *)self.p_handshake;
+    struct bolt8_t *pBolt = (struct bolt8_t *)self.p_handshake;
     ASSERT_EQ(WAIT_ACT_ONE, pBolt->state);
 
     //ephemeralの差し替え
@@ -1197,6 +1222,7 @@ TEST_F(bolt8test, responder_act3_bad_mac_cipher)
 
     ret = ln_enc_auth_handshake_recv(&self, &buf);
     ASSERT_FALSE(ret);
+    ln_enc_auth_term(&self);
 }
 
 
@@ -1216,9 +1242,10 @@ TEST_F(bolt8test, responder_act3_bad_rs)
 
     ln_node_setkey(LS_PRIV);
 
+    ln_enc_auth_init(&self);
     ret = ln_enc_auth_handshake_init(&self, NULL);
     ASSERT_TRUE(ret);
-    struct bolt8 *pBolt = (struct bolt8 *)self.p_handshake;
+    struct bolt8_t *pBolt = (struct bolt8_t *)self.p_handshake;
     ASSERT_EQ(WAIT_ACT_ONE, pBolt->state);
 
     //ephemeralの差し替え
@@ -1294,6 +1321,7 @@ TEST_F(bolt8test, responder_act3_bad_rs)
 
     ret = ln_enc_auth_handshake_recv(&self, &buf);
     ASSERT_FALSE(ret);
+    ln_enc_auth_term(&self);
 }
 
 
@@ -1313,9 +1341,10 @@ TEST_F(bolt8test, responder_act3_bad_mac)
 
     ln_node_setkey(LS_PRIV);
 
+    ln_enc_auth_init(&self);
     ret = ln_enc_auth_handshake_init(&self, NULL);
     ASSERT_TRUE(ret);
-    struct bolt8 *pBolt = (struct bolt8 *)self.p_handshake;
+    struct bolt8_t *pBolt = (struct bolt8_t *)self.p_handshake;
     ASSERT_EQ(WAIT_ACT_ONE, pBolt->state);
 
     //ephemeralの差し替え
@@ -1391,6 +1420,7 @@ TEST_F(bolt8test, responder_act3_bad_mac)
 
     ret = ln_enc_auth_handshake_recv(&self, &buf);
     ASSERT_FALSE(ret);
+    ln_enc_auth_term(&self);
 }
 
 
@@ -1418,6 +1448,9 @@ TEST_F(bolt8test, enc_dec)
         0x0b, 0xcf, 0x11, 0x1e, 0xd8, 0xd5, 0x88, 0xca,
         0xf9, 0xab, 0x4b, 0xe7, 0x16, 0xe4, 0x2b, 0x01,
     };
+    ln_enc_auth_init(&self);
+    ln_enc_auth_init(&self_dec);
+
     memcpy(self.noise_send.key, SK, sizeof(SK));
     memcpy(self.noise_recv.key, RK, sizeof(RK));
     memcpy(self.noise_send.ck, CK, sizeof(CK));
@@ -1658,5 +1691,6 @@ TEST_F(bolt8test, enc_dec)
     ASSERT_EQ(1001, count);
 
     ptarm_buf_free(&bufin);
+    ln_enc_auth_term(&self_dec);
+    ln_enc_auth_term(&self);
 }
-

--- a/ptarm/include/ln.h
+++ b/ptarm/include/ln.h
@@ -995,7 +995,7 @@ typedef struct {
  */
 struct ln_self_t {
     uint8_t                     peer_node_id[PTARM_SZ_PUBKEY];  ///< 接続先ノード
-    uint8_t                     status;
+    ln_status_t                 status;
 
     ln_self_priv_t              priv_data;
 
@@ -1072,6 +1072,7 @@ struct ln_self_t {
     ln_noise_t                  noise_send;                     ///< noise protocol
     ln_noise_t                  noise_recv;                     ///< noise protocol
     void                        *p_handshake;
+    void                        *p_chacha_poly;                 ///< ChaCha20-Poly1305 context
 
     //last error
     int                         err;                            ///< error code(ln_err.h)

--- a/ptarm/libs/Makefile
+++ b/ptarm/libs/Makefile
@@ -26,6 +26,11 @@ mk_mbedtls:
 	cp mbedtls/library/libmbedcrypto.a $(INSTALL_DIR)/lib/
 	cp -ra mbedtls/include/* $(INSTALL_DIR)/include/
 
+clean_mbedtls:
+	-make -C mbedtls clean
+
+mbedtls_all: clean_mbedtls mk_mbedtls
+
 clean:
 	-make -C libbase58 clean
 	-make -C libsodium clean

--- a/ptarm/libs/mbedtls_config/check_config.h
+++ b/ptarm/libs/mbedtls_config/check_config.h
@@ -87,6 +87,11 @@
 #error "MBEDTLS_CMAC_C defined, but not all prerequisites"
 #endif
 
+#if defined(MBEDTLS_NIST_KW_C) && \
+    ( !defined(MBEDTLS_AES_C) || !defined(MBEDTLS_CIPHER_C) )
+#error "MBEDTLS_NIST_KW_C defined, but not all prerequisites"
+#endif
+
 #if defined(MBEDTLS_ECDH_C) && !defined(MBEDTLS_ECP_C)
 #error "MBEDTLS_ECDH_C defined, but not all prerequisites"
 #endif

--- a/ptarm/libs/mbedtls_config/config-ptarm.h
+++ b/ptarm/libs/mbedtls_config/config-ptarm.h
@@ -89,6 +89,28 @@
 //#define MBEDTLS_NO_UDBL_DIVISION
 
 /**
+ * \def MBEDTLS_NO_64BIT_MULTIPLICATION
+ *
+ * The platform lacks support for 32x32 -> 64-bit multiplication.
+ *
+ * Used in:
+ *      library/poly1305.c
+ *
+ * Some parts of the library may use multiplication of two unsigned 32-bit
+ * operands with a 64-bit result in order to speed up computations. On some
+ * platforms, this is not available in hardware and has to be implemented in
+ * software, usually in a library provided by the toolchain.
+ *
+ * Sometimes it is not desirable to have to link to that library. This option
+ * removes the dependency of that library on platforms that lack a hardware
+ * 64-bit multiplier by embedding a software implementation in Mbed TLS.
+ *
+ * Note that depending on the compiler, this may decrease performance compared
+ * to using the library function provided by the toolchain.
+ */
+#define MBEDTLS_NO_64BIT_MULTIPLICATION
+
+/**
  * \def MBEDTLS_HAVE_SSE2
  *
  * CPU supports SSE2 instruction set.
@@ -279,14 +301,18 @@
 //#define MBEDTLS_BLOWFISH_ALT
 //#define MBEDTLS_CAMELLIA_ALT
 //#define MBEDTLS_CCM_ALT
+//#define MBEDTLS_CHACHA20_ALT
+//#define MBEDTLS_CHACHAPOLY_ALT
 //#define MBEDTLS_CMAC_ALT
 //#define MBEDTLS_DES_ALT
 //#define MBEDTLS_DHM_ALT
 //#define MBEDTLS_ECJPAKE_ALT
 //#define MBEDTLS_GCM_ALT
+//#define MBEDTLS_NIST_KW_ALT
 //#define MBEDTLS_MD2_ALT
 //#define MBEDTLS_MD4_ALT
 //#define MBEDTLS_MD5_ALT
+//#define MBEDTLS_POLY1305_ALT
 //#define MBEDTLS_RIPEMD160_ALT
 //#define MBEDTLS_RSA_ALT
 //#define MBEDTLS_SHA1_ALT
@@ -1945,6 +1971,26 @@
 #define MBEDTLS_CERTS_C
 
 /**
+ * \def MBEDTLS_CHACHA20_C
+ *
+ * Enable the ChaCha20 stream cipher.
+ *
+ * Module:  library/chacha20.c
+ */
+#define MBEDTLS_CHACHA20_C
+
+/**
+ * \def MBEDTLS_CHACHAPOLY_C
+ *
+ * Enable the ChaCha20-Poly1305 AEAD algorithm.
+ *
+ * Module:  library/chachapoly.c
+ *
+ * This module requires: MBEDTLS_CHACHA20_C, MBEDTLS_POLY1305_C
+ */
+#define MBEDTLS_CHACHAPOLY_C
+
+/**
  * \def MBEDTLS_CIPHER_C
  *
  * Enable the generic cipher layer.
@@ -2202,6 +2248,19 @@
  * Uncomment to enable the HMAC_DRBG random number geerator.
  */
 #define MBEDTLS_HMAC_DRBG_C
+
+/**
+ * \def MBEDTLS_NIST_KW_C
+ *
+ * Enable the Key Wrapping mode for 128-bit block ciphers,
+ * as defined in NIST SP 800-38F. Only KW and KWP modes
+ * are supported. At the moment, only AES is approved by NIST.
+ *
+ * Module:  library/nist_kw.c
+ *
+ * Requires: MBEDTLS_AES_C and MBEDTLS_CIPHER_C
+ */
+//#define MBEDTLS_NIST_KW_C
 
 /**
  * \def MBEDTLS_MD_C
@@ -2485,6 +2544,16 @@
  * This module enables abstraction of common (libc) functions.
  */
 #define MBEDTLS_PLATFORM_C
+
+/**
+ * \def MBEDTLS_POLY1305_C
+ *
+ * Enable the Poly1305 MAC algorithm.
+ *
+ * Module:  library/poly1305.c
+ * Caller:  library/chachapoly.c
+ */
+#define MBEDTLS_POLY1305_C
 
 /**
  * \def MBEDTLS_RIPEMD160_C
@@ -2896,7 +2965,51 @@
 //#define MBEDTLS_SSL_CACHE_DEFAULT_MAX_ENTRIES      50 /**< Maximum entries in cache */
 
 /* SSL options */
-//#define MBEDTLS_SSL_MAX_CONTENT_LEN             16384 /**< Maxium fragment length in bytes, determines the size of each of the two internal I/O buffers */
+
+/** \def MBEDTLS_SSL_MAX_CONTENT_LEN
+ *
+ * Maximum fragment length in bytes.
+ *
+ * Determines the size of both the incoming and outgoing TLS I/O buffers.
+ *
+ * Uncommenting MBEDTLS_SSL_IN_CONTENT_LEN and/or MBEDTLS_SSL_OUT_CONTENT_LEN
+ * will override this length by setting maximum incoming and/or outgoing
+ * fragment length, respectively.
+ */
+//#define MBEDTLS_SSL_MAX_CONTENT_LEN             16384
+
+/** \def MBEDTLS_SSL_IN_CONTENT_LEN
+ *
+ * Maximum incoming fragment length in bytes.
+ *
+ * Uncomment to set the size of the inward TLS buffer independently of the
+ * outward buffer.
+ */
+//#define MBEDTLS_SSL_IN_CONTENT_LEN              16384
+
+/** \def MBEDTLS_SSL_OUT_CONTENT_LEN
+ *
+ * Maximum outgoing fragment length in bytes.
+ *
+ * Uncomment to set the size of the outward TLS buffer independently of the
+ * inward buffer.
+ *
+ * It is possible to save RAM by setting a smaller outward buffer, while keeping
+ * the default inward 16384 byte buffer to conform to the TLS specification.
+ *
+ * The minimum required outward buffer size is determined by the handshake
+ * protocol's usage. Handshaking will fail if the outward buffer is too small.
+ * The specific size requirement depends on the configured ciphers and any
+ * certificate data which is sent during the handshake.
+ *
+ * For absolute minimum RAM usage, it's best to enable
+ * MBEDTLS_SSL_MAX_FRAGMENT_LENGTH and reduce MBEDTLS_SSL_MAX_CONTENT_LEN. This
+ * reduces both incoming and outgoing buffer sizes. However this is only
+ * guaranteed if the other end of the connection also supports the TLS
+ * max_fragment_len extension. Otherwise the connection may fail.
+ */
+//#define MBEDTLS_SSL_OUT_CONTENT_LEN             16384
+
 //#define MBEDTLS_SSL_DEFAULT_TICKET_LIFETIME     86400 /**< Lifetime of session tickets (if enabled) */
 //#define MBEDTLS_PSK_MAX_LEN               32 /**< Max size of TLS pre-shared keys, in bytes (default 256 bits) */
 //#define MBEDTLS_SSL_COOKIE_TIMEOUT        60 /**< Default expiration delay of DTLS cookies, in seconds if HAVE_TIME, or in number of cookies issued */
@@ -2973,7 +3086,7 @@
 /* \} name SECTION: Customisation configuration options */
 
 /* Target and application specific configurations */
-//#define YOTTA_CFG_MBEDTLS_TARGET_CONFIG_FILE "mbedtls/target_config.h"
+//#define YOTTA_CFG_MBEDTLS_TARGET_CONFIG_FILE "target_config.h"
 
 #if defined(TARGET_LIKE_MBED) && defined(YOTTA_CFG_MBEDTLS_TARGET_CONFIG_FILE)
 #include YOTTA_CFG_MBEDTLS_TARGET_CONFIG_FILE

--- a/ptarm/src/inc/ln/ln_enc_auth.h
+++ b/ptarm/src/inc/ln/ln_enc_auth.h
@@ -33,6 +33,18 @@
  * prototypes
  ********************************************************************/
 
+/** noise protocol初期化
+ * 
+ */
+void HIDDEN ln_enc_auth_init(ln_self_t *self);
+
+
+/** noise protocol停止
+ * 
+ */
+void HIDDEN ln_enc_auth_term(ln_self_t *self);
+
+
 /** noise handshake初期化
  *
  * @param[in,out]       self        channel情報

--- a/ptarm/src/ln/ln.c
+++ b/ptarm/src/ln/ln.c
@@ -409,6 +409,8 @@ bool ln_init(ln_self_t *self, const uint8_t *pSeed, const ln_anno_prm_t *pAnnoPr
     self->commit_local.commit_num = 0;
     self->commit_remote.commit_num = 0;
 
+    ln_enc_auth_init(self);
+
     LOGD("END\n");
 
     return true;
@@ -424,13 +426,14 @@ void ln_term(ln_self_t *self)
         self->cnl_add_htlc[idx].p_onion_route = NULL;
         ptarm_buf_free(&self->cnl_add_htlc[idx].shared_secret);
     }
+    ln_enc_auth_term(self);
     //LOGD("END\n");
 }
 
 
 void ln_set_status(ln_self_t *self, ln_status_t Status)
 {
-    LOGD("status: %02x --> %02x\n", self->status, Status);
+    LOGD("status: %02x --> %02x\n", (uint8_t)self->status, Status);
     self->status = Status;
     M_DB_SELF_SAVE(self);
 }

--- a/update_libs.sh
+++ b/update_libs.sh
@@ -34,4 +34,4 @@ cd ../ptarm/libs
 func_upd libbase58 https://github.com/luke-jr/libbase58.git master
 func_tag libsodium https://github.com/jedisct1/libsodium.git master 1.0.16
 func_tag lmdb https://github.com/LMDB/lmdb.git mdb.master LMDB_0.9.22
-func_tag mbedtls https://github.com/ARMmbed/mbedtls.git development mbedtls-2.11.0
+func_tag mbedtls https://github.com/ARMmbed/mbedtls.git development mbedtls-2.12.0


### PR DESCRIPTION
update MbedTLS

* MbedTLS v2.12.0
* Noise Protocol: libsodium --> MbedTLS

## NOTE

* onionプロトコルでChaCha20(original)を使っているため、libsodiumは残している