### PR TITLE
fix #669

### DIFF
--- a/ptarm/src/ln/ln.c
+++ b/ptarm/src/ln/ln.c
@@ -3218,6 +3218,11 @@ static bool recv_announcement_signatures(ln_self_t *self, const uint8_t *pData, 
     uint8_t *p_sig_node;
     uint8_t *p_sig_btc;
 
+    if (self->fund_flag == 0) {
+        LOGD("fail: not open peer\n");
+        return false;
+    }
+
     if (self->cnl_anno.buf == NULL) {
         create_local_channel_announcement(self);
     }


### PR DESCRIPTION
チャネルオープンしていないpeerからannouncement_signaturesを受信すると、署名検証に失敗する。