### PR TITLE
utl: add utl_jsonrpc.[ch]

### DIFF
--- a/utl/Makefile
+++ b/utl/Makefile
@@ -45,6 +45,7 @@ C_SOURCE_FILES += $(PRJ_PATH)/utl_push.c
 C_SOURCE_FILES += $(PRJ_PATH)/utl_net.c
 C_SOURCE_FILES += $(PRJ_PATH)/utl_args.c
 C_SOURCE_FILES += $(PRJ_PATH)/utl_str.c
+C_SOURCE_FILES += $(PRJ_PATH)/utl_jsonrpc.c
 #ifeq ($(findstring 1,$(USE_PLOG_PTARMD) $(USE_PLOG_PTARMLIB)), 1)
 C_SOURCE_FILES += $(PRJ_PATH)/utl_log.c
 #endif

--- a/utl/tests/test_utl.cpp
+++ b/utl/tests/test_utl.cpp
@@ -14,6 +14,7 @@ extern "C" {
 #include "utl_net.c"
 #include "utl_str.c"
 #include "utl_args.c"
+#include "utl_jsonrpc.c"
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -39,3 +40,4 @@ TEST_F(utl, first)
 #include "testinc_net.cpp"
 #include "testinc_str.cpp"
 #include "testinc_args.cpp"
+#include "testinc_jsonrpc.cpp"

--- a/utl/tests/testinc_jsonrpc.cpp
+++ b/utl/tests/testinc_jsonrpc.cpp
@@ -1,0 +1,63 @@
+////////////////////////////////////////////////////////////////////////
+//FAKE関数
+
+//FAKE_VALUE_FUNC(int, external_function, int);
+
+////////////////////////////////////////////////////////////////////////
+
+class jsonrpc: public testing::Test {
+protected:
+    virtual void SetUp() {
+        //RESET_FAKE(external_function)
+        utl_dbg_malloc_cnt_reset();
+    }
+
+    virtual void TearDown() {
+        ASSERT_EQ(0, utl_dbg_malloc_cnt());
+    }
+
+public:
+    static void DumpBin(const uint8_t *pData, uint16_t Len)
+    {
+        for (uint16_t lp = 0; lp < Len; lp++) {
+            printf("%02x", pData[lp]);
+        }
+        printf("\n");
+    }
+};
+
+////////////////////////////////////////////////////////////////////////
+
+TEST_F(jsonrpc, create_request)
+{
+    utl_jsonrpc_param_t non_string_params[] = {
+        {"method0", 0},
+        {"method1", 0},
+        {"method1", 1},
+        {"method2", 1},
+        {"method2", 2},
+        {NULL, 0}, //watchdog
+    };
+
+    const char *method = "method2";
+
+    const char *paramv[] = {
+        "param0", //string
+        "param1", //non-string
+        "param2", //non-string
+        "param3", //string
+    };
+
+    utl_str_t body;
+    utl_str_init(&body);
+    ASSERT_TRUE(utl_jsonrpc_create_request(&body, method, paramv, ARRAY_SIZE(paramv), non_string_params));
+    const char *p = utl_str_get(&body);
+    ASSERT_NE(p, NULL);
+    ASSERT_STREQ(p, ""
+        "{"
+        "\"method\":\"method2\","
+        "\"params\":[\"param0\",param1,param2,\"param3\"]"
+        "}"
+    );
+    utl_str_free(&body);
+}

--- a/utl/utl_jsonrpc.c
+++ b/utl/utl_jsonrpc.c
@@ -1,0 +1,79 @@
+/*
+ *  Copyright (C) 2017, Nayuta, Inc. All Rights Reserved
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+#include <string.h>
+
+#include "utl_str.h"
+#include "utl_jsonrpc.h"
+
+
+/**************************************************************************
+ * prototypes
+ **************************************************************************/
+
+static bool param_is_set(const utl_jsonrpc_param_t params[], const char *method, int index);
+
+
+/**************************************************************************
+ * public functions
+ **************************************************************************/
+
+bool utl_jsonrpc_create_request(utl_str_t *body, const char *method, const char *paramv[], int paramc, const utl_jsonrpc_param_t non_string_params[])
+{
+    bool ret = false;
+    utl_str_init(body);
+
+    if (!utl_str_append(body, "{\"method\":\"")) goto LABEL_EXIT;
+    if (!utl_str_append(body, method)) goto LABEL_EXIT;
+    if (!utl_str_append(body, "\",\"params\":[")) goto LABEL_EXIT;
+    for (int i = 0; i < paramc; i++) {
+        if (i && !utl_str_append(body, ",")) goto LABEL_EXIT;
+        if (param_is_set(non_string_params, method, i)) {
+            if (!utl_str_append(body, paramv[i])) goto LABEL_EXIT;
+        } else {
+            if (!utl_str_append(body, "\"")) goto LABEL_EXIT;
+            if (!utl_str_append(body, paramv[i])) goto LABEL_EXIT;
+            if (!utl_str_append(body, "\"")) goto LABEL_EXIT;
+        }
+    }
+    if (!utl_str_append(body, "]}")) goto LABEL_EXIT;
+    ret = true;
+
+LABEL_EXIT:
+    if (!ret) {
+        utl_str_free(body);
+    }
+    return ret;
+}
+
+
+/**************************************************************************
+ * private functions
+ **************************************************************************/
+
+static bool param_is_set(const utl_jsonrpc_param_t params[], const char *method, int index) {
+    for (int i = 0; params[i].method; i++) {
+        if (strcmp(params[i].method, method)) continue;
+        if (params[i].index == index) return true;
+    }
+    return false;
+}

--- a/utl/utl_jsonrpc.h
+++ b/utl/utl_jsonrpc.h
@@ -1,0 +1,77 @@
+/*
+ *  Copyright (C) 2017, Nayuta, Inc. All Rights Reserved
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+/**
+ * @file    utl_jsonrpc.h
+ * @brief   utl_jsonrpc
+ */
+#ifndef UTL_JSONRPC_H__
+#define UTL_JSONRPC_H__
+
+#include <stdint.h>
+#include <inttypes.h>
+#include <stdbool.h>
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif  //__cplusplus
+
+
+/**************************************************************************
+ * macros
+ **************************************************************************/
+
+/********************************************************************
+ * typedefs
+ ********************************************************************/
+
+/** @struct utl_jsonrpc_param_t
+ *  @brief  params
+ *
+ */
+typedef struct {
+    const char *method;     ///< method
+    int index;              ///< index of params
+} utl_jsonrpc_param_t;
+
+
+/**************************************************************************
+ * prototypes
+ **************************************************************************/
+
+/** create json-rpc request
+ *
+ * @param[in/out]   body                json-rpc request body
+ * @param[in]       method              method
+ * @param[in]       paramv              param values
+ * @param[in]       paramc              param count
+ * @param[in]       non_string_params   params of non-string(bool/number/etc.)
+ * @retval          true                success
+ */
+bool utl_jsonrpc_create_request(utl_str_t *body, const char *method, const char *paramv[], int paramc, const utl_jsonrpc_param_t *non_string_params);
+
+
+#ifdef __cplusplus
+}
+#endif  //__cplusplus
+
+#endif /* UTL_JSONRPC_H__ */


### PR DESCRIPTION
jsonrpcのbody作成用の関数を追加

bool utl_jsonrpc_create_request(
utl_str_t *body,
const char *method,
const char *paramv[],
int paramc,
const utl_jsonrpc_param_t *non_string_params
);

上４つは説明不要であろう。
最後はparamvの要素がstringかそれ以外（bool/number/etc.）であるかを判断するためのテーブルである。