### PR TITLE
update_fail_malformed_htlc

### DIFF
--- a/ptarmd/cmd_json.c
+++ b/ptarmd/cmd_json.c
@@ -979,6 +979,12 @@ static cJSON *cmd_debug(jrpc_context *ctx, cJSON *params, cJSON *id)
         if (!LN_DBG_NODE_AUTO_CONNECT()) {
             LOGD("no node Auto connect\n");
         }
+        if (!LN_DBG_ONION_CREATE_NORMAL_REALM()) {
+            LOGD("create invalid realm onion\n");
+        }
+        if (!LN_DBG_ONION_CREATE_NORMAL_VERSION()) {
+            LOGD("create invalid version onion\n");
+        }
         cJSON_AddItemToObject(result, "new", cJSON_CreateString(str));
     } else {
         ctx->error_code = RPCERR_PARSE;

--- a/tests/2nodes_test/clean.sh
+++ b/tests/2nodes_test/clean.sh
@@ -2,7 +2,7 @@
 killall ptarmd
 bitcoin-cli -conf=`pwd`/regtest.conf -datadir=`pwd`/regtest stop
 sleep 1
-rm -rf *.cnl node_3333 node_4444 conf pay_*.conf routing.dot routing.png regtest *.log
+rm -rf *.cnl node_3333 node_4444 conf pay_*.conf routing.dot routing.png regtest *.log n?.txt anno.conf channel.conf
 
 # remove synbolic link
 rm ptarmcli ptarmd showdb routing fund-test-in.sh regtest.conf generate.sh default_conf.sh

--- a/tests/2nodes_test/example_st4fail4c.sh
+++ b/tests/2nodes_test/example_st4fail4c.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+#   PAYERが不正なrealmのonionを作成する
+
+PAY_BEGIN=4444
+PAY_END=3333
+AMOUNT=100000
+PAYER_PORT=$(( ${PAY_BEGIN} + 1 ))
+
+# create invalid realm onion
+./ptarmcli --debug 16 $PAYER_PORT
+
+./example_st4pay_r.sh $PAY_BEGIN $PAY_END $AMOUNT
+
+sleep 2
+
+# reset
+./ptarmcli --debug 16 $PAYER_PORT

--- a/tests/2nodes_test/example_st4fail4d.sh
+++ b/tests/2nodes_test/example_st4fail4d.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+#   PAYERが不正なversionのonionを作成する
+
+PAY_BEGIN=4444
+PAY_END=3333
+AMOUNT=100000
+PAYER_PORT=$(( ${PAY_BEGIN} + 1 ))
+
+# create invalid version onion
+./ptarmcli --debug 32 $PAYER_PORT
+
+./example_st4pay_r.sh $PAY_BEGIN $PAY_END $AMOUNT
+
+sleep 2
+
+# reset
+./ptarmcli --debug 32 $PAYER_PORT

--- a/tests/4nodes_test/clean.sh
+++ b/tests/4nodes_test/clean.sh
@@ -2,7 +2,7 @@
 killall ptarmd
 bitcoin-cli -conf=`pwd`/regtest.conf -datadir=`pwd`/regtest stop
 sleep 1
-rm -rf *.cnl node_3333 node_4444 node_5555 node_6666 conf pay_*.conf routing.dot routing.png regtest *.log
+rm -rf *.cnl node_3333 node_4444 node_5555 node_6666 conf pay_*.conf routing.dot routing.png regtest *.log n?.txt anno.conf channel.conf
 
 # remove synbolic link
 rm ptarmcli ptarmd showdb routing fund-test-in.sh regtest.conf generate.sh default_conf.sh

--- a/tests/4nodes_test/example_st4fail4c.sh
+++ b/tests/4nodes_test/example_st4fail4c.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+PAY_BEGIN=4444
+PAY_END=6666
+AMOUNT=100000
+PAYER_PORT=$(( ${PAY_BEGIN} + 1 ))
+
+# create invalid realm onion
+./ptarmcli --debug 16 $PAYER_PORT
+
+./example_st4pay_r.sh $PAY_BEGIN $PAY_END $AMOUNT $1
+
+sleep 2
+
+# reset
+./ptarmcli --debug 16 $PAYER_PORT

--- a/utl/utl_misc.c
+++ b/utl/utl_misc.c
@@ -146,3 +146,24 @@ void utl_misc_bin2str_rev(char *pStr, const uint8_t *pBin, uint32_t BinLen)
     }
 }
 
+
+uint16_t utl_misc_be16(const uint8_t *pData)
+{
+    return (uint16_t)((uint16_t)pData[0] << 8 | (uint16_t)pData[1]);
+}
+
+
+uint32_t utl_misc_be32(const uint8_t *pData)
+{
+    return (uint32_t)((uint32_t)pData[0] << 24 | (uint32_t)pData[1] << 16 |
+                (uint32_t)pData[2] << 8 | (uint32_t)pData[3]);
+}
+
+
+uint64_t utl_misc_be64(const uint8_t *pData)
+{
+    return (uint64_t)((uint64_t)pData[0] << 56 | (uint64_t)pData[1] << 48 |
+                (uint64_t)pData[2] << 40 | (uint64_t)pData[3] << 32 |
+                (uint64_t)pData[4] << 24 | (uint64_t)pData[5] << 16 |
+                (uint64_t)pData[6] <<  8 | (uint64_t)pData[7]);
+}

--- a/utl/utl_misc.h
+++ b/utl/utl_misc.h
@@ -116,6 +116,29 @@ void utl_misc_bin2str_rev(char *pStr, const uint8_t *pBin, uint32_t BinLen);
 void utl_misc_strftime(char *pTmStr, uint32_t Tm);
 
 
+/** convert uint8_t[] --> uint16_t
+ * 
+ * @param[in]   pData       big endian
+ * @return  uint16_t
+ */
+uint16_t utl_misc_be16(const uint8_t *pData);
+
+
+/** convert uint8_t[] --> uint32_t
+ * 
+ * @param[in]   pData       big endian
+ * @return  uint32_t
+ */
+uint32_t utl_misc_be32(const uint8_t *pData);
+
+
+/** convert uint8_t[] --> uint64_t
+ * 
+ * @param[in]   pData       big endian
+ * @return  uint64_t
+ */
+uint64_t utl_misc_be64(const uint8_t *pData);
+
 #ifdef __cplusplus
 }
 #endif  //__cplusplus


### PR DESCRIPTION
`update_fail_malformed_htlc`に対応。
ただし、2ノード間でしかテストできていない。