### PR TITLE
add opened flag

### DIFF
--- a/ptarm/include/ln.h
+++ b/ptarm/include/ln.h
@@ -191,6 +191,7 @@ typedef enum {
     LN_FUNDFLAG_ANNO_CH     = 0x02,     ///< open_channel.channel_flags.announce_channel
     LN_FUNDFLAG_FUNDING     = 0x04,     ///< 1:open_channel～funding_lockedまで
     LN_FUNDFLAG_CLOSE       = 0x08,     ///< 1:funding_txがspentになっている
+    LN_FUNDFLAG_OPENED      = 0x80      ///< 1:opened
 } ln_fundflag_t;
 
 

--- a/ptarm/src/ln/ln.c
+++ b/ptarm/src/ln/ln.c
@@ -5484,7 +5484,7 @@ static void free_establish(ln_self_t *self, bool bEndEstablish)
             LOGD("free\n");
         }
     }
-    self->fund_flag = (ln_fundflag_t)(self->fund_flag & ~LN_FUNDFLAG_FUNDING);
+    self->fund_flag = (ln_fundflag_t)((self->fund_flag & ~LN_FUNDFLAG_FUNDING) | LN_FUNDFLAG_OPENED);
 }
 
 


### PR DESCRIPTION
fix #676 

`self->fund_flag`にopen済み状態を追加。
funding状態だから、open前の状態やcloseのフラグを持つことも何らおかしくないはずだ。