### PR TITLE
fix #690

### DIFF
--- a/ptarm/ln_script.c
+++ b/ptarm/ln_script.c
@@ -212,6 +212,7 @@ bool HIDDEN ln_check_scriptpkh(const ptarm_buf_t *pBuf)
 void HIDDEN ln_htlcinfo_init(ln_htlcinfo_t *pHtlcInfo)
 {
     pHtlcInfo->type = LN_HTLCTYPE_NONE;
+    pHtlcInfo->add_htlc_idx = (uint16_t)-1;
     pHtlcInfo->expiry = 0;
     pHtlcInfo->amount_msat = 0;
     pHtlcInfo->preimage_hash = NULL;

--- a/ptarm/ln_script.h
+++ b/ptarm/ln_script.h
@@ -52,6 +52,7 @@ typedef struct {
  */
 typedef struct {
     ln_htlctype_t           type;                   ///< HTLC種別
+    uint16_t                add_htlc_idx;           ///< 対応するself->cnl_add_htlc[]のindex値
     uint32_t                expiry;                 ///< Expiry
     uint64_t                amount_msat;            ///< amount_msat
     const uint8_t           *preimage_hash;         ///< preimageをHASH160したデータ


### PR DESCRIPTION
self->cnl_add_htlc[]の配列は空きが生じる場合があるが、pp_htlcinfo[]にはその空きを詰めているため、添字に違いが生じる可能性がある。