### PR TITLE
disable auto connect on `ptarmcli -q`

### DIFF
--- a/ptarmd/cmd_json.c
+++ b/ptarmd/cmd_json.c
@@ -339,6 +339,7 @@ static cJSON *cmd_stop(jrpc_context *ctx, cJSON *params, cJSON *id)
 
     cJSON *result = NULL;
 
+    monitor_disable_autoconn(true);
     int err = cmd_stop_proc();
     if (err == 0) {
         result = cJSON_CreateString("OK");


### PR DESCRIPTION
切断に時間がかかるチャネルがある場合、自動接続によって切断済みのチャネルに接続してしまう