### PR TITLE
ptarmcli RPC port number from DB

### DIFF
--- a/include/ptarmd.h
+++ b/include/ptarmd.h
@@ -317,12 +317,6 @@ void ptarmd_preimage_unlock(void);
 lnapp_conf_t *ptarmd_search_connected_cnl(uint64_t short_channel_id);
 
 
-/** ptarmd実行パス取得
- *
- */
-// const char *ptarmd_get_exec_path(void);
-
-
 /** ノード接続失敗リスト追加
  *
  */

--- a/ptarm/include/ln_db_lmdb.h
+++ b/ptarm/include/ln_db_lmdb.h
@@ -112,6 +112,13 @@ typedef struct {
 void ln_lmdb_set_path(const char *pPath);
 
 
+/**　DBディレクトリの存在チェック
+ * 
+ * @retval  true    カレントディレクトリにDBディレクトリがある
+ */
+bool ln_lmdb_have_dbdir(void);
+
+
 /** LMDB selfパス取得
  * 
  * @return  dbselfパス

--- a/ptarm/src/ln/ln_db_lmdb.c
+++ b/ptarm/src/ln/ln_db_lmdb.c
@@ -491,6 +491,14 @@ void ln_lmdb_set_path(const char *pPath)
 }
 
 
+bool ln_lmdb_have_dbdir(void)
+{
+    struct stat buf;
+    int retval = stat(M_DBDIR, &buf);
+    return (retval == 0) && S_ISDIR(buf.st_mode);
+}
+
+
 const char *ln_lmdb_get_selfpath(void)
 {
     return mPathSelf;

--- a/ptarmcli/ptarmcli.c
+++ b/ptarmcli/ptarmcli.c
@@ -31,6 +31,7 @@
 #include <jansson.h>
 
 #include "ptarmd.h"
+#include "ln_db_lmdb.h"
 #include "conf.h"
 #include "misc.h"
 #include "segwit_addr.h"
@@ -222,13 +223,21 @@ int main(int argc, char *argv[])
     if (conn) {
         connect_rpc();
     }
-
-    uint16_t port;
+    uint16_t port = 0;
     if (optind == argc) {
-        port = 9736;
+        if (ln_lmdb_have_dbdir()) {
+            (void)ln_node_init(0);
+            if (ln_node_addr()->port != 0) {
+                port = ln_node_addr()->port + 1;
+            }
+        }
+        if (port == 0) {
+            port = 9736;
+        }
     } else {
         port = (uint16_t)atoi(argv[optind]);
     }
+    fprintf(stderr, "RPC port=%d\n", port);
 
     int ret = msg_send(mBuf, mBuf, mAddr, port, mTcpSend);
 

--- a/ptarmd/ptarmd.c
+++ b/ptarmd/ptarmd.c
@@ -87,7 +87,6 @@ LIST_HEAD(nodefaillisthead_t, nodefaillist_t);
  ********************************************************************/
 
 static pthread_mutex_t      mMuxPreimage;
-// static char                 mExecPath[PATH_MAX];
 static struct nodefaillisthead_t    mNodeFailListHead;
 
 
@@ -232,15 +231,6 @@ int main(int argc, char *argv[])
             goto LABEL_EXIT;
         }
     }
-
-    //ptarmdがあるパスを取る("routepay"用)
-    // const char *p_delimit = strrchr(argv[0], '/');
-    // if (p_delimit != NULL) {
-    //     memcpy(mExecPath, argv[0], p_delimit - argv[0] + 1);
-    //     mExecPath[p_delimit - argv[0] + 1] = '\0';
-    // } else {
-    //     mExecPath[0] = '\0';
-    // }
 
     signal(SIGPIPE , SIG_IGN);   //ignore SIGPIPE
     p2p_cli_init();
@@ -402,12 +392,6 @@ lnapp_conf_t *ptarmd_search_connected_cnl(uint64_t short_channel_id)
     }
     return p_appconf;
 }
-
-
-// const char *ptarmd_get_exec_path(void)
-// {
-//     return mExecPath;
-// }
 
 
 // ptarmd 起動中に接続失敗したnodeを登録していく。


### PR DESCRIPTION
`ptarmcli` でポート番号未指定の場合、カレントディレクトリに `dbptarm` があるならば、そちらを使用する。