### PR TITLE
move all submodules to libs/(2)

### DIFF
--- a/ptarm/examples/Makefile
+++ b/ptarm/examples/Makefile
@@ -15,8 +15,8 @@ INC_PATHS +=
 #COMMANDS
 ######################################
 
-INC_PATHS += -I../include -I../libs/install/include
-LD_PATHS += -L.. -L../libs/install/lib
+INC_PATHS += -I.. -I../../libs/install/include
+LD_PATHS += -L.. -L../../libs/install/lib
 
 OBJECT_DIRECTORY = _build
 OUTPUT_BINARY_DIRECTORY = .

--- a/routing/routing.c
+++ b/routing/routing.c
@@ -19,7 +19,7 @@
  *  specific language governing permissions and limitations
  *  under the License.
  */
-/** @file   routing.cpp
+/** @file   routing.c
  *  @brief  routing計算アプリ
  *  @author ueno@nayuta.co
  */


### PR DESCRIPTION
examplesのビルドが通らなかったので追加の修正。
ついでにrouting.cppも修正。