### PR TITLE
fix initial_routing_sync OFF

### DIFF
--- a/ln/ln.h
+++ b/ln/ln.h
@@ -464,7 +464,7 @@ typedef struct {
     uint32_t    cltv_expiry;                        ///< 4:  cltv_expirty
     uint8_t     payment_sha256[LN_SZ_HASH];         ///< 32: payment_hash
     utl_buf_t   buf_payment_preimage;               ///< 32: payment_preimage
-    utl_buf_t   buf_onion_reason;                   ///< 
+    utl_buf_t   buf_onion_reason;                   ///<
                                                     //  update_add_htlc
                                                     //      1366: onion_routing_packet
                                                     //          final node: length == 0
@@ -486,16 +486,16 @@ typedef struct {
      *      preimage = NULL
      *      set:  flag = SEND
      *      sent: flag = SEND | ADDHTLC
-     * 
+     *
      * update_add_htlc受信
      *      set:  flag = RECV
      *            preimage = NULL
-     * 
+     *
      * update_fulfill_htlc送信
      *      set:  flag = RECV | FULFILLHTLC
      *            preimage = payment_preimage
      *      sent: clear HTLC
-     * 
+     *
      * update_fulfill_htlc受信
      *      set:  flag = RECV | FULFILLHTLC
      *            preimage = payment_preimage
@@ -1558,7 +1558,7 @@ void ln_create_fulfill_htlc(ln_self_t *self, utl_buf_t *pFulfill, uint16_t Idx);
 
 
 /** update_fail_htlc設定
- * 
+ *
  * @param[in,out]       self            channel情報
  * @param[in]           Idx             index
  * @param[in]           pReason         reason
@@ -1632,7 +1632,7 @@ bool ln_create_pong(ln_self_t *self, utl_buf_t *pPong, uint16_t NumPongBytes);
  ********************************************************************/
 
 /** HTLCが安定しているかどうか
- * 
+ *
  */
 bool ln_htlc_is_stable(const ln_self_t *self);
 
@@ -1870,6 +1870,16 @@ static inline const uint8_t *ln_funding_blockhash(const ln_self_t *self) {
 #endif
 
 
+/** initial_routing_sync動作が必要かどうか
+ *
+ * @param[in]           self            channel情報
+ * @retval  true    必要:保持しているchannel情報を送信する
+ */
+static inline bool ln_need_init_routing_sync(const ln_self_t *self) {
+    return self->lfeature_remote & LN_INIT_LF_ROUTE_SYNC;
+}
+
+
 /** announcement_signatures交換済みかどうか
  *
  * @param[in]           self            channel情報
@@ -1978,7 +1988,7 @@ static inline const ln_commit_data_t *ln_commit_remote(const ln_self_t *self) {
 
 
 /** commitment_signedの送信が必要かどうか
- * 
+ *
  * @param[in]           self            channel情報
  * @return      true:送信が必要
  */
@@ -1988,7 +1998,7 @@ static inline bool ln_uncommit_get(const ln_self_t *self) {
 
 
 /** commitment_signed未commitフラグクリア
- * 
+ *
  * @param[in,out]       self            channel情報
  */
 static inline void ln_uncommit_clr(ln_self_t *self) {

--- a/ln/ln_db.h
+++ b/ln/ln_db.h
@@ -213,12 +213,12 @@ bool ln_db_annocnl_load(utl_buf_t *pCnlAnno, uint64_t ShortChannelId);
  * @param[in]       pCnlAnno
  * @param[in]       ShortChannelId  pCnlAnnoのshort_channel_id
  * @param[in]       pSendId         pCnlAnnoの送信元/先node_id
- * @param[in]       pChan1          channel_announcementのnode1
- * @param[in]       pChan2          channel_announcementのnode2
+ * @param[in]       pNodeId1        channel_announcementのnode_id1
+ * @param[in]       pNodeId2        channel_announcementのnode_id2
  * @retval      true    成功
  */
 bool ln_db_annocnl_save(const utl_buf_t *pCnlAnno, uint64_t ShortChannelId, const uint8_t *pSendId,
-                        const uint8_t *pChan1, const uint8_t *pChan2);
+                        const uint8_t *pNodeId1, const uint8_t *pNodeId2);
 
 
 /** channel_update読込み
@@ -290,19 +290,19 @@ bool ln_db_annocnls_add_nodeid(void *pDb, uint64_t ShortChannelId, char Type, bo
 //uint64_t ln_db_annocnlall_search_channel_short_channel_id(const uint8_t *pNodeId1, const uint8_t *pNodeId2);
 
 
-/** DB curosrオープン
+/** DB cursorオープン
  *
- * @param[out]      ppCur   curosr情報(ln_dbで使用する)
- * @param[in,out]   pDb     #ln_db_node_cur_transaction()取得したDB情報
+ * @param[out]      ppCurAnnoCnl    cursor情報(ln_dbで使用する)
+ * @param[in,out]   pDb             #ln_db_node_cur_transaction(LN_DB_TXN_CNL)取得したDB情報
  */
-bool ln_db_annocnl_cur_open(void **ppCur, void *pDb);
+bool ln_db_annocnl_cur_open(void **ppCurAnnoCnl, void *pDb);
 
 
-/** DB curosrクローズ
+/** DB cursorクローズ
  *
- * @param[in]       pCur    #ln_db_annocnl_cur_open()で取得したcursor情報
+ * @param[in]       pCurAnnoCnl     #ln_db_annocnl_cur_open()で取得したcursor情報
  */
-void ln_db_annocnl_cur_close(void *pCur);
+void ln_db_annocnl_cur_close(void *pCurAnnoCnl);
 
 
 /** channel_announcement関連情報送信済み検索
@@ -313,7 +313,7 @@ void ln_db_annocnl_cur_close(void *pCur);
  * @param[in]       pSendId             対象node_id
  * @retval  true    pSendIdへ送信済み
  */
-bool ln_db_annocnls_search_nodeid(void *pDb, uint64_t ShortChannelId, char Type, const uint8_t *pSendId);
+bool ln_db_annocnlinfo_search_nodeid(void *pDb, uint64_t ShortChannelId, char Type, const uint8_t *pSendId);
 
 
 /** channel_announcement関連情報の順次取得
@@ -462,6 +462,7 @@ bool ln_db_annonod_cur_open(void **ppCur, void *pDb);
  */
 void ln_db_annonod_cur_close(void *pCur);
 
+
 /** node_announcement順次取得
  *
  * @param[in,out]   pCur            #ln_db_annonod_cur_open()でオープンしたDB cursor
@@ -478,6 +479,8 @@ bool ln_db_annonod_cur_get(void *pCur, utl_buf_t *pBuf, uint32_t *pTimeStamp, ui
 ////////////////////
 
 /** channel_announcement/channel_update/node_announcement送受信ノード情報削除
+ * announcement送信済みのnode_idを保持しているので、起動時に全削除する。
+ * また、チャネル接続時には接続先node_idの情報を削除する。
  *
  * @param[in]       pNodeId     削除対象のnode_id(NULL時は全削除)
  */
@@ -522,7 +525,7 @@ bool ln_db_preimg_search(ln_db_func_preimg_t pFunc, void *p_param);
 bool ln_db_preimg_del_hash(const uint8_t *pPreImageHash);
 
 
-/** preimage curosrオープン
+/** preimage cursorオープン
  *
  * @param[in,out]   ppCur
  * @retval  true

--- a/ln/ln_node.c
+++ b/ln/ln_node.c
@@ -161,8 +161,11 @@ bool ln_node_init(uint8_t Features)
         }
         ret = ln_db_annonod_save(&buf_node, &anno, NULL);
     }
+    LOGD("my node_id: ");
+    DUMPD(mNode.keys.pub, BTC_SZ_PUBKEY);
 
     if (ret) {
+        //annoinfo情報削除(全削除)
         ln_db_annoinfo_del(NULL);
         print_node();
     }


### PR DESCRIPTION
fix #715

* initial_routing_syncが無効な場合はannouncement送信を擬似的に行い、全部送信したように見せかけてから接続を開始する

Squashed commit of the following:

commit ef8d84f7d797034dfa0a47f4e6ec51fb3947d09d
Author: ueno <ueno@nayuta.co>
Date:   Tue Aug 28 14:35:57 2018 +0900

    名前整理

commit 968e2bcce29e65b3048f2beb37e80988ba6ee405
Author: ueno <ueno@nayuta.co>
Date:   Tue Aug 28 10:37:39 2018 +0900

    log

commit 6e037811fa68c6c86466a920b1753eca55084515
Author: ueno <ueno@nayuta.co>
Date:   Tue Aug 28 10:33:46 2018 +0900

    作戦変更

    announcement送信処理で「ダミー」ができるようにし、起動時に全部送信したことにする

commit d0b767df9d2992642dfe3929710ca30b3cc0d63d
Author: ueno <ueno@nayuta.co>
Date:   Tue Aug 28 01:04:43 2018 +0900

    途中までやったが、中断

commit f9c1e052c0617a7059ce73358f6feff2a26b2dd7
Author: ueno <ueno@nayuta.co>
Date:   Tue Aug 28 01:04:21 2018 +0900

    log

commit 2aef1c32ecb1db6ee3bc1485f1f8ddf37135118e
Author: ueno <ueno@nayuta.co>
Date:   Mon Aug 27 21:11:02 2018 +0900

    initial_routing_syncがOFFの場合にはln_db_annoinfo_add()を呼ぶようにしたが、うまくいっていない