### PR TITLE
exit on listen port already using

### DIFF
--- a/ptarmd/cmd_json.c
+++ b/ptarmd/cmd_json.c
@@ -161,6 +161,14 @@ void cmd_json_start(uint16_t Port)
 }
 
 
+void cmd_json_stop(void)
+{
+    if (mJrpc.port_number != 0) {
+        jrpc_server_stop(&mJrpc);
+    }
+}
+
+
 int cmd_json_connect(const uint8_t *pNodeId, const char *pIpAddr, uint16_t Port)
 {
     char nodestr[BTC_SZ_PUBKEY * 2 + 1];
@@ -1188,9 +1196,7 @@ static int cmd_stop_proc(void)
 {
     LOGD("stop\n");
 
-    p2p_svr_stop_all();
-    p2p_cli_stop_all();
-    monitor_stop();
+    ptarmd_stop();
 
     return 0;
 }

--- a/ptarmd/cmd_json.h
+++ b/ptarmd/cmd_json.h
@@ -34,6 +34,12 @@
 void cmd_json_start(uint16_t Port);
 
 
+/** ptarmd JSON-RPC動作停止
+ * 
+ */
+void cmd_json_stop(void);
+
+
 /** ノード接続
  *
  * @param[in]       pNodeId     接続先ノードID

--- a/ptarmd/p2p_svr.c
+++ b/ptarmd/p2p_svr.c
@@ -65,7 +65,7 @@ void *p2p_svr_start(void *pArg)
     (void)pArg;
 
     int ret;
-    int sock;
+    int sock = -1;
     struct sockaddr_in sv_addr, cl_addr;
 
     memset(&mAppConf, 0, sizeof(mAppConf));
@@ -159,6 +159,11 @@ void *p2p_svr_start(void *pArg)
     }
 
 LABEL_EXIT:
+    if (sock > 0) {
+        close(sock);
+    }
+    ptarmd_stop();
+    LOGD("stop thread\n");
     return NULL;
 }
 

--- a/ptarmd/ptarmd.c
+++ b/ptarmd/ptarmd.c
@@ -362,6 +362,15 @@ LABEL_EXIT:
  * public functions
  ********************************************************************/
 
+void ptarmd_stop(void)
+{
+    cmd_json_stop();
+    p2p_svr_stop_all();
+    p2p_cli_stop_all();
+    monitor_stop();
+}
+
+
 bool ptarmd_transfer_channel(uint64_t ShortChannelId, trans_cmd_t Cmd, utl_buf_t *pBuf)
 {
     lnapp_conf_t *p_appconf = NULL;

--- a/ptarmd/ptarmd.h
+++ b/ptarmd/ptarmd.h
@@ -251,6 +251,12 @@ typedef struct lnapp_conf_t lnapp_conf_t;
  * prototypes
  ********************************************************************/
 
+/** stop all threads
+ * 
+ */
+void ptarmd_stop(void);
+
+
 /** ノード内転送
  *
  */


### PR DESCRIPTION
LISTENしようとしたポートが既に使われていたら、終了する。

エラーチェックはしていたが、他のスレッドが生き残っていたため終了できていなかった。