### PR TITLE
refactor log macros

### DIFF
--- a/btc/btc_local.h
+++ b/btc/btc_local.h
@@ -39,6 +39,8 @@
 #include <assert.h>
 
 #include "btc.h"
+#define LOG_TAG "BTC"
+#include "utl_log.h"
 
 
 /**************************************************************************
@@ -48,31 +50,6 @@
 /**************************************************************************
  * macro functions
  **************************************************************************/
-
-#ifdef PTARM_DEBUG
-#include "utl_log.h"
-#define LOG_TAG "BTC"
-
-#define LOGV(...)       utl_log_write(UTL_LOG_PRI_VERBOSE, __FILE__, __LINE__, 1, LOG_TAG, __func__, __VA_ARGS__)
-#define DUMPV(dt,ln)    utl_log_dump(UTL_LOG_PRI_VERBOSE, __FILE__, __LINE__, 0, LOG_TAG, __func__, dt, ln)
-#define TXIDV(dt)       utl_log_dump_rev(UTL_LOG_PRI_VERBOSE, __FILE__, __LINE__, 0, LOG_TAG, __func__, dt, BTC_SZ_TXID)
-
-#define LOGD(...)       utl_log_write(UTL_LOG_PRI_DBG, __FILE__, __LINE__, 1, LOG_TAG, __func__, __VA_ARGS__)
-#define LOGD2(...)      utl_log_write(UTL_LOG_PRI_DBG, __FILE__, __LINE__, 0, LOG_TAG, __func__, __VA_ARGS__)
-#define DUMPD(dt,ln)    utl_log_dump(UTL_LOG_PRI_DBG, __FILE__, __LINE__, 0, LOG_TAG, __func__, dt, ln)
-#define TXIDD(dt)       utl_log_dump_rev(UTL_LOG_PRI_DBG, __FILE__, __LINE__, 0, LOG_TAG, __func__, dt, BTC_SZ_TXID)
-
-#else //PTARM_DEBUG
-#define LOGV(...)       //none
-#define DUMPV(...)      //none
-#define TXIDV(...)      //none
-
-#define LOGD(...)       //none
-#define LOGD2(...)      //none
-#define DUMPD(...)      //none
-#define TXIDD(...)      //none
-#endif //PTARM_DEBUG
-
 
 #ifdef PTARM_DEBUG_MEM
 #define M_MALLOC(a)         utl_dbg_malloc(a); LOGD("M_MALLOC:%d\n", utl_dbg_malloc_cnt());       ///< malloc(カウント付き)(PTARM_DEBUG_MEM定義時のみ有効)

--- a/ln/ln_local.h
+++ b/ln/ln_local.h
@@ -46,6 +46,8 @@
 #endif  //PTARM_USE_RNG
 
 #include "ln.h"
+#define LOG_TAG "LN"
+#include "utl_log.h"
 
 
 /**************************************************************************
@@ -134,33 +136,6 @@
 /**************************************************************************
  * macro functions
  **************************************************************************/
-
-#define ARRAY_SIZE(a)       (sizeof(a) / sizeof(a[0]))  ///< 配列要素数
-
-#ifdef PTARM_DEBUG
-#include "utl_log.h"
-#define LOG_TAG "LN"
-
-#define LOGV(...)       utl_log_write(UTL_LOG_PRI_VERBOSE, __FILE__, __LINE__, 1, LOG_TAG, __func__, __VA_ARGS__)
-#define DUMPV(dt,ln)    utl_log_dump(UTL_LOG_PRI_VERBOSE, __FILE__, __LINE__, 0, LOG_TAG, __func__, dt, ln)
-#define TXIDV(dt)       utl_log_dump_rev(UTL_LOG_PRI_VERBOSE, __FILE__, __LINE__, 0, LOG_TAG, __func__, dt, BTC_SZ_TXID)
-
-#define LOGD(...)       utl_log_write(UTL_LOG_PRI_DBG, __FILE__, __LINE__, 1, LOG_TAG, __func__, __VA_ARGS__)
-#define LOGD2(...)      utl_log_write(UTL_LOG_PRI_DBG, __FILE__, __LINE__, 0, LOG_TAG, __func__, __VA_ARGS__)
-#define DUMPD(dt,ln)    utl_log_dump(UTL_LOG_PRI_DBG, __FILE__, __LINE__, 0, LOG_TAG, __func__, dt, ln)
-#define TXIDD(dt)       utl_log_dump_rev(UTL_LOG_PRI_DBG, __FILE__, __LINE__, 0, LOG_TAG, __func__, dt, BTC_SZ_TXID)
-
-#else //PTARM_DEBUG
-#define LOGV(...)       //none
-#define DUMPV(...)      //none
-#define TXIDV(...)      //none
-
-#define LOGD(...)       //none
-#define LOGD2(...)      //none
-#define DUMPD(...)      //none
-#define TXIDD(...)      //none
-#endif //PTARM_DEBUG
-
 
 #ifdef PTARM_DEBUG_MEM
 #define M_MALLOC(a)         utl_dbg_malloc(a); LOGD("M_MALLOC:%d\n", utl_dbg_malloc_cnt());       ///< malloc(カウント付き)(PTARM_DEBUG_MEM定義時のみ有効)

--- a/ptarmd/ptarmd.h
+++ b/ptarmd/ptarmd.h
@@ -43,6 +43,8 @@ static inline int tid() {
 }
 
 #include "utl_misc.h"
+#define LOG_TAG "APP"
+#include "utl_log.h"
 #include "ln.h"
 
 
@@ -108,33 +110,6 @@ static inline int tid() {
 /********************************************************************
  * macros functions
  ********************************************************************/
-
-#define ARRAY_SIZE(a)       (sizeof(a) / sizeof(a[0]))
-
-#if 1
-#include "utl_log.h"
-#define LOG_TAG "APP"
-
-#define LOGV(...)       utl_log_write(UTL_LOG_PRI_VERBOSE, __FILE__, __LINE__, 1, LOG_TAG, __func__, __VA_ARGS__)
-#define DUMPV(dt,ln)    utl_log_dump(UTL_LOG_PRI_VERBOSE, __FILE__, __LINE__, 0, LOG_TAG, __func__, dt, ln)
-#define TXIDV(dt)       utl_log_dump_rev(UTL_LOG_PRI_VERBOSE, __FILE__, __LINE__, 0, LOG_TAG, __func__, dt, BTC_SZ_TXID)
-
-#define LOGD(...)       utl_log_write(UTL_LOG_PRI_DBG, __FILE__, __LINE__, 1, LOG_TAG, __func__, __VA_ARGS__)
-#define LOGD2(...)      utl_log_write(UTL_LOG_PRI_DBG, __FILE__, __LINE__, 0, LOG_TAG, __func__, __VA_ARGS__)
-#define DUMPD(dt,ln)    utl_log_dump(UTL_LOG_PRI_DBG, __FILE__, __LINE__, 0, LOG_TAG, __func__, dt, ln)
-#define TXIDD(dt)       utl_log_dump_rev(UTL_LOG_PRI_DBG, __FILE__, __LINE__, 0, LOG_TAG, __func__, dt, BTC_SZ_TXID)
-
-#else
-#define LOGV(...)       //none
-#define DUMPV(...)      //none
-#define TXIDV(...)      //none
-
-#define LOGD(...)       //none
-#define LOGD2(...)      //none
-#define DUMPD(...)      //none
-#define TXIDD(...)      //none
-
-#endif
 
 
 /********************************************************************

--- a/utl/utl_local.h
+++ b/utl/utl_local.h
@@ -38,39 +38,18 @@
 #include <string.h>
 #include <assert.h>
 
+#define LOG_TAG "UTL"
+#include "utl_log.h"
+
 
 /**************************************************************************
  * macros
  **************************************************************************/
 
+
 /**************************************************************************
  * macro functions
  **************************************************************************/
-
-#ifdef PTARM_DEBUG
-#include "utl_log.h"
-#define LOG_TAG "UTL"
-
-#define LOGV(...)       utl_log_write(UTL_LOG_PRI_VERBOSE, __FILE__, __LINE__, 1, LOG_TAG, __func__, __VA_ARGS__)
-#define DUMPV(dt,ln)    utl_log_dump(UTL_LOG_PRI_VERBOSE, __FILE__, __LINE__, 0, LOG_TAG, __func__, dt, ln)
-#define TXIDV(dt)       utl_log_dump_rev(UTL_LOG_PRI_VERBOSE, __FILE__, __LINE__, 0, LOG_TAG, __func__, dt, PTARM_SZ_TXID)
-
-#define LOGD(...)       utl_log_write(UTL_LOG_PRI_DBG, __FILE__, __LINE__, 1, LOG_TAG, __func__, __VA_ARGS__)
-#define LOGD2(...)      utl_log_write(UTL_LOG_PRI_DBG, __FILE__, __LINE__, 0, LOG_TAG, __func__, __VA_ARGS__)
-#define DUMPD(dt,ln)    utl_log_dump(UTL_LOG_PRI_DBG, __FILE__, __LINE__, 0, LOG_TAG, __func__, dt, ln)
-#define TXIDD(dt)       utl_log_dump_rev(UTL_LOG_PRI_DBG, __FILE__, __LINE__, 0, LOG_TAG, __func__, dt, PTARM_SZ_TXID)
-
-#else //PTARM_DEBUG
-#define LOGV(...)       //none
-#define DUMPV(...)      //none
-#define TXIDV(...)      //none
-
-#define LOGD(...)       //none
-#define LOGD2(...)      //none
-#define DUMPD(...)      //none
-#define TXIDD(...)      //none
-#endif //PTARM_DEBUG
-
 
 #ifdef PTARM_DEBUG_MEM
 #define M_MALLOC(a)         utl_dbg_malloc(a); LOGD("M_MALLOC:%d\n", utl_dbg_malloc_cnt());       ///< malloc(カウント付き)(PTARM_DEBUG_MEM定義時のみ有効)

--- a/utl/utl_log.c
+++ b/utl/utl_log.c
@@ -12,6 +12,7 @@
 #include <sys/stat.h>
 
 #include "utl_misc.h"
+#define LOG_TAG "dummy"
 #include "utl_log.h"
 
 #define FNAME_MAX       (50)

--- a/utl/utl_log.h
+++ b/utl/utl_log.h
@@ -35,6 +35,33 @@ void utl_log_dump(int Pri, const char* pFname, int Line, int Flag, const char *p
 void utl_log_dump_rev(int Pri, const char* pFname, int Line, int Flag, const char *pTag, const char *pFunc, const void *pData, size_t Len);
 
 
+#ifndef PTARM_UTL_LOG_MACRO_DISABLED
+#ifndef LOG_TAG
+#error "LOG_TAG needs to be defined"
+#endif
+
+#define LOGV(...)       utl_log_write(UTL_LOG_PRI_VERBOSE, __FILE__, __LINE__, 1, LOG_TAG, __func__, __VA_ARGS__)
+#define DUMPV(dt,ln)    utl_log_dump(UTL_LOG_PRI_VERBOSE, __FILE__, __LINE__, 0, LOG_TAG, __func__, dt, ln)
+#define TXIDV(dt)       utl_log_dump_rev(UTL_LOG_PRI_VERBOSE, __FILE__, __LINE__, 0, LOG_TAG, __func__, dt, BTC_SZ_TXID)
+
+#define LOGD(...)       utl_log_write(UTL_LOG_PRI_DBG, __FILE__, __LINE__, 1, LOG_TAG, __func__, __VA_ARGS__)
+#define LOGD2(...)      utl_log_write(UTL_LOG_PRI_DBG, __FILE__, __LINE__, 0, LOG_TAG, __func__, __VA_ARGS__)
+#define DUMPD(dt,ln)    utl_log_dump(UTL_LOG_PRI_DBG, __FILE__, __LINE__, 0, LOG_TAG, __func__, dt, ln)
+#define TXIDD(dt)       utl_log_dump_rev(UTL_LOG_PRI_DBG, __FILE__, __LINE__, 0, LOG_TAG, __func__, dt, BTC_SZ_TXID)
+
+#else //PTARM_UTL_LOG_MACRO_DISABLED
+#define LOGV(...)       //none
+#define DUMPV(...)      //none
+#define TXIDV(...)      //none
+
+#define LOGD(...)       //none
+#define LOGD2(...)      //none
+#define DUMPD(...)      //none
+#define TXIDD(...)      //none
+
+#endif //PTARM_UTL_LOG_MACRO_DISABLED
+
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
to remove log macros, explicitly define `PTARM_UTL_LOG_MACRO_DISABLED`