### PR TITLE
fix invoice `r-field`

### DIFF
--- a/ln/ln_db_lmdb.c
+++ b/ln/ln_db_lmdb.c
@@ -624,7 +624,7 @@ bool HIDDEN ln_db_init(char *pWif, char *pNodeName, uint16_t *pPort)
         goto LABEL_EXIT;
     }
     //ln_db_invoice_drop();
-    ln_db_annocnl_del_orphan();
+    //ln_db_annocnl_del_orphan();
 
 LABEL_EXIT:
     if (retval == 0) {


### PR DESCRIPTION
fix #731 

複数のprivate channelがあり、複数のr-fieldを含んだinvoiceを作る場合、2番目以降がおかしなデータになっていた。
各r-fieldごとにencodeするのではなく、全部のr-fieldを作ってからencodeする必要があった。