### PR TITLE
check invoice timestamp before payment

### DIFF
--- a/ptarmd/cmd_json.c
+++ b/ptarmd/cmd_json.c
@@ -1308,7 +1308,13 @@ static int cmd_routepay_proc1(
     ln_invoice_t *p_invoice_data = *ppInvoiceData;
     if ( (p_invoice_data->hrp_type != LN_INVOICE_TESTNET) &&
         (p_invoice_data->hrp_type != LN_INVOICE_REGTEST) ) {
+        LOGD("fail: mismatch blockchain\n");
         return RPCERR_INVOICE_FAIL;
+    }
+    time_t now = time(NULL);
+    if (p_invoice_data->timestamp + p_invoice_data->expiry < (uint64_t)now) {
+        LOGD("fail: invoice outdated\n");
+        return RPCERR_INVOICE_OUTDATE;
     }
     p_invoice_data->amount_msat += AddAmountMsat;
 

--- a/ptarmd/ptarmd.c
+++ b/ptarmd/ptarmd.c
@@ -470,22 +470,32 @@ char *ptarmd_error_str(int ErrCode)
         { RPCERR_NOCHANN,                   "no channel" },
         { RPCERR_PARSE,                     "parse param" },
         { RPCERR_NOINIT,                    "no init or init not end" },
+        { RPCERR_BLOCKCHAIN,                "fail blockchain access" },
+
         { RPCERR_NODEID,                    "invalid node_id" },
         { RPCERR_NOOPEN,                    "channel not open" },
         { RPCERR_ALOPEN,                    "channel already opened" },
         { RPCERR_FULLCLI,                   "client full" },
         { RPCERR_SOCK,                      "socket" },
         { RPCERR_CONNECT,                   "connect" },
+        { RPCERR_PEER_ERROR,                "peer error" },
         { RPCERR_OPENING,                   "funding now" },
+
         { RPCERR_FUNDING,                   "fail funding" },
+
         { RPCERR_INVOICE_FULL,              "invoice full" },
-        { RPCERR_INVOICE_ERASE,             "fail: erase invoice" },
+        { RPCERR_INVOICE_ERASE,             "erase invoice" },
+        { RPCERR_INVOICE_FAIL,              "decode invoice" },
+        { RPCERR_INVOICE_OUTDATE,           "outdated invoice" },
+
         { RPCERR_CLOSE_START,               "fail start closing" },
         { RPCERR_CLOSE_FAIL,                "fail unilateral close" },
+
         { RPCERR_PAY_STOP,                  "stop payment" },
         { RPCERR_NOROUTE,                   "fail routing" },
         { RPCERR_PAYFAIL,                   "" },
-        { RPCERR_PAY_RETRY,                 "retry payment" }
+        { RPCERR_PAY_RETRY,                 "retry payment" },
+        { RPCERR_TOOMANYHOP,                "fail create invoice(too many hop)" },
     };
 
     const char *p_str = "";

--- a/ptarmd/ptarmd.h
+++ b/ptarmd/ptarmd.h
@@ -94,6 +94,7 @@ static inline int tid() {
 #define RPCERR_INVOICE_FULL         (-22000)
 #define RPCERR_INVOICE_ERASE        (-22001)
 #define RPCERR_INVOICE_FAIL         (-22002)
+#define RPCERR_INVOICE_OUTDATE      (-22003)
 
 #define RPCERR_CLOSE_START          (-25000)
 #define RPCERR_CLOSE_FAIL           (-25001)

--- a/ptarmd/ptarmd.h
+++ b/ptarmd/ptarmd.h
@@ -71,7 +71,7 @@ static inline int tid() {
 #define FNAME_EVENTCH_LOG           "evt_%s.log"
 #define FNAME_FMT_NODECONF          "ptarm_%s.conf"
 
-
+//need update ptarmd_error_str()
 #define RPCERR_ERROR                (-10000)
 #define RPCERR_NOCONN               (-10001)
 #define RPCERR_ALCONN               (-10002)


### PR DESCRIPTION
fix #665 

送金前にinvoiceのtimestamp + expiryが現在時刻を過ぎていないかチェックする(イコールはOKとする)。