### PR TITLE
issue #546

### DIFF
--- a/ptarm/include/ln.h
+++ b/ptarm/include/ln.h
@@ -77,10 +77,8 @@ extern "C" {
 #define LN_FEE_COMMIT_BASE              (724ULL)    ///< commit_tx base fee
 
 // ln_update_add_htlc_t.flag用
-#define LN_HTLC_FLAG_IS_RECV(f)         ((f) & LN_HTLC_FLAG_RECV)   ///< true:Received HTLC / false:Offered HTLC
-#define LN_HTLC_FLAG_IS_COMMITTED(f)    ((f) & LN_HTLC_FLAG_COMMIT) ///< true:このHTLCに関するcommitment_signed受信済み
-#define LN_HTLC_FLAG_SEND               (0x00)                      ///< Offered HTLC(add_htlcを送信した)
-#define LN_HTLC_FLAG_RECV               (0x01)                      ///< Received HTLC(add_htlcを受信した)
+#define LN_HTLC_FLAG_SEND               (0x01)                      ///< Offered HTLC(add_htlcを送信した)
+#define LN_HTLC_FLAG_RECV               (0x02)                      ///< Received HTLC(add_htlcを受信した)
 #define LN_HTLC_FLAG_COMMIT             (0x80)                      ///< commitment_signed受信済み
 
 // channel_update.flags
@@ -1019,6 +1017,7 @@ struct ln_self_t {
 #ifndef USE_SPV
 #else
     uint8_t                     funding_bhash[PTARM_SZ_SHA256]; ///< funding_txがマイニングされたblock hash
+    uint32_t                    funding_bheight;                ///< funding_txがマイニングされたblock height
 #endif
     ln_establish_t              *p_establish;                   ///< Establishワーク領域
     uint32_t                    min_depth;                      ///< minimum_depth
@@ -1535,6 +1534,15 @@ bool ln_create_commit_signed(ln_self_t *self, ptarm_buf_t *pCommSig);
  * @param[in]           FeeratePerKw    更新後のfeerate_per_kw
  */
 bool ln_create_update_fee(ln_self_t *self, ptarm_buf_t *pUpdFee, uint32_t FeeratePerKw);
+
+
+/** HTLCを完了させる
+ *
+ * HTLCが残っている場合、解消に向けて動く。
+ *
+ * @param[in,out]       self            channel情報
+ */
+void ln_htlc_fulfillment(ln_self_t *self);
 
 
 /********************************************************************

--- a/ptarm/src/ln/ln_db_lmdb.c
+++ b/ptarm/src/ln/ln_db_lmdb.c
@@ -257,6 +257,7 @@ static const backup_param_t DBSELF_KEYS[] = {
 #ifndef USE_SPV
 #else
     M_ITEM(ln_self_t, funding_bhash),
+    M_ITEM(ln_self_t, funding_bheight),
 #endif
     //flck_flag: none
     //p_establish: none
@@ -602,7 +603,7 @@ bool HIDDEN ln_db_init(char *pWif, char *pNodeName, uint16_t *pPort)
         LOGD("FAIL: check version db\n");
         goto LABEL_EXIT;
     }
-    ln_db_invoice_drop();
+    //ln_db_invoice_drop();
     ln_db_annocnl_del_orphan();
 
 LABEL_EXIT:
@@ -1766,6 +1767,7 @@ bool ln_db_invoice_save(const char *pInvoice, uint64_t AddAmountMsat, const uint
         goto LABEL_EXIT;
     }
 
+    LOGD("\n");
     key.mv_size = LN_SZ_HASH;
     key.mv_data = (CONST_CAST uint8_t *)pPayHash;
     size_t len = strlen(pInvoice);
@@ -1928,6 +1930,7 @@ bool ln_db_invoice_drop(void)
         goto LABEL_EXIT;
     }
 
+    LOGD("\n");
     retval = mdb_drop(txn, dbi, 1);
     if (retval != 0) {
         LOGD("ERR: %s\n", mdb_strerror(retval));

--- a/showdb/showdb.c
+++ b/showdb/showdb.c
@@ -258,7 +258,7 @@ static void ln_print_self(const ln_self_t *self)
                 }
                 printf(INDENT4 "{\n");
                 printf(INDENT5 M_QQ("id") ": %" PRIu64 ",\n", self->cnl_add_htlc[lp].id);
-                printf(INDENT5 M_QQ("flag") ": " M_QQ("%s(%02x)") ",\n", ((LN_HTLC_FLAG_IS_RECV(self->cnl_add_htlc[lp].flag)) ? "Received" : "Offered"), self->cnl_add_htlc[lp].flag);
+                printf(INDENT5 M_QQ("flag") ": " M_QQ("%s(%02x)") ",\n", ((self->cnl_add_htlc[lp].flag & LN_HTLC_FLAG_RECV) ? "Received" : "Offered"), self->cnl_add_htlc[lp].flag);
                 printf(INDENT5 M_QQ("amount_msat") ": %" PRIu64 ",\n", self->cnl_add_htlc[lp].amount_msat);
                 printf(INDENT5 M_QQ("cltv_expiry") ": %" PRIu32 ",\n", self->cnl_add_htlc[lp].cltv_expiry);
                 printf(INDENT5 M_QQ("payhash") ": \"");


### PR DESCRIPTION
`commitment_number`と`revocation_number`から、HTLCの状態を割り出すように変更。

* 安定
* 状態1: update_add_htlc側がcommitment_signedを送信後
* 状態2: それに対してrevoke_and_ack返信後
* 状態3: 続けてcommitment_signed送信後
* 状態4(＝安定): それに対してrevoke_and_ack送信後

状態1の途中であればHTLCの追加をキャンセルし、それ以降は`commitment_signed`を再送する。