### PR TITLE
fix #640

### DIFF
--- a/ptarm/include/ln.h
+++ b/ptarm/include/ln.h
@@ -1184,10 +1184,12 @@ void ln_free_establish(ln_self_t *self);
  * @param[in]           Index           funding_txのTXIDが入っているindex
  * @param[in]           FundingIndex    funding_tx vout in channel
  * @param[in]           pMinedHash      funding_txがマイニングされたblock hash
+ * @retval  true    OK
+ * @retval  false   short_channel_idに0以外が代入済みで、結果が異なる
  * @note
  *      - #LN_CB_FUNDINGTX_WAIT でコールバックされた後、安定後に呼び出すこと
  */
-void ln_set_short_channel_id_param(ln_self_t *self, uint32_t Height, uint32_t Index, uint32_t FundingIndex, const uint8_t *pMinedHash);
+bool ln_set_short_channel_id_param(ln_self_t *self, uint32_t Height, uint32_t Index, uint32_t FundingIndex, const uint8_t *pMinedHash);
 
 
 /** short_channel_id情報取得

--- a/ptarm/src/inc/ln/ln_msg_anno.h
+++ b/ptarm/src/inc/ln/ln_msg_anno.h
@@ -146,6 +146,8 @@ uint64_t HIDDEN ln_msg_announce_signs_read_short_cnl_id(const uint8_t *pData, ui
  * @param[in]       pData   対象データ
  * @param[in]       Len     pData長
  * @retval  true    成功
+ * @note
+ *      pMsg->short_channel_idに0以外を設定しておくと、不一致時にfalseを返す
  */
 bool HIDDEN ln_msg_announce_signs_read(ln_announce_signs_t *pMsg, const uint8_t *pData, uint16_t Len);
 
@@ -154,5 +156,11 @@ bool HIDDEN ln_msg_announce_signs_read(ln_announce_signs_t *pMsg, const uint8_t 
  *
  */
 void HIDDEN ln_msg_get_anno_signs(ln_self_t *self, uint8_t **pp_sig_node, uint8_t **pp_sig_btc, bool bLocal, ptarm_keys_sort_t Sort);
+
+
+/** short_channel_id書き換え
+ * 
+ */
+bool HIDDEN ln_msg_cnl_announce_update_short_cnl_id(ln_self_t *self, uint64_t ShortChannelId, ptarm_keys_sort_t Sort);
 
 #endif /* LN_MSG_ANNO_H__ */

--- a/ptarm/src/ln/ln_db_lmdb.c
+++ b/ptarm/src/ln/ln_db_lmdb.c
@@ -1213,7 +1213,7 @@ bool ln_db_annocnl_save(const ptarm_buf_t *pCnlAnno, uint64_t ShortChannelId, co
         //DB保存されていない＝新規channel
         retval = annocnl_save(&db, pCnlAnno, ShortChannelId);
     } else {
-        LOGV("exist channel_announcement: %0" PRIx64 "\n", ShortChannelId);
+        LOGV("exist channel_announcement: %016" PRIx64 "\n", ShortChannelId);
         if (!ptarm_buf_cmp(&buf_ann, pCnlAnno)) {
             LOGD("fail: different channel_announcement\n");
             retval = -1;
@@ -1437,7 +1437,7 @@ bool ln_db_annocnls_add_nodeid(void *pDb, uint64_t ShortChannelId, char Type, bo
         if (retval == 0) {
             detect = annoinfo_search(&data, pSendId);
         } else {
-            LOGV("new reg[%" PRIx64 ":%c] ", ShortChannelId, Type);
+            LOGV("new reg[%016" PRIx64 ":%c] ", ShortChannelId, Type);
             DUMPV(pSendId, PTARM_SZ_PUBKEY);
             data.mv_size = 0;
         }

--- a/ptarm/src/ln/ln_enc_auth.c
+++ b/ptarm/src/ln/ln_enc_auth.c
@@ -111,6 +111,7 @@ static bool actthree_receiver(ln_self_t *self, ptarm_buf_t *pBuf);
 void HIDDEN ln_enc_auth_init(ln_self_t *self)
 {
 #ifdef M_USE_SODIUM
+    (void)self;
 #else
     self->p_chacha_poly = M_MALLOC(sizeof(mbedtls_chachapoly_context));
     mbedtls_chachapoly_context *p_ctx = (mbedtls_chachapoly_context *)self->p_chacha_poly;
@@ -122,6 +123,7 @@ void HIDDEN ln_enc_auth_init(ln_self_t *self)
 void HIDDEN ln_enc_auth_term(ln_self_t *self)
 {
 #ifdef M_USE_SODIUM
+    (void)self;
 #else
     mbedtls_chachapoly_context *p_ctx = (mbedtls_chachapoly_context *)self->p_chacha_poly;
     mbedtls_chachapoly_free(p_ctx);
@@ -281,7 +283,7 @@ bool HIDDEN ln_enc_auth_enc(ln_self_t *self, ptarm_buf_t *pBufEnc, const ptarm_b
     mbedtls_chachapoly_context *p_ctx = (mbedtls_chachapoly_context *)self->p_chacha_poly;
     rc = mbedtls_chachapoly_setkey(p_ctx, self->noise_send.key);
     if (rc != 0) {
-        LOGD("fail: mbedtls_chachapoly_setkey rc=%d\n", rc);
+        LOGD("fail: mbedtls_chachapoly_setkey rc=-%04x\n", -rc);
         goto LABEL_EXIT;
     }
     rc = mbedtls_chachapoly_encrypt_and_tag(p_ctx,
@@ -292,7 +294,7 @@ bool HIDDEN ln_enc_auth_enc(ln_self_t *self, ptarm_buf_t *pBufEnc, const ptarm_b
                     cl,                 //output
                     cl + sizeof(l));    //MAC
     if (rc != 0) {
-        LOGD("fail: mbedtls_chachapoly_encrypt_and_tag rc=%d\n", rc);
+        LOGD("fail: mbedtls_chachapoly_encrypt_and_tag rc=-%04x\n", -rc);
         goto LABEL_EXIT;
     }
 #endif
@@ -318,7 +320,7 @@ bool HIDDEN ln_enc_auth_enc(ln_self_t *self, ptarm_buf_t *pBufEnc, const ptarm_b
 #else
     rc = mbedtls_chachapoly_setkey(p_ctx, self->noise_send.key);
     if (rc != 0) {
-        LOGD("fail: mbedtls_chachapoly_setkey rc=%d\n", rc);
+        LOGD("fail: mbedtls_chachapoly_setkey rc=-%04x\n", -rc);
         goto LABEL_EXIT;
     }
     rc = mbedtls_chachapoly_encrypt_and_tag(p_ctx,
@@ -329,7 +331,7 @@ bool HIDDEN ln_enc_auth_enc(ln_self_t *self, ptarm_buf_t *pBufEnc, const ptarm_b
                     cm,                 //output
                     cm + pBufIn->len);  //MAC
     if (rc != 0) {
-        LOGD("fail: mbedtls_chachapoly_encrypt_and_tag rc=%d\n", rc);
+        LOGD("fail: mbedtls_chachapoly_encrypt_and_tag rc=-%04x\n", -rc);
         goto LABEL_EXIT;
     }
 #endif
@@ -391,7 +393,7 @@ uint16_t HIDDEN ln_enc_auth_dec_len(ln_self_t *self, const uint8_t *pData, uint1
     mbedtls_chachapoly_context *p_ctx = (mbedtls_chachapoly_context *)self->p_chacha_poly;
     rc = mbedtls_chachapoly_setkey(p_ctx, self->noise_recv.key);
     if (rc != 0) {
-        LOGD("fail: mbedtls_chachapoly_setkey rc=%d\n", rc);
+        LOGD("fail: mbedtls_chachapoly_setkey rc=-%04x\n", -rc);
         goto LABEL_EXIT;
     }
     rc = mbedtls_chachapoly_auth_decrypt(p_ctx,
@@ -402,7 +404,7 @@ uint16_t HIDDEN ln_enc_auth_dec_len(ln_self_t *self, const uint8_t *pData, uint1
                     pData,                  //input
                     pl);                    //output
     if (rc != 0) {
-        LOGD("fail: mbedtls_chachapoly_auth_decrypt rc=%d\n", rc);
+        LOGD("fail: mbedtls_chachapoly_auth_decrypt rc=-%04x\n", -rc);
         goto LABEL_EXIT;
     }
 #endif
@@ -449,7 +451,7 @@ bool HIDDEN ln_enc_auth_dec_msg(ln_self_t *self, ptarm_buf_t *pBuf)
     mbedtls_chachapoly_context *p_ctx = (mbedtls_chachapoly_context *)self->p_chacha_poly;
     rc = mbedtls_chachapoly_setkey(p_ctx, self->noise_recv.key);
     if (rc != 0) {
-        LOGD("fail: mbedtls_chachapoly_setkey rc=%d\n", rc);
+        LOGD("fail: mbedtls_chachapoly_setkey rc=-%04x\n", -rc);
         goto LABEL_EXIT;
     }
     rc = mbedtls_chachapoly_auth_decrypt(p_ctx,
@@ -460,7 +462,7 @@ bool HIDDEN ln_enc_auth_dec_msg(ln_self_t *self, ptarm_buf_t *pBuf)
                     pBuf->buf,          //input
                     pm);                //output
     if (rc != 0) {
-        LOGD("fail: mbedtls_chachapoly_auth_decrypt rc=%d\n", rc);
+        LOGD("fail: mbedtls_chachapoly_auth_decrypt rc=-%04x\n", -rc);
         goto LABEL_EXIT;
     }
 
@@ -577,7 +579,7 @@ static bool actone_sender(ln_self_t *self, ptarm_buf_t *pBuf, const uint8_t *pRS
     mbedtls_chachapoly_context *p_ctx = (mbedtls_chachapoly_context *)self->p_chacha_poly;
     rc = mbedtls_chachapoly_setkey(p_ctx, pBolt->temp_k);
     if (rc != 0) {
-        LOGD("fail: mbedtls_chachapoly_setkey rc=%d\n", rc);
+        LOGD("fail: mbedtls_chachapoly_setkey rc=-%04x\n", -rc);
         goto LABEL_EXIT;
     }
     rc = mbedtls_chachapoly_encrypt_and_tag(p_ctx,
@@ -588,7 +590,7 @@ static bool actone_sender(ln_self_t *self, ptarm_buf_t *pBuf, const uint8_t *pRS
                     NULL,                           //output
                     c);                             //MAC
     if (rc != 0) {
-        LOGD("fail: mbedtls_chachapoly_encrypt_and_tag rc=%d\n", rc);
+        LOGD("fail: mbedtls_chachapoly_encrypt_and_tag rc=-%04x\n", -rc);
         goto LABEL_EXIT;
     }
 #endif
@@ -655,7 +657,7 @@ static bool actone_receiver(ln_self_t *self, ptarm_buf_t *pBuf)
     mbedtls_chachapoly_context *p_ctx = (mbedtls_chachapoly_context *)self->p_chacha_poly;
     rc = mbedtls_chachapoly_setkey(p_ctx, pBolt->temp_k);
     if (rc != 0) {
-        LOGD("fail: mbedtls_chachapoly_setkey rc=%d\n", rc);
+        LOGD("fail: mbedtls_chachapoly_setkey rc=-%04x\n", -rc);
         goto LABEL_EXIT;
     }
     rc = mbedtls_chachapoly_auth_decrypt(p_ctx,
@@ -666,7 +668,7 @@ static bool actone_receiver(ln_self_t *self, ptarm_buf_t *pBuf)
                     NULL,               //input
                     p);                 //output
     if (rc != 0) {
-        LOGD("fail: mbedtls_chachapoly_auth_decrypt rc=%d\n", rc);
+        LOGD("fail: mbedtls_chachapoly_auth_decrypt rc=-%04x\n", -rc);
         goto LABEL_EXIT;
     }
 #endif
@@ -717,7 +719,7 @@ static bool acttwo_sender(ln_self_t *self, ptarm_buf_t *pBuf, const uint8_t *pRE
     mbedtls_chachapoly_context *p_ctx = (mbedtls_chachapoly_context *)self->p_chacha_poly;
     rc = mbedtls_chachapoly_setkey(p_ctx, pBolt->temp_k);
     if (rc != 0) {
-        LOGD("fail: mbedtls_chachapoly_setkey rc=%d\n", rc);
+        LOGD("fail: mbedtls_chachapoly_setkey rc=-%04x\n", -rc);
         goto LABEL_EXIT;
     }
     rc = mbedtls_chachapoly_encrypt_and_tag(p_ctx,
@@ -728,7 +730,7 @@ static bool acttwo_sender(ln_self_t *self, ptarm_buf_t *pBuf, const uint8_t *pRE
                     NULL,                           //output
                     c);                             //MAC
     if (rc != 0) {
-        LOGD("fail: mbedtls_chachapoly_encrypt_and_tag rc=%d\n", rc);
+        LOGD("fail: mbedtls_chachapoly_encrypt_and_tag rc=-%04x\n", -rc);
         goto LABEL_EXIT;
     }
 #endif
@@ -794,7 +796,7 @@ static bool acttwo_receiver(ln_self_t *self, ptarm_buf_t *pBuf)
     mbedtls_chachapoly_context *p_ctx = (mbedtls_chachapoly_context *)self->p_chacha_poly;
     rc = mbedtls_chachapoly_setkey(p_ctx, pBolt->temp_k);
     if (rc != 0) {
-        LOGD("fail: mbedtls_chachapoly_setkey rc=%d\n", rc);
+        LOGD("fail: mbedtls_chachapoly_setkey rc=-%04x\n", -rc);
         goto LABEL_EXIT;
     }
     memset(p, 0, sizeof(p));
@@ -806,7 +808,7 @@ static bool acttwo_receiver(ln_self_t *self, ptarm_buf_t *pBuf)
                     NULL,                       //input
                     p);                         //output
     if (rc != 0) {
-        LOGD("fail: mbedtls_chachapoly_auth_decrypt rc=%d\n", rc);
+        LOGD("fail: mbedtls_chachapoly_auth_decrypt rc=-%04x\n", -rc);
         goto LABEL_EXIT;
     }
 #endif
@@ -851,7 +853,7 @@ static bool actthree_sender(ln_self_t *self, ptarm_buf_t *pBuf, const uint8_t *p
     mbedtls_chachapoly_context *p_ctx = (mbedtls_chachapoly_context *)self->p_chacha_poly;
     rc = mbedtls_chachapoly_setkey(p_ctx, pBolt->temp_k);
     if (rc != 0) {
-        LOGD("fail: mbedtls_chachapoly_setkey rc=%d\n", rc);
+        LOGD("fail: mbedtls_chachapoly_setkey rc=-%04x\n", -rc);
         goto LABEL_EXIT;
     }
     rc = mbedtls_chachapoly_encrypt_and_tag(p_ctx,
@@ -862,7 +864,7 @@ static bool actthree_sender(ln_self_t *self, ptarm_buf_t *pBuf, const uint8_t *p
                     c,                              //output
                     c + PTARM_SZ_PUBKEY);           //MAC
     if (rc != 0) {
-        LOGD("fail: mbedtls_chachapoly_encrypt_and_tag rc=%d\n", rc);
+        LOGD("fail: mbedtls_chachapoly_encrypt_and_tag rc=-%04x\n", -rc);
         goto LABEL_EXIT;
     }
 #endif
@@ -892,7 +894,7 @@ static bool actthree_sender(ln_self_t *self, ptarm_buf_t *pBuf, const uint8_t *p
 #else
     rc = mbedtls_chachapoly_setkey(p_ctx, pBolt->temp_k);
     if (rc != 0) {
-        LOGD("fail: mbedtls_chachapoly_setkey rc=%d\n", rc);
+        LOGD("fail: mbedtls_chachapoly_setkey rc=-%04x\n", -rc);
         goto LABEL_EXIT;
     }
     rc = mbedtls_chachapoly_encrypt_and_tag(p_ctx,
@@ -903,7 +905,7 @@ static bool actthree_sender(ln_self_t *self, ptarm_buf_t *pBuf, const uint8_t *p
                     NULL,                           //output
                     t);                             //MAC
     if (rc != 0) {
-        LOGD("fail: mbedtls_chachapoly_encrypt_and_tag rc=%d\n", rc);
+        LOGD("fail: mbedtls_chachapoly_encrypt_and_tag rc=-%04x\n", -rc);
         goto LABEL_EXIT;
     }
 #endif
@@ -963,7 +965,7 @@ static bool actthree_receiver(ln_self_t *self, ptarm_buf_t *pBuf)
     mbedtls_chachapoly_context *p_ctx = (mbedtls_chachapoly_context *)self->p_chacha_poly;
     rc = mbedtls_chachapoly_setkey(p_ctx, pBolt->temp_k);
     if (rc != 0) {
-        LOGD("fail: mbedtls_chachapoly_setkey rc=%d\n", rc);
+        LOGD("fail: mbedtls_chachapoly_setkey rc=-%04x\n", -rc);
         goto LABEL_EXIT;
     }
     rc = mbedtls_chachapoly_auth_decrypt(p_ctx,
@@ -974,7 +976,7 @@ static bool actthree_receiver(ln_self_t *self, ptarm_buf_t *pBuf)
                     c,                          //input
                     rs);                        //output
     if (rc != 0) {
-        LOGD("fail: mbedtls_chachapoly_auth_decrypt rc=%d\n", rc);
+        LOGD("fail: mbedtls_chachapoly_auth_decrypt rc=-%04x\n", -rc);
         goto LABEL_EXIT;
     }
 #endif
@@ -1006,7 +1008,7 @@ static bool actthree_receiver(ln_self_t *self, ptarm_buf_t *pBuf)
 #else
     rc = mbedtls_chachapoly_setkey(p_ctx, pBolt->temp_k);
     if (rc != 0) {
-        LOGD("fail: mbedtls_chachapoly_setkey rc=%d\n", rc);
+        LOGD("fail: mbedtls_chachapoly_setkey rc=-%04x\n", -rc);
         goto LABEL_EXIT;
     }
     rc = mbedtls_chachapoly_auth_decrypt(p_ctx,
@@ -1017,7 +1019,7 @@ static bool actthree_receiver(ln_self_t *self, ptarm_buf_t *pBuf)
                     NULL,                       //input
                     p);                         //output
     if (rc != 0) {
-        LOGD("fail: mbedtls_chachapoly_auth_decrypt rc=%d\n", rc);
+        LOGD("fail: mbedtls_chachapoly_auth_decrypt rc=-%04x\n", -rc);
         goto LABEL_EXIT;
     }
 #endif

--- a/ptarm/src/ln/ln_msg_anno.c
+++ b/ptarm/src/ln/ln_msg_anno.c
@@ -42,12 +42,14 @@
  * macros
  ********************************************************************/
 
-//#define DBG_PRINT_CREATE_CNL
-//#define DBG_PRINT_READ_CNL
-//#define DBG_PRINT_CREATE_NOD
-//#define DBG_PRINT_READ_NOD
-//#define DBG_PRINT_CREATE_UPD
-//#define DBG_PRINT_READ_UPD
+#ifdef DEVELOPER_MODE
+#define DBG_PRINT_CREATE_CNL
+#define DBG_PRINT_READ_CNL
+#define DBG_PRINT_CREATE_NOD
+#define DBG_PRINT_READ_NOD
+#define DBG_PRINT_CREATE_UPD
+#define DBG_PRINT_READ_UPD
+#endif
 #define DBG_PRINT_CREATE_SIG
 #define DBG_PRINT_READ_SIG
 
@@ -83,6 +85,7 @@ static const uint8_t M_ADDRLEN2[] = { 0, 6, 18, 12, 37 };    //port考慮
  * prototypes
  **************************************************************************/
 
+static bool cnl_announce_sign(const ln_self_t *self, uint8_t *pData, uint16_t Len, ptarm_keys_sort_t Sort);
 static bool cnl_announce_ptr(cnl_announce_ptr_t *pPtr, const uint8_t *pData, uint16_t Len);
 
 #if defined(DBG_PRINT_CREATE_NOD) || defined(DBG_PRINT_READ_NOD)
@@ -160,20 +163,17 @@ bool HIDDEN ln_msg_cnl_announce_create(const ln_self_t *self, ptarm_buf_t *pBuf,
     const uint8_t *p_node_2;
     const uint8_t *p_btc_1;
     const uint8_t *p_btc_2;
-    int offset_sig;
     if (pMsg->sort == PTARM_KEYS_SORT_ASC) {
         //自ノードが先
         p_node_1 = pMsg->p_my_node_pub;
         p_node_2 = pMsg->p_peer_node_pub;
         p_btc_1 = pMsg->p_my_funding_pub;
         p_btc_2 = pMsg->p_peer_funding_pub;
-        offset_sig = 0;
     } else {
         p_node_1 = pMsg->p_peer_node_pub;
         p_node_2 = pMsg->p_my_node_pub;
         p_btc_1 = pMsg->p_peer_funding_pub;
         p_btc_2 = pMsg->p_my_funding_pub;
-        offset_sig = LN_SZ_SIGNATURE;
     }
     //        [33:node_id_1]
     ptarm_push_data(&proto, p_node_1, PTARM_SZ_PUBKEY);
@@ -191,38 +191,15 @@ bool HIDDEN ln_msg_cnl_announce_create(const ln_self_t *self, ptarm_buf_t *pBuf,
 
     ptarm_push_trim(&proto);
 
-    //署名-node
-    uint8_t hash[PTARM_SZ_HASH256];
-    bool ret;
-
-    ptarm_util_hash256(hash, pBuf->buf + sizeof(uint16_t) + LN_SZ_SIGNATURE * 4,
-                                pBuf->len - (sizeof(uint16_t) + LN_SZ_SIGNATURE * 4));
-    //LOGD("hash=");
-    //DUMPD(hash, PTARM_SZ_HASH256);
-
-    ret = ln_node_sign_nodekey(pBuf->buf + sizeof(uint16_t) + offset_sig, hash);
-    if (!ret) {
-        LOGD("fail: sign node\n");
-        goto LABEL_EXIT;
-    }
-
-    //署名-btc
-    ret = ln_signer_sign_rs(pBuf->buf + sizeof(uint16_t) + offset_sig + LN_SZ_SIGNATURE * 2,
-                    hash, &self->priv_data, MSG_FUNDIDX_FUNDING);
-    if (!ret) {
-        LOGD("fail: sign btc\n");
-        goto LABEL_EXIT;
-    }
-
-LABEL_EXIT:
-#ifdef DBG_PRINT_CREATE_CNL
-    LOGD("@@@@@ %s @@@@@\n", __func__);
+    bool ret = cnl_announce_sign(self, pBuf->buf, pBuf->len, pMsg->sort);
     if (ret) {
+#ifdef DBG_PRINT_CREATE_CNL
+        LOGD("short_channel_id=%" PRIx64 "\n", pMsg->short_channel_id);
         ln_msg_cnl_announce_print(pBuf->buf, pBuf->len);
+#endif  //DBG_PRINT_CREATE_CNL
     } else {
         LOGD("something error\n");
     }
-#endif  //DBG_PRINT_CREATE_CNL
 
     return ret;
 }
@@ -250,6 +227,12 @@ bool ln_msg_cnl_announce_read(ln_cnl_announce_read_t *pMsg, const uint8_t *pData
         memcpy(pMsg->btc_key1, ptr.p_btc_key1, PTARM_SZ_PUBKEY);
         memcpy(pMsg->btc_key2, ptr.p_btc_key2, PTARM_SZ_PUBKEY);
         pMsg->short_channel_id = ptr.short_channel_id;
+#ifdef DBG_PRINT_READ_CNL
+        LOGD("short_channel_id=%016" PRIx64 "\n", pMsg->short_channel_id);
+        ln_msg_cnl_announce_print(pData, Len);
+#endif
+    } else {
+        LOGD("something error\n");
     }
 
     return ret;
@@ -293,77 +276,6 @@ bool HIDDEN ln_msg_cnl_announce_verify(const uint8_t *pData, uint16_t Len)
 }
 
 
-static bool cnl_announce_ptr(cnl_announce_ptr_t *pPtr, const uint8_t *pData, uint16_t Len)
-{
-    int pos = sizeof(uint16_t);
-
-    //        [64:node_signature_1]
-    pPtr->p_node_signature1 = pData + pos;
-    pos += LN_SZ_SIGNATURE;
-
-    //        [64:node_signature_2]
-    pPtr->p_node_signature2 = pData + pos;
-    pos += LN_SZ_SIGNATURE;
-
-    //        [64:bitcoin_signature_1]
-    pPtr->p_btc_signature1 = pData + pos;
-    pos += LN_SZ_SIGNATURE;
-
-    //        [64:bitcoin_signature_2]
-    pPtr->p_btc_signature2 = pData + pos;
-    pos += LN_SZ_SIGNATURE;
-
-    //        [2:len]
-    uint16_t len = ln_misc_get16be(pData + pos);
-    pos += sizeof(len);
-
-    //        [len:features]
-    if (len > 0) {
-        LOGD("features(%d): ", len);
-        DUMPD(pData + pos, len);
-        pos += len;
-    }
-
-    //    [32:chain_hash]
-    int cmp = memcmp(gGenesisChainHash, pData + pos, sizeof(gGenesisChainHash));
-    if (cmp != 0) {
-        LOGD("fail: chain_hash mismatch\n");
-        LOGD("node: ");
-        DUMPD(gGenesisChainHash, LN_SZ_HASH);
-        LOGD("msg:  ");
-        DUMPD(pData + pos, LN_SZ_HASH);
-        return false;
-    }
-    pos += sizeof(gGenesisChainHash);
-
-    //        [8:short_channel_id]
-    pPtr->short_channel_id = ln_misc_get64be(pData + pos);
-    if (pPtr->short_channel_id == 0) {
-        LOGD("fail: short_channel_id == 0\n");
-        return false;
-    }
-    pos += LN_SZ_SHORT_CHANNEL_ID;
-
-    //        [33:node_id_1]
-    pPtr->p_node_id1 = pData + pos;
-    pos += PTARM_SZ_PUBKEY;
-
-    //        [33:node_id_2]
-    pPtr->p_node_id2 = pData + pos;
-    pos += PTARM_SZ_PUBKEY;
-
-    //        [33:bitcoin_key_1]
-    pPtr->p_btc_key1 = pData + pos;
-    pos += PTARM_SZ_PUBKEY;
-
-    //        [33:bitcoin_key_2]
-    pPtr->p_btc_key2 = pData + pos;
-    pos += PTARM_SZ_PUBKEY;
-
-    return Len == pos;
-}
-
-
 void HIDDEN ln_msg_cnl_announce_print(const uint8_t *pData, uint16_t Len)
 {
 #ifdef PTARM_DEBUG
@@ -372,6 +284,7 @@ void HIDDEN ln_msg_cnl_announce_print(const uint8_t *pData, uint16_t Len)
     uint16_t type = ln_misc_get16be(pData);
     if (type != MSGTYPE_CHANNEL_ANNOUNCEMENT) {
         LOGD("fail: type not match: %04x\n", type);
+        DUMPD(pData, Len);
         return;
     }
     int pos = sizeof(uint16_t);
@@ -469,7 +382,132 @@ void HIDDEN ln_msg_get_anno_signs(ln_self_t *self, uint8_t **pp_sig_node, uint8_
     }
     *pp_sig_btc = *pp_sig_node + LN_SZ_SIGNATURE * 2;
 
-    ln_msg_cnl_announce_print(self->cnl_anno.buf, self->cnl_anno.len);
+    // ln_msg_cnl_announce_print(self->cnl_anno.buf, self->cnl_anno.len);
+}
+
+
+bool HIDDEN ln_msg_cnl_announce_update_short_cnl_id(ln_self_t *self, uint64_t ShortChannelId, ptarm_keys_sort_t Sort)
+{
+    uint8_t *pData = self->cnl_anno.buf;
+    int pos = sizeof(uint16_t) + LN_SZ_SIGNATURE * 4;
+    //        [2:len]
+    uint16_t len = ln_misc_get16be(pData + pos);
+    pos += sizeof(len) + len + PTARM_SZ_SHA256;
+    //        [8:short_channel_id]
+    for (size_t lp = 0; lp < sizeof(uint64_t); lp++) {
+        *(pData + pos + sizeof(uint64_t) - 1 - lp) = (uint8_t)ShortChannelId;
+        ShortChannelId >>= 8;
+    }
+
+    return cnl_announce_sign(self, self->cnl_anno.buf, self->cnl_anno.len, Sort);
+}
+
+
+static bool cnl_announce_sign(const ln_self_t *self, uint8_t *pData, uint16_t Len, ptarm_keys_sort_t Sort)
+{
+    int offset_sig;
+    if (Sort == PTARM_KEYS_SORT_ASC) {
+        //自ノードが先
+        offset_sig = 0;
+    } else {
+        offset_sig = LN_SZ_SIGNATURE;
+    }
+
+    //署名-node
+    uint8_t hash[PTARM_SZ_HASH256];
+    bool ret;
+
+    ptarm_util_hash256(hash, pData + sizeof(uint16_t) + LN_SZ_SIGNATURE * 4,
+                                Len - (sizeof(uint16_t) + LN_SZ_SIGNATURE * 4));
+    //LOGD("hash=");
+    //DUMPD(hash, PTARM_SZ_HASH256);
+
+    ret = ln_node_sign_nodekey(pData + sizeof(uint16_t) + offset_sig, hash);
+    if (!ret) {
+        LOGD("fail: sign node\n");
+        goto LABEL_EXIT;
+    }
+
+    //署名-btc
+    ret = ln_signer_sign_rs(pData + sizeof(uint16_t) + offset_sig + LN_SZ_SIGNATURE * 2,
+                    hash, &self->priv_data, MSG_FUNDIDX_FUNDING);
+    if (!ret) {
+        LOGD("fail: sign btc\n");
+        //goto LABEL_EXIT;
+    }
+
+LABEL_EXIT:
+    return ret;
+}
+
+
+static bool cnl_announce_ptr(cnl_announce_ptr_t *pPtr, const uint8_t *pData, uint16_t Len)
+{
+    int pos = sizeof(uint16_t);
+
+    //        [64:node_signature_1]
+    pPtr->p_node_signature1 = pData + pos;
+    pos += LN_SZ_SIGNATURE;
+
+    //        [64:node_signature_2]
+    pPtr->p_node_signature2 = pData + pos;
+    pos += LN_SZ_SIGNATURE;
+
+    //        [64:bitcoin_signature_1]
+    pPtr->p_btc_signature1 = pData + pos;
+    pos += LN_SZ_SIGNATURE;
+
+    //        [64:bitcoin_signature_2]
+    pPtr->p_btc_signature2 = pData + pos;
+    pos += LN_SZ_SIGNATURE;
+
+    //        [2:len]
+    uint16_t len = ln_misc_get16be(pData + pos);
+    pos += sizeof(len);
+
+    //        [len:features]
+    if (len > 0) {
+        LOGD("features(%d): ", len);
+        DUMPD(pData + pos, len);
+        pos += len;
+    }
+
+    //    [32:chain_hash]
+    int cmp = memcmp(gGenesisChainHash, pData + pos, sizeof(gGenesisChainHash));
+    if (cmp != 0) {
+        LOGD("fail: chain_hash mismatch\n");
+        LOGD("node: ");
+        DUMPD(gGenesisChainHash, LN_SZ_HASH);
+        LOGD("msg:  ");
+        DUMPD(pData + pos, LN_SZ_HASH);
+        return false;
+    }
+    pos += sizeof(gGenesisChainHash);
+
+    //        [8:short_channel_id]
+    pPtr->short_channel_id = ln_misc_get64be(pData + pos);
+    if (pPtr->short_channel_id == 0) {
+        LOGD("fail: short_channel_id == 0\n");
+    }
+    pos += LN_SZ_SHORT_CHANNEL_ID;
+
+    //        [33:node_id_1]
+    pPtr->p_node_id1 = pData + pos;
+    pos += PTARM_SZ_PUBKEY;
+
+    //        [33:node_id_2]
+    pPtr->p_node_id2 = pData + pos;
+    pos += PTARM_SZ_PUBKEY;
+
+    //        [33:bitcoin_key_1]
+    pPtr->p_btc_key1 = pData + pos;
+    pos += PTARM_SZ_PUBKEY;
+
+    //        [33:bitcoin_key_2]
+    pPtr->p_btc_key2 = pData + pos;
+    pos += PTARM_SZ_PUBKEY;
+
+    return Len == pos;
 }
 
 
@@ -1004,7 +1042,13 @@ bool HIDDEN ln_msg_announce_signs_read(ln_announce_signs_t *pMsg, const uint8_t 
     pos += LN_SZ_CHANNEL_ID;
 
     //        [8:short_channel_id]
-    pMsg->short_channel_id = ln_misc_get64be(pData + pos);
+    uint64_t short_channel_id = ln_misc_get64be(pData + pos);
+    if (pMsg->short_channel_id == 0) {
+        pMsg->short_channel_id = short_channel_id;
+    } else if (pMsg->short_channel_id != short_channel_id) {
+        LOGD("fail: short_channel_id mismatch: %" PRIx64 " != %" PRIx64 "\n", pMsg->short_channel_id, short_channel_id);
+        return false;
+    }
     pos += LN_SZ_SHORT_CHANNEL_ID;
 
     //        [64:node_signature]

--- a/ptarmd/lnapp.c
+++ b/ptarmd/lnapp.c
@@ -1817,8 +1817,8 @@ static bool get_short_channel_id(lnapp_conf_t *p_conf)
     bool ret = btcrpc_get_short_channel_param(p_conf->p_self, &bheight, &bindex, mined_hash, ln_funding_txid(p_conf->p_self));
     if (ret) {
         //LOGD("bindex=%d, bheight=%d\n", bindex, bheight);
-        ln_set_short_channel_id_param(p_conf->p_self, bheight, bindex, ln_funding_txindex(p_conf->p_self), mined_hash);
-        LOGD("short_channel_id = %016" PRIx64 "\n", ln_short_channel_id(p_conf->p_self));
+        ret = ln_set_short_channel_id_param(p_conf->p_self, bheight, bindex, ln_funding_txindex(p_conf->p_self), mined_hash);
+        LOGD("short_channel_id = %016" PRIx64 "(%d)\n", ln_short_channel_id(p_conf->p_self), ret);
     }
 
     return ret;
@@ -2897,7 +2897,7 @@ static void stop_threads(lnapp_conf_t *p_conf)
         p_conf->loop = false;
         //mainloop待ち合わせ解除(*2)
         pthread_cond_signal(&p_conf->cond);
-        LOGD("disconnect channel: %" PRIx64 "\n", ln_short_channel_id(p_conf->p_self));
+        LOGD("disconnect channel: %016" PRIx64 "\n", ln_short_channel_id(p_conf->p_self));
         LOGD("===================================\n");
         LOGD("=  CHANNEL THREAD END             =\n");
         LOGD("===================================\n");
@@ -3107,7 +3107,7 @@ static bool send_announcement(lnapp_conf_t *p_conf)
             }
         } else {
             //channel_announcementが無いchannel_updateの場合
-            LOGD("skip channel_%c: last=%0" PRIx64 " / get=%0" PRIx64 "\n", type, p_conf->last_annocnl_sci, short_channel_id);
+            LOGD("skip channel_%c: last=%016" PRIx64 " / get=%016" PRIx64 "\n", type, p_conf->last_annocnl_sci, short_channel_id);
         }
         ptarm_buf_free(&buf_cnl);
     }


### PR DESCRIPTION
fix #640 

以下の順番で処理が進むと、`channel_announcement`のshort_channel_idが0になってしまう。

1. [recv]`funding_locked`
2. [recv]`announcement_signatures`
3. [send]`funding_locked`
4. [send]`announcement_signatures`