### PR TITLE
utl: add utl_args.[ch]

### DIFF
--- a/utl/Makefile
+++ b/utl/Makefile
@@ -43,6 +43,7 @@ C_SOURCE_FILES += $(PRJ_PATH)/utl_misc.c
 C_SOURCE_FILES += $(PRJ_PATH)/utl_buf.c
 C_SOURCE_FILES += $(PRJ_PATH)/utl_push.c
 C_SOURCE_FILES += $(PRJ_PATH)/utl_net.c
+C_SOURCE_FILES += $(PRJ_PATH)/utl_args.c
 C_SOURCE_FILES += $(PRJ_PATH)/utl_str.c
 #ifeq ($(findstring 1,$(USE_PLOG_PTARMD) $(USE_PLOG_PTARMLIB)), 1)
 C_SOURCE_FILES += $(PRJ_PATH)/utl_log.c

--- a/utl/tests/test_utl.cpp
+++ b/utl/tests/test_utl.cpp
@@ -13,6 +13,7 @@ extern "C" {
 #include "utl_log.c"
 #include "utl_net.c"
 #include "utl_str.c"
+#include "utl_args.c"
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -37,3 +38,4 @@ TEST_F(utl, first)
 #include "testinc_push.cpp"
 #include "testinc_net.cpp"
 #include "testinc_str.cpp"
+#include "testinc_args.cpp"

--- a/utl/tests/testinc_args.cpp
+++ b/utl/tests/testinc_args.cpp
@@ -1,0 +1,358 @@
+////////////////////////////////////////////////////////////////////////
+//FAKE関数
+
+//FAKE_VALUE_FUNC(int, external_function, int);
+
+////////////////////////////////////////////////////////////////////////
+
+class args: public testing::Test {
+protected:
+    virtual void SetUp() {
+        //RESET_FAKE(external_function)
+        utl_dbg_malloc_cnt_reset();
+    }
+
+    virtual void TearDown() {
+        ASSERT_EQ(0, utl_dbg_malloc_cnt());
+    }
+
+public:
+    static void DumpBin(const uint8_t *pData, uint16_t Len)
+    {
+        for (uint16_t lp = 0; lp < Len; lp++) {
+            printf("%02x", pData[lp]);
+        }
+        printf("\n");
+    }
+};
+
+////////////////////////////////////////////////////////////////////////
+
+/*typedef struct {
+    const char      *name;          ///< name(required, but set NULL in the watchdog entry)
+    const char      *arg;           ///< arg(optional, if set, display name=<arg>)
+    const char      *param_default; ///< param_default(optional)
+    const char      *help;          ///< help(optional)
+    char            *param;         ///< param
+    bool            is_set;         ///< is_set
+} utl_arginfo_t;*/
+
+TEST_F(args, parse0)
+{
+    // argv[0]: program -- skip
+    // argv[1]: -option0
+    // argv[2]: -option1
+
+    utl_arginfo_t arginfo[] = {
+        {"-name0", "arg0", "param_default0", "help0", NULL, false},
+        {"-name1", "arg1", "param_default1", "help1", NULL, false},
+        {"-name2", "arg2", "param_default2", "help2", NULL, false},
+        {NULL, NULL, NULL, NULL, NULL, false}, //watchdog
+    };
+
+    const char* argv[] = {
+        "program",
+        "-name0=arg0",
+        "-name1=arg1",
+    };
+
+    ASSERT_TRUE(utl_args_parse(arginfo, ARRAY_SIZE(argv), argv));
+    utl_args_free(arginfo);
+}
+
+TEST_F(args, parse1)
+{
+    // argv[0]: program -- skip
+    // argv[1]: command
+    // argv[2]: -option0
+    // argv[3]: -option1
+
+    utl_arginfo_t arginfo[] = {
+        {"-name0", "arg0", "param_default0", "help0", NULL, false},
+        {"-name1", "arg1", "param_default1", "help1", NULL, false},
+        {"-name2", "arg2", "param_default2", "help2", NULL, false},
+        {NULL, NULL, NULL, NULL, NULL, false}, //watchdog
+    };
+
+    const char* argv[] = {
+        "program",
+        "command",
+        "-name0=arg0",
+        "-name1=arg1",
+    };
+
+    ASSERT_TRUE(utl_args_parse(arginfo, ARRAY_SIZE(argv), argv));
+    utl_args_free(arginfo);
+}
+
+TEST_F(args, parse2)
+{
+    // argv[0]: program -- skip
+    // argv[1]: command
+    // argv[2]: -option0
+    // argv[3]: -option1
+    // argv[4]: command_param0 -- skip
+    // argv[5]: command_param1 -- skip
+
+    utl_arginfo_t arginfo[] = {
+        {"-name0", "arg0", "param_default0", "help0", NULL, false},
+        {"-name1", "arg1", "param_default1", "help1", NULL, false},
+        {"-name2", "arg2", "param_default2", "help2", NULL, false},
+        {NULL, NULL, NULL, NULL, NULL, false}, //watchdog
+    };
+
+    const char* argv[] = {
+        "program",
+        "command",
+        "-name0=arg0",
+        "-name1=arg1",
+        "command_param0",
+        "command_param1",
+    };
+
+    ASSERT_TRUE(utl_args_parse(arginfo, ARRAY_SIZE(argv), argv));
+    utl_args_free(arginfo);
+}
+
+TEST_F(args, parse_invalid0)
+{
+    utl_arginfo_t arginfo[] = {
+        //arg == NULL && param_default == "param_default0" -> invalid
+        {"-name0", NULL, "param_default0", "help0", NULL, false},
+        {NULL, NULL, NULL, NULL, NULL, false}, //watchdog
+    };
+
+    const char* argv[] = {
+        "program",
+        "-name0=arg0",
+        "-name1=arg1",
+    };
+
+    ASSERT_FALSE(utl_args_parse(arginfo, ARRAY_SIZE(argv), argv));
+}
+
+TEST_F(args, parse_invalid1)
+{
+    utl_arginfo_t arginfo[] = {
+        //is_set == true -> invalid
+        {"-name0", "arg0", "param_default0", "help0", NULL, true},
+        {NULL, NULL, NULL, NULL, NULL, false}, //watchdog
+    };
+
+    const char* argv[] = {
+        "program",
+        "-name0=arg0",
+        "-name1=arg1",
+    };
+
+    ASSERT_FALSE(utl_args_parse(arginfo, ARRAY_SIZE(argv), argv));
+}
+
+TEST_F(args, parse_invalid2)
+{
+    char param0[] = {'p', 'a', 'r', 'a', 'm', '0', '\0'};
+    utl_arginfo_t arginfo[] = {
+        //param == "param0" -> invalid
+        {"-name0", "arg0", "param_default0", "help0", param0, false},
+        {NULL, NULL, NULL, NULL, NULL, false}, //watchdog
+    };
+
+    const char* argv[] = {
+        "program",
+        "-name0=arg0",
+        "-name1=arg1",
+    };
+
+    ASSERT_FALSE(utl_args_parse(arginfo, ARRAY_SIZE(argv), argv));
+}
+
+TEST_F(args, option_with_no_arg)
+{
+    utl_arginfo_t arginfo[] = {
+        {"-name0", NULL, NULL, "help0", NULL, false},
+        {NULL, NULL, NULL, NULL, NULL, false}, //watchdog
+    };
+    {
+        const char* argv[] = {
+            "program",
+            //empty
+        };
+        ASSERT_TRUE(utl_args_parse(arginfo, ARRAY_SIZE(argv), argv));
+        ASSERT_FALSE(utl_args_is_set(arginfo, "-name0"));
+        ASSERT_EQ(utl_args_get_string(arginfo, "-name0"), NULL);
+        utl_args_free(arginfo);
+    }
+    {
+        const char* argv[] = {
+            "program",
+            "-name0",
+        };
+        ASSERT_TRUE(utl_args_parse(arginfo, ARRAY_SIZE(argv), argv));
+        ASSERT_TRUE(utl_args_is_set(arginfo, "-name0"));
+        ASSERT_EQ(utl_args_get_string(arginfo, "-name0"), NULL);
+        utl_args_free(arginfo);
+    }
+}
+
+TEST_F(args, option_with_no_arg_invalid)
+{
+    utl_arginfo_t arginfo[] = {
+        {"-name0", NULL, NULL, "help0", NULL, false},
+        {NULL, NULL, NULL, NULL, NULL, false}, //watchdog
+    };
+    {
+        const char* argv[] = {
+            "program",
+            "-name0=param0", //invalid
+        };
+        ASSERT_FALSE(utl_args_parse(arginfo, ARRAY_SIZE(argv), argv));
+    }
+    {
+        const char* argv[] = {
+            "program",
+            "-name1", //invalid
+        };
+        ASSERT_FALSE(utl_args_parse(arginfo, ARRAY_SIZE(argv), argv));
+    }
+}
+
+TEST_F(args, option_with_arg)
+{
+    utl_arginfo_t arginfo[] = {
+        {"-name0", "arg0", NULL, "help0", NULL, false},
+        {NULL, NULL, NULL, NULL, NULL, false}, //watchdog
+    };
+    {
+        const char* argv[] = {
+            "program",
+            //empty
+        };
+        ASSERT_TRUE(utl_args_parse(arginfo, ARRAY_SIZE(argv), argv));
+        ASSERT_FALSE(utl_args_is_set(arginfo, "-name0"));
+        ASSERT_EQ(utl_args_get_string(arginfo, "-name0"), NULL);
+        utl_args_free(arginfo);
+    }
+    {
+        const char* argv[] = {
+            "program",
+            "-name0=param0",
+        };
+        ASSERT_TRUE(utl_args_parse(arginfo, ARRAY_SIZE(argv), argv));
+        ASSERT_TRUE(utl_args_is_set(arginfo, "-name0"));
+        ASSERT_STREQ(utl_args_get_string(arginfo, "-name0"), "param0");
+        utl_args_free(arginfo);
+    }
+}
+
+TEST_F(args, option_with_arg_invalid)
+{
+    utl_arginfo_t arginfo[] = {
+        {"-name0", "arg0", NULL, "help0", NULL, false},
+        {NULL, NULL, NULL, NULL, NULL, false}, //watchdog
+    };
+    {
+        const char* argv[] = {
+            "program",
+            "-name0", //invalid
+        };
+        ASSERT_FALSE(utl_args_parse(arginfo, ARRAY_SIZE(argv), argv));
+    }
+    {
+        const char* argv[] = {
+            "program",
+            "-name1=param1", //invalid
+        };
+        ASSERT_FALSE(utl_args_parse(arginfo, ARRAY_SIZE(argv), argv));
+    }
+}
+
+TEST_F(args, option_with_arg_and_param_default) {
+    utl_arginfo_t arginfo[] = {
+        {"-name0", "arg0", "param_default0", "help0", NULL, false},
+        {NULL, NULL, NULL, NULL, NULL, false}, //watchdog
+    };
+    {
+        const char* argv[] = {
+            "program",
+            //empty
+        };
+        ASSERT_TRUE(utl_args_parse(arginfo, ARRAY_SIZE(argv), argv));
+        ASSERT_TRUE(utl_args_is_set(arginfo, "-name0"));
+        ASSERT_STREQ(utl_args_get_string(arginfo, "-name0"), "param_default0");
+        utl_args_free(arginfo);
+    }
+    {
+        const char* argv[] = {
+            "program",
+            "-name0=param0",
+        };
+        ASSERT_TRUE(utl_args_parse(arginfo, ARRAY_SIZE(argv), argv));
+        ASSERT_TRUE(utl_args_is_set(arginfo, "-name0"));
+        ASSERT_STREQ(utl_args_get_string(arginfo, "-name0"), "param0");
+        utl_args_free(arginfo);
+    }
+}
+
+TEST_F(args, option_with_arg_and_param_default_invalid)
+{
+    utl_arginfo_t arginfo[] = {
+        {"-name0", "arg0", "param_default0", "help0", NULL, false},
+        {NULL, NULL, NULL, NULL, NULL, false}, //watchdog
+    };
+    {
+        const char* argv[] = {
+            "program",
+            "-name0", //invalid
+        };
+        ASSERT_FALSE(utl_args_parse(arginfo, ARRAY_SIZE(argv), argv));
+    }
+    {
+        const char* argv[] = {
+            "program",
+            "-name1=param1", //invalid
+        };
+        ASSERT_FALSE(utl_args_parse(arginfo, ARRAY_SIZE(argv), argv));
+    }
+}
+
+TEST_F(args, arg_type_u32)
+{
+    utl_arginfo_t arginfo[] = {
+        {"-name0", "arg0", NULL, "help0", NULL, false},
+        {NULL, NULL, NULL, NULL, NULL, false}, //watchdog
+    };
+    {
+        const char* argv[] = {
+            "program",
+            "-name0=1234567890"
+        };
+        ASSERT_TRUE(utl_args_parse(arginfo, ARRAY_SIZE(argv), argv));
+        ASSERT_TRUE(utl_args_is_set(arginfo, "-name0"));
+        ASSERT_STREQ(utl_args_get_string(arginfo, "-name0"), "1234567890");
+        uint32_t n;
+        ASSERT_TRUE(utl_args_get_u32(arginfo, &n, "-name0"));
+        ASSERT_EQ(n, 1234567890);
+        utl_args_free(arginfo);
+    }
+}
+
+TEST_F(args, arg_type_u32_invalid)
+{
+    utl_arginfo_t arginfo[] = {
+        {"-name0", "arg0", NULL, "help0", NULL, false},
+        {NULL, NULL, NULL, NULL, NULL, false}, //watchdog
+    };
+    {
+        const char* argv[] = {
+            "program",
+            "-name0=param0"
+        };
+        ASSERT_TRUE(utl_args_parse(arginfo, ARRAY_SIZE(argv), argv));
+        ASSERT_TRUE(utl_args_is_set(arginfo, "-name0"));
+        ASSERT_STREQ(utl_args_get_string(arginfo, "-name0"), "param0");
+        uint32_t n;
+        ASSERT_FALSE(utl_args_get_u32(arginfo, &n, "-name0"));
+        utl_args_free(arginfo);
+    }
+}
+

--- a/utl/utl_args.c
+++ b/utl/utl_args.c
@@ -1,0 +1,169 @@
+/*
+ *  Copyright (C) 2017, Nayuta, Inc. All Rights Reserved
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+#include <string.h>
+
+#include "utl_dbg.h"
+#include "utl_str.h"
+#include "utl_args.h"
+
+
+/**************************************************************************
+ * prototypes
+ **************************************************************************/
+
+static utl_arginfo_t *findn_arginfo(utl_arginfo_t* arginfo, const char* name, int len);
+static utl_arginfo_t *find_arginfo(utl_arginfo_t* arginfo, const char* name);
+
+
+/**************************************************************************
+ * public functions
+ **************************************************************************/
+
+bool utl_args_parse(utl_arginfo_t* arginfo, int argc, const char* const argv[])
+{
+    //case1
+    // argv[0]: program -- skip
+    // argv[1]: -option0
+    // argv[2]: -option1
+
+    //case2
+    // argv[0]: program -- skip
+    // argv[1]: command -- skip
+    // argv[2]: -option0
+    // argv[3]: -option1
+    // argv[5]: command_param0 -- skip
+    // argv[6]: command_param1 -- skip
+
+    bool ret = false;
+    int offset = 1;
+
+    if (argc < 1) return false;
+    if (argc >= 2) {
+        if (argv[1][0] != '-') {
+            //skip command
+            offset++;
+        }
+    }
+    
+    for (int i = 0; arginfo[i].name; i++) {
+        if (!arginfo[i].arg) {
+            if (arginfo[i].param_default) return false;
+        }
+        if (arginfo[i].param) return false;
+        if (arginfo[i].is_set) return false;
+    }
+
+    for (int i = offset; i < argc; i++) {
+        const char *v = argv[i];
+
+        //skip command_params
+        if (v[0] != '-') break;
+
+        const char *p = strchr(v, '=');
+        int v_len = strlen(v);
+        if (p) {
+            v_len = p - v;
+        }
+
+        utl_arginfo_t *info = findn_arginfo(arginfo, v, v_len);
+        if (!info) goto LABEL_EXIT;
+        if (info->is_set) goto LABEL_EXIT;
+        if (info->arg && p) {
+            info->param = UTL_DBG_STRDUP(p + 1);
+        } else if (!info->arg && !p) {
+        } else {
+            goto LABEL_EXIT;
+        }
+        info->is_set = true;
+    }
+
+    for (int i = 0; arginfo[i].name; i++) {
+        utl_arginfo_t *info = &arginfo[i];
+        if (!info->is_set && info->param_default) {
+            info->param = UTL_DBG_STRDUP(info->param_default);
+            info->is_set = true;
+        }
+    }
+
+    ret = true;
+
+LABEL_EXIT:
+    if (!ret) {
+        utl_args_free(arginfo);
+    }
+    return ret;
+}
+
+bool utl_args_is_set(utl_arginfo_t* arginfo, const char *name)
+{
+    utl_arginfo_t *info = find_arginfo(arginfo, name);
+    if (!info) return false;
+    return info->is_set;
+}
+
+const char *utl_args_get_string(utl_arginfo_t* arginfo, const char *name)
+{
+    utl_arginfo_t *info = find_arginfo(arginfo, name);
+    if (!info) return NULL;
+    if (!info->is_set) return NULL;
+    return info->param;
+}
+
+bool utl_args_get_u32(utl_arginfo_t* arginfo, uint32_t* n, const char *name)
+{
+    utl_arginfo_t *info = find_arginfo(arginfo, name);
+    if (!info) return false;
+    if (!info->is_set) return false;
+    if (!info->param) return false;
+    if (!utl_str_scan_u32(n, info->param)) return false;
+    return true;
+}
+
+void utl_args_free(utl_arginfo_t* arginfo)
+{
+    for (int i = 0; arginfo[i].name; i++) {
+        arginfo[i].is_set = false;
+        if (!arginfo[i].param) continue;
+        UTL_DBG_FREE(arginfo[i].param);
+        arginfo[i].param = 0;
+    }
+}
+
+
+/**************************************************************************
+ * private functions
+ **************************************************************************/
+
+static utl_arginfo_t *findn_arginfo(utl_arginfo_t* arginfo, const char* name, int len)
+{
+    for (int i = 0; arginfo[i].name; i++) {
+        if (!strncmp(name, arginfo[i].name, len)) return &arginfo[i];
+    }
+    return NULL;
+}
+
+static utl_arginfo_t *find_arginfo(utl_arginfo_t* arginfo, const char* name)
+{
+    return findn_arginfo(arginfo, name, strlen(name));
+}
+

--- a/utl/utl_args.h
+++ b/utl/utl_args.h
@@ -1,0 +1,78 @@
+/*
+ *  Copyright (C) 2017, Nayuta, Inc. All Rights Reserved
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+/**
+ * @file    utl_args.h
+ * @brief   utl_args.h
+ */
+#ifndef UTL_ARGS_H__
+#define UTL_ARGS_H__
+
+#include <stdint.h>
+#include <stdbool.h>
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif  //__cplusplus
+
+/**************************************************************************
+ * macros
+ **************************************************************************/
+
+/**************************************************************************
+ * types
+ **************************************************************************/
+
+/** @struct utl_arginfo_t
+ *  @brief  utl_arginfo_t
+ *
+ */
+typedef struct {
+    const char      *name;          ///< name(required, but set NULL in the watchdog entry)
+    const char      *arg;           ///< arg(optional, if set, display name=<arg>)
+    const char      *param_default; ///< param_default(optional)
+    const char      *help;          ///< help(optional)
+    char            *param;         ///< param
+    bool            is_set;         ///< is_set
+} utl_arginfo_t;
+
+
+/**************************************************************************
+ * prototypes
+ **************************************************************************/
+
+bool utl_args_parse(utl_arginfo_t* arginfo, int argc, const char* const argv[]);
+
+bool utl_args_is_set(utl_arginfo_t* arginfo, const char *name);
+
+const char *utl_args_get_string(utl_arginfo_t* arginfo, const char *name);
+
+bool utl_args_get_u32(utl_arginfo_t* arginfo, uint32_t* n, const char *name);
+
+void utl_args_free(utl_arginfo_t* arginfo);
+
+
+#ifdef __cplusplus
+}
+#endif  //__cplusplus
+
+#endif /* UTL_ARGS_H__ */

--- a/utl/utl_args.h
+++ b/utl/utl_args.h
@@ -62,13 +62,13 @@ typedef struct {
 
 bool utl_args_parse(utl_arginfo_t* arginfo, int argc, const char* const argv[]);
 
+void utl_args_free(utl_arginfo_t* arginfo);
+
 bool utl_args_is_set(utl_arginfo_t* arginfo, const char *name);
 
 const char *utl_args_get_string(utl_arginfo_t* arginfo, const char *name);
 
 bool utl_args_get_u32(utl_arginfo_t* arginfo, uint32_t* n, const char *name);
-
-void utl_args_free(utl_arginfo_t* arginfo);
 
 
 #ifdef __cplusplus


### PR DESCRIPTION
コマンドラインオプション（argv）パース用
bitcoind形式のオプションを想定
引数あり：-name=\<arg\>
引数なし：-name

utl_arginfo_t型のスタティックなテーブルに、対応するオプションとデフォルト値、helpの文言等を定義し、そのテーブルとargv、argcを一緒にパースする。

utl_args_is_setでオプションが設定されているか確認。
引数ありの場合には、utl_args_get_string等で設定されたオプションの値やデフォルト値を取得。
