### PR TITLE
read update_malformed_htlc (not tested)

### DIFF
--- a/ln/ln.h
+++ b/ln/ln.h
@@ -558,7 +558,7 @@ typedef struct {
 typedef struct {
     uint8_t     *p_channel_id;                      ///< 32: channel-id
     uint64_t    id;                                 ///< 8:  id
-    uint8_t     *p_sha256_onion;                    ///< 32: sha256-of-onion
+    uint8_t     sha256_onion[BTC_SZ_SHA256];        ///< 32: sha256-of-onion
     uint16_t    failure_code;                       ///< 2:  failure-code
 } ln_update_fail_malformed_htlc_t;
 
@@ -2393,6 +2393,14 @@ bool ln_onion_failure_read(utl_buf_t *pReason,
  * @retval  true    成功
  */
 bool ln_onion_read_err(ln_onion_err_t *pOnionErr, const utl_buf_t *pReason);
+
+
+/** ONION failure reason文字列取得
+ *
+ * @param[in]       pOnionErr
+ * @return  エラー文字列(呼び元でfree()すること)
+ */
+char *ln_onion_get_errstr(const ln_onion_err_t *pOnionErr);
 
 
 /********************************************************************

--- a/ln/ln_msg_normalope.c
+++ b/ln/ln_msg_normalope.c
@@ -700,7 +700,7 @@ bool HIDDEN ln_msg_update_fail_malformed_htlc_create(utl_buf_t *pBuf, const ln_u
     ln_misc_push64be(&proto, pMsg->id);
 
     //        [32:sha256-of-onion]
-    utl_push_data(&proto, pMsg->p_sha256_onion, LN_SZ_HASH);
+    utl_push_data(&proto, pMsg->sha256_onion, BTC_SZ_SHA256);
 
     //        [2:failure-code]
     ln_misc_push16be(&proto, pMsg->failure_code);
@@ -737,8 +737,8 @@ bool HIDDEN ln_msg_update_fail_malformed_htlc_read(ln_update_fail_malformed_htlc
     pos += sizeof(uint64_t);
 
     //        [32:sha256-of-onion]
-    memcpy(pMsg->p_sha256_onion, pData + pos, LN_SZ_HASH);
-    pos += LN_SZ_HASH;
+    memcpy(pMsg->sha256_onion, pData + pos, BTC_SZ_SHA256);
+    pos += BTC_SZ_SHA256;
 
     //        [2:failure-code]
     pMsg->failure_code = ln_misc_get16be(pData + pos);
@@ -762,8 +762,8 @@ static void update_fail_malformed_htlc_print(const ln_update_fail_malformed_htlc
     LOGD("channel-id: ");
     DUMPD(pMsg->p_channel_id, LN_SZ_CHANNEL_ID);
     LOGD("id: %" PRIu64 "\n", pMsg->id);
-    LOGD("p_sha256_onion: ");
-    DUMPD(pMsg->p_sha256_onion, LN_SZ_HASH);
+    LOGD("sha256_onion: ");
+    DUMPD(pMsg->sha256_onion, BTC_SZ_SHA256);
     LOGD("failure_code: %04x\n", pMsg->failure_code);
     LOGD("--------------------------------\n");
 #endif  //PTARM_DEBUG

--- a/ln/ln_onion.c
+++ b/ln/ln_onion.c
@@ -542,6 +542,52 @@ bool ln_onion_read_err(ln_onion_err_t *pOnionErr, const utl_buf_t *pReason)
 }
 
 
+char *ln_onion_get_errstr(const ln_onion_err_t *pOnionErr)
+{
+    const struct {
+        uint16_t err;
+        const char *str;
+    } ONIONERR[] = {
+        { LNONION_INV_REALM, "invalid realm" },
+        { LNONION_TMP_NODE_FAIL, "temporary_node_failure" },
+        { LNONION_PERM_NODE_FAIL, "permanent_node_failure" },
+        { LNONION_REQ_NODE_FTR_MISSING, "required_node_feature_missing" },
+        { LNONION_INV_ONION_VERSION, "invalid_onion_version" },
+        { LNONION_INV_ONION_HMAC, "invalid_onion_hmac" },
+        { LNONION_INV_ONION_KEY, "invalid_onion_key" },
+        { LNONION_TMP_CHAN_FAIL, "temporary_channel_failure" },
+        { LNONION_PERM_CHAN_FAIL, "permanent_channel_failure" },
+        { LNONION_REQ_CHAN_FTR_MISSING, "required_channel_feature_missing" },
+        { LNONION_UNKNOWN_NEXT_PEER, "unknown_next_peer" },
+        { LNONION_AMT_BELOW_MIN, "amount_below_minimum" },
+        { LNONION_FEE_INSUFFICIENT, "fee_insufficient" },
+        { LNONION_INCORR_CLTV_EXPIRY, "incorrect_cltv_expiry" },
+        { LNONION_EXPIRY_TOO_SOON, "expiry_too_soon" },
+        { LNONION_UNKNOWN_PAY_HASH, "unknown_payment_hash" },
+        { LNONION_INCORR_PAY_AMT, "incorrect_payment_amount" },
+        { LNONION_FINAL_EXPIRY_TOO_SOON, "final_expiry_too_soon" },
+        { LNONION_FINAL_INCORR_CLTV_EXP, "final_incorrect_cltv_expiry" },
+        { LNONION_FINAL_INCORR_HTLC_AMT, "final_incorrect_htlc_amount" },
+        { LNONION_CHAN_DISABLE, "channel_disabled" },
+        { LNONION_EXPIRY_TOO_FAR, "expiry_too_far" },
+    };
+
+    const char *p_str = NULL;
+    for (size_t lp = 0; lp < ARRAY_SIZE(ONIONERR); lp++) {
+        if (pOnionErr->reason == ONIONERR[lp].err) {
+            p_str = ONIONERR[lp].str;
+            break;
+        }
+    }
+    char str[128];
+    if (p_str == NULL) {
+        sprintf(str, "unknown reason[%04x]", pOnionErr->reason);
+        p_str = str;
+    }
+    return strdup(p_str);
+}
+
+
 /**************************************************************************
  * private functions
  **************************************************************************/


### PR DESCRIPTION
issue #98 (part 1).

receive `update_malformed_htlc`.

* backward `update_fail_htlc` with `failure_code` and `sha256_of_onion`.