### PR TITLE
fix ekey print

### DIFF
--- a/btc/btc.h
+++ b/btc/btc.h
@@ -212,7 +212,7 @@ typedef struct {
     uint32_t    fingerprint;                    ///<
     uint32_t    child_number;                   ///<
     uint8_t     chain_code[BTC_SZ_CHAINCODE];   ///<
-    uint8_t     key[BTC_SZ_PUBKEY];             ///<
+    uint8_t     key[BTC_SZ_PUBKEY];             ///< typeがBTC_EKEY_PRIVの場合、先頭の32byteが有効
 } btc_ekey_t;
 
 
@@ -326,7 +326,7 @@ btc_chain_t btc_get_chain(void);
 bool btc_keys_wif2priv(uint8_t *pPrivKey, btc_chain_t *pChain, const char *pWifPriv);
 
 
-/** RAW秘密鍵をWI形式秘密鍵に変換
+/** RAW秘密鍵をWIF形式秘密鍵に変換
  *
  * @param[out]      pWifPriv
  * @param[in]       pPrivKey
@@ -356,7 +356,7 @@ bool btc_keys_pub2p2pkh(char *pAddr, const uint8_t *pPubKey);
 
 /** 公開鍵をBitcoinアドレス(P2WPKH)に変換
  *
- * @param[out]      pWAddr          変換後データ(BTC_SZ_WPKHADDR以上のサイズを想定)
+ * @param[out]      pWAddr          変換後データ(#BTC_SZ_ADDR_MAX 以上のサイズを想定)
  * @param[in]       pPubKey         対象データ(BTC_SZ_PUBKEY)
  */
 bool btc_keys_pub2p2wpkh(char *pWAddr, const uint8_t *pPubKey);

--- a/btc/btc_ekey.c
+++ b/btc/btc_ekey.c
@@ -353,15 +353,17 @@ void btc_print_extendedkey(const btc_ekey_t *pEKey)
     btc_util_dumpbin(fp, pEKey->chain_code, 32, true);
     if (pEKey->type == BTC_EKEY_PUB) {
         fprintf(fp, "pubkey: ");
-        btc_util_dumpbin(fp, pEKey->key, 33, true);
+        btc_util_dumpbin(fp, pEKey->key, BTC_SZ_PUBKEY, true);
     } else {
         fprintf(fp, "privkey: ");
-        btc_util_dumpbin(fp, pEKey->key, 32, true);
+        btc_util_dumpbin(fp, pEKey->key, BTC_SZ_PRIVKEY, true);
 
         uint8_t pubkey[BTC_SZ_PUBKEY];
-        btc_keys_priv2pub(pubkey, pEKey->key);
-        fprintf(fp, "pubkey: ");
-        btc_util_dumpbin(fp, pubkey, sizeof(pubkey), true);
+        bool b = btc_keys_priv2pub(pubkey, pEKey->key);
+        if (b) {
+            fprintf(fp, "pubkey: ");
+            btc_util_dumpbin(fp, pubkey, sizeof(pubkey), true);
+        }
     }
     fprintf(fp, "------------------------\n");
 }

--- a/btc/btc_keys.c
+++ b/btc/btc_keys.c
@@ -26,7 +26,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <assert.h>
 
 #include "mbedtls/asn1write.h"
 #include "mbedtls/ecdsa.h"
@@ -73,7 +72,6 @@ bool btc_keys_wif2priv(uint8_t *pPrivKey, btc_chain_t *pChain, const char *pWifP
         ret = (memcmp(buf_sha256, b58dec + 1 + BTC_SZ_PRIVKEY + tail, 4) == 0);
     } else {
         ret = false;
-        assert(0);
     }
     if (ret) {
         memcpy(pPrivKey, b58dec + 1, BTC_SZ_PRIVKEY);
@@ -128,12 +126,10 @@ bool btc_keys_priv2pub(uint8_t *pPubKey, const uint8_t *pPrivKey)
     //P:result, m:掛ける数値, grp.G:point
     ret = mbedtls_mpi_read_binary(&m, pPrivKey, BTC_SZ_PRIVKEY);
     if (ret) {
-        assert(0);
         goto LABEL_EXIT;
     }
     ret = mbedtls_ecp_mul(&keypair.grp, &P, &m, &keypair.grp.G, NULL, NULL);
     if (ret) {
-        assert(0);
         goto LABEL_EXIT;
     }
 


### PR DESCRIPTION
ekeyのprint APIで、key[]にでたらめな値が入っているとABORTしていた。