### PR TITLE
move to btc_local.h using only libbtc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,17 +22,18 @@ endif
 
 all: lib default
 
-small:
-	$(MAKE) CFLAGS=-DPTARM_UTL_LOG_MACRO_DISABLED -C utl
-	$(MAKE) CFLAGS=-DPTARM_UTL_LOG_MACRO_DISABLED -C btc
-	mkdir -p $(INSTALL_DIR)/small/include
-	mkdir -p $(INSTALL_DIR)/small/lib
-	cp utl/libutl.a $(INSTALL_DIR)/small/lib/
-	cp btc/libbtc.a $(INSTALL_DIR)/small/lib/
-	cp -ra utl/utl_buf.h $(INSTALL_DIR)/small/include/
-	cp -ra btc/btc.h $(INSTALL_DIR)/small/include/
-	cp libs/install/lib/libbase58.a $(INSTALL_DIR)/small/lib/
-	cp libs/install/lib/libmbedcrypto.a $(INSTALL_DIR)/small/lib/
+btconly:
+	$(MAKE) -C utl
+	$(MAKE) -C btc
+	mkdir -p $(INSTALL_DIR)/ptarmbtc/include
+	mkdir -p $(INSTALL_DIR)/ptarmbtc/lib
+	cp utl/libutl.a $(INSTALL_DIR)/ptarmbtc/lib/
+	cp btc/libbtc.a $(INSTALL_DIR)/ptarmbtc/lib/
+	cp -ra utl/utl_buf.h $(INSTALL_DIR)/ptarmbtc/include/
+	cp -ra utl/utl_log.h $(INSTALL_DIR)/ptarmbtc/include/
+	cp -ra btc/btc.h $(INSTALL_DIR)/ptarmbtc/include/
+	cp libs/install/lib/libbase58.a $(INSTALL_DIR)/ptarmbtc/lib/
+	cp libs/install/lib/libmbedcrypto.a $(INSTALL_DIR)/ptarmbtc/lib/
 
 clean:
 	$(MAKE) -C gtest clean
@@ -46,7 +47,7 @@ clean:
 	-@rm -rf $(INSTALL_DIR)/ptarmd $(INSTALL_DIR)/ptarmcli $(INSTALL_DIR)/showdb $(INSTALL_DIR)/routing GPATH GRTAGS GSYMS GTAGS
 
 full: git_subs lib default
-full_small: git_subs lib small
+full_btconly: git_subs lib btconly
 
 distclean: lib_clean clean
 

--- a/btc/btc.h
+++ b/btc/btc.h
@@ -1239,10 +1239,10 @@ void btc_util_sort_bip69(btc_tx_t *pTx);
 btc_genesis_t btc_util_get_genesis(const uint8_t *pGenesisHash);
 
 
-/** ブロックチェーンハッシュ取得
+/** genesis block hash取得
  *
  * @param[in]       Kind
- * @return      ブロックチェーンハッシュ(未知のKindの場合はNULL)
+ * @return      genesis block hash(未知のKindの場合はNULL)
  */
 const uint8_t *btc_util_get_genesis_block(btc_genesis_t Kind);
 
@@ -1294,20 +1294,49 @@ void btc_util_hash256(uint8_t *pHash256, const uint8_t *pData, uint16_t Len);
 void btc_util_sha256cat(uint8_t *pSha256, const uint8_t *pData1, uint16_t Len1, const uint8_t *pData2, uint16_t Len2);
 
 
-int btc_util_set_keypair(void *pKeyPair, const uint8_t *pPubKey);
+/** 圧縮公開鍵を非圧縮公開鍵展開
+ *
+ * @param[out]  point       非圧縮公開鍵座標
+ * @param[in]   pPubKey     圧縮公開鍵
+ * @return      0...正常
+ *
+ * @note
+ *      - https://gist.github.com/flying-fury/6bc42c8bb60e5ea26631
+ */
 int btc_util_ecp_point_read_binary2(void *pPoint, const uint8_t *pPubKey);
+
+
+/** PubKeyHash(P2PKH)をPubKeyHash(P2WPKH)に変換
+ *
+ * [00][14][pubKeyHash] --> HASH160
+ *
+ * @param[out]      pWPubKeyHash    変換後データ(BTC_SZ_PUBKEYHASH以上のサイズを想定)
+ * @param[in]       pPubKeyHash     対象データ(BTC_SZ_PUBKEYHASH)
+ */
 void btc_util_create_pkh2wpkh(uint8_t *pWPubKeyHash, const uint8_t *pPubKeyHash);
+
+
+/** 種類に応じたscriptPubKey設定
+ *
+ * @param[out]      pBuf
+ * @param[in]       pPubKeyHash
+ * @param[in]       Prefix
+ */
 void btc_util_create_scriptpk(utl_buf_t *pBuf, const uint8_t *pPubKeyHash, int Prefix);
-bool btc_util_keys_pkh2addr(char *pAddr, const uint8_t *pPubKeyHash, uint8_t Prefix);
+
+
+/**
+ * pPubKeyOut = pPubKeyIn + pA * G
+ *
+ */
 int btc_util_ecp_muladd(uint8_t *pResult, const uint8_t *pPubKeyIn, const void *pA);
+
+
+/**
+ * pResult = pPubKey * pMul
+ *
+ */
 bool btc_util_mul_pubkey(uint8_t *pResult, const uint8_t *pPubKey, const uint8_t *pMul, int MulLen);
-void btc_util_generate_shared_secret(uint8_t *pResult, const uint8_t *pPubKey, const uint8_t *pPrivKey);
-bool btc_util_calc_mac(uint8_t *pMac, const uint8_t *pKeyStr, int StrLen,  const uint8_t *pMsg, int MsgLen);
-bool btc_util_create_tx(utl_buf_t *pBuf, const btc_tx_t *pTx, bool enableSegWit);
-void btc_util_add_vout_pub(btc_tx_t *pTx, uint64_t Value, const uint8_t *pPubKey, uint8_t Pref);
-void btc_util_add_vout_pkh(btc_tx_t *pTx, uint64_t Value, const uint8_t *pPubKeyHash, uint8_t Pref);
-int btc_util_get_varint_len(uint32_t Len);
-int btc_util_set_varint_len(uint8_t *pData, const uint8_t *pOrg, uint32_t Len, bool isScript);
 
 
 #if defined(PTARM_USE_PRINTFUNC) || defined(PTARM_DEBUG)

--- a/btc/btc_keys.c
+++ b/btc/btc_keys.c
@@ -151,7 +151,7 @@ bool btc_keys_pub2p2pkh(char *pAddr, const uint8_t *pPubKey)
     uint8_t pkh[BTC_SZ_PUBKEYHASH];
 
     btc_util_hash160(pkh, pPubKey, BTC_SZ_PUBKEY);
-    return btc_util_keys_pkh2addr(pAddr, pkh, BTC_PREF_P2PKH);
+    return btcl_util_keys_pkh2addr(pAddr, pkh, BTC_PREF_P2PKH);
 }
 
 
@@ -169,7 +169,7 @@ bool btc_keys_pub2p2wpkh(char *pWAddr, const uint8_t *pPubKey)
         btc_util_create_pkh2wpkh(pkh, pkh);
         pref = BTC_PREF_P2SH;
     }
-    ret = btc_util_keys_pkh2addr(pWAddr, pkh, pref);
+    ret = btcl_util_keys_pkh2addr(pWAddr, pkh, pref);
     return ret;
 }
 
@@ -201,7 +201,7 @@ bool btc_keys_addr2p2wpkh(char *pWAddr, const char *pAddr)
         ret = segwit_addr_encode(pWAddr, hrp_type, 0x00, pkh, BTC_SZ_HASH160);
     } else {
         btc_util_create_pkh2wpkh(pkh, pkh);
-        ret = btc_util_keys_pkh2addr(pWAddr, pkh, BTC_PREF_P2SH);
+        ret = btcl_util_keys_pkh2addr(pWAddr, pkh, BTC_PREF_P2SH);
     }
     return ret;
 }
@@ -235,7 +235,7 @@ bool btc_keys_wit2waddr(char *pWAddr, const utl_buf_t *pWitScript)
         wit_prog[1] = BTC_SZ_HASH256;
         btc_util_sha256(wit_prog + 2, pWitScript->buf, pWitScript->len);
         btc_util_hash160(pkh, wit_prog, sizeof(wit_prog));
-        ret = btc_util_keys_pkh2addr(pWAddr, pkh, BTC_PREF_P2SH);
+        ret = btcl_util_keys_pkh2addr(pWAddr, pkh, BTC_PREF_P2SH);
     }
     return ret;
 }
@@ -247,7 +247,7 @@ bool btc_keys_pubuncomp(uint8_t *pUncomp, const uint8_t *pPubKey)
     mbedtls_ecp_keypair_init(&keypair);
     mbedtls_ecp_group_load(&(keypair.grp), MBEDTLS_ECP_DP_SECP256K1);
 
-    int ret = btc_util_set_keypair(&keypair, pPubKey);
+    int ret = btcl_util_set_keypair(&keypair, pPubKey);
     if (!ret) {
         mbedtls_mpi_write_binary(&(keypair.Q.X), pUncomp, BTC_SZ_PUBKEY - 1);
         mbedtls_mpi_write_binary(&(keypair.Q.Y), pUncomp + BTC_SZ_PUBKEY - 1, BTC_SZ_PUBKEY - 1);
@@ -288,7 +288,7 @@ bool btc_keys_chkpub(const uint8_t *pPubKey)
     mbedtls_ecp_keypair_init(&keypair);
     mbedtls_ecp_group_load(&(keypair.grp), MBEDTLS_ECP_DP_SECP256K1);
 
-    int ret = btc_util_set_keypair(&keypair, pPubKey);
+    int ret = btcl_util_set_keypair(&keypair, pPubKey);
     mbedtls_ecp_keypair_free(&keypair);
 
     return ret == 0;
@@ -437,7 +437,7 @@ bool btc_keys_spk2addr(char *pAddr, const utl_buf_t *pScriptPk)
     const uint8_t *pkh;
     int prefix = spk2prefix(&pkh, pScriptPk);
     if (prefix != BTC_PREF_MAX) {
-        btc_util_keys_pkh2addr(pAddr, pkh, prefix);
+        btcl_util_keys_pkh2addr(pAddr, pkh, prefix);
         ret = true;
     } else {
         ret = false;

--- a/btc/btc_sw.c
+++ b/btc/btc_sw.c
@@ -34,13 +34,13 @@
 
 void btc_sw_add_vout_p2wpkh_pub(btc_tx_t *pTx, uint64_t Value, const uint8_t *pPubKey)
 {
-    btc_util_add_vout_pub(pTx, Value, pPubKey, (mNativeSegwit) ? BTC_PREF_NATIVE : BTC_PREF_P2SH);
+    btcl_util_add_vout_pub(pTx, Value, pPubKey, (mNativeSegwit) ? BTC_PREF_NATIVE : BTC_PREF_P2SH);
 }
 
 
 void btc_sw_add_vout_p2wpkh(btc_tx_t *pTx, uint64_t Value, const uint8_t *pPubKeyHash)
 {
-    btc_util_add_vout_pkh(pTx, Value, pPubKeyHash, (mNativeSegwit) ? BTC_PREF_NATIVE : BTC_PREF_P2SH);
+    btcl_util_add_vout_pkh(pTx, Value, pPubKeyHash, (mNativeSegwit) ? BTC_PREF_NATIVE : BTC_PREF_P2SH);
 }
 
 
@@ -94,9 +94,9 @@ bool btc_sw_scriptcode_p2wpkh_vin(utl_buf_t *pScriptCode, const btc_vin_t *pVin)
 
 void btc_sw_scriptcode_p2wsh(utl_buf_t *pScriptCode, const utl_buf_t *pWit)
 {
-    utl_buf_alloc(pScriptCode, btc_util_get_varint_len(pWit->len) + pWit->len);
+    utl_buf_alloc(pScriptCode, btcl_util_get_varint_len(pWit->len) + pWit->len);
     uint8_t *p = pScriptCode->buf;
-    p += btc_util_set_varint_len(p, NULL, pWit->len, false);
+    p += btcl_util_set_varint_len(p, NULL, pWit->len, false);
     memcpy(p, pWit->buf, pWit->len);
 }
 
@@ -503,7 +503,7 @@ bool btc_sw_wtxid(uint8_t *pWTxId, const btc_tx_t *pTx)
         return false;
     }
 
-    bool ret = btc_util_create_tx(&txbuf, pTx, true);
+    bool ret = btcl_util_create_tx(&txbuf, pTx, true);
     if (!ret) {
         assert(0);
         goto LABEL_EXIT;

--- a/btc/btc_tx.c
+++ b/btc/btc_tx.c
@@ -164,14 +164,14 @@ void btc_tx_add_vout_spk(btc_tx_t *pTx, uint64_t Value, const utl_buf_t *pScript
 
 bool btc_tx_add_vout_p2pkh_pub(btc_tx_t *pTx, uint64_t Value, const uint8_t *pPubKey)
 {
-    btc_util_add_vout_pub(pTx, Value, pPubKey, BTC_PREF_P2PKH);
+    btcl_util_add_vout_pub(pTx, Value, pPubKey, BTC_PREF_P2PKH);
     return true;
 }
 
 
 bool btc_tx_add_vout_p2pkh(btc_tx_t *pTx, uint64_t Value, const uint8_t *pPubKeyHash)
 {
-    btc_util_add_vout_pkh(pTx, Value, pPubKeyHash, BTC_PREF_P2PKH);
+    btcl_util_add_vout_pkh(pTx, Value, pPubKeyHash, BTC_PREF_P2PKH);
     return true;
 }
 
@@ -555,7 +555,7 @@ bool btc_tx_read(btc_tx_t *pTx, const uint8_t *pData, uint32_t Len)
 
 bool btc_tx_create(utl_buf_t *pBuf, const btc_tx_t *pTx)
 {
-    return btc_util_create_tx(pBuf, pTx, true);
+    return btcl_util_create_tx(pBuf, pTx, true);
 }
 
 
@@ -706,7 +706,7 @@ bool btc_tx_verify(const utl_buf_t *pSig, const uint8_t *pTxHash, const uint8_t 
         goto LABEL_EXIT;
     }
 
-    ret = btc_util_set_keypair(&keypair, pPubKey);
+    ret = btcl_util_set_keypair(&keypair, pPubKey);
     if (!ret) {
         ret = mbedtls_ecdsa_read_signature((mbedtls_ecdsa_context *)&keypair,
                     pTxHash, BTC_SZ_HASH256,
@@ -753,7 +753,7 @@ bool btc_tx_verify_rs(const uint8_t *pRS, const uint8_t *pTxHash, const uint8_t 
         assert(0);
         goto LABEL_EXIT;
     }
-    ret = btc_util_set_keypair(&keypair, pPubKey);
+    ret = btcl_util_set_keypair(&keypair, pPubKey);
     if (!ret) {
         ret = mbedtls_ecdsa_verify(&keypair.grp, pTxHash, BTC_SZ_HASH256, &keypair.Q, &r, &s);
     } else {
@@ -1086,7 +1086,7 @@ bool btc_tx_txid(uint8_t *pTxId, const btc_tx_t *pTx)
 {
     utl_buf_t txbuf;
 
-    bool ret = btc_util_create_tx(&txbuf, pTx, false);
+    bool ret = btcl_util_create_tx(&txbuf, pTx, false);
     if (!ret) {
         assert(0);
         goto LABEL_EXIT;
@@ -1143,7 +1143,7 @@ uint32_t btc_tx_get_vbyte_raw(const uint8_t *pData, uint32_t Len)
 
         btc_tx_read(&txold, pData, Len);
 
-        bool ret = btc_util_create_tx(&txbuf_old, &txold, false);
+        bool ret = btcl_util_create_tx(&txbuf_old, &txold, false);
         if (ret) {
             uint32_t fmt_old = txbuf_old.len;
             uint32_t fmt_new = Len;
@@ -1161,7 +1161,7 @@ uint32_t btc_tx_get_vbyte_raw(const uint8_t *pData, uint32_t Len)
 }
 
 
-#ifdef PTARM_USE_PRINTFUNC
+#if defined(PTARM_USE_PRINTFUNC) && !defined(PTARM_UTL_LOG_MACRO_DISABLED)
 void btc_print_tx(const btc_tx_t *pTx)
 {
     LOGD("======================================\n");
@@ -1213,7 +1213,7 @@ void btc_print_tx(const btc_tx_t *pTx)
         if ( (buf->len == 25) && (buf->buf[0] == 0x76) && (buf->buf[1] == 0xa9) &&
              (buf->buf[2] == 0x14) && (buf->buf[23] == 0x88) && (buf->buf[24] == 0xac) ) {
             char addr[BTC_SZ_ADDR_MAX];
-            bool ret = btc_util_keys_pkh2addr(addr, &(buf->buf[3]), BTC_PREF_P2PKH);
+            bool ret = btcl_util_keys_pkh2addr(addr, &(buf->buf[3]), BTC_PREF_P2PKH);
             assert(ret);
             if (!ret) {
                 return;
@@ -1691,7 +1691,7 @@ SKIP_LOOP:
  * @return      varint型のデータ長サイズ
  *
  * @note
- *      - #btc_util_get_varint_len()との違いに注意すること
+ *      - #btcl_util_get_varint_len()との違いに注意すること
  *      - データ長は0xFFFFまでしか対応しない
  */
 static int get_varint(uint16_t *pLen, const uint8_t *pData)

--- a/ln/ln_enc_auth.c
+++ b/ln/ln_enc_auth.c
@@ -509,7 +509,7 @@ static bool noise_hkdf(uint8_t *ck, uint8_t *k, const uint8_t *pSalt, const uint
     mbedtls_md_context_t ctx;
 
     uint8_t ikm_len = (pIkm) ? BTC_SZ_SHA256 : 0;
-    ret = btc_util_calc_mac(prk, pSalt, BTC_SZ_SHA256, pIkm, ikm_len);
+    ret = ln_misc_calc_mac(prk, pSalt, BTC_SZ_SHA256, pIkm, ikm_len);
     if (!ret) {
         LOGD("fail: calc_mac\n");
         return false;
@@ -547,7 +547,7 @@ static bool actone_sender(ln_self_t *self, utl_buf_t *pBuf, const uint8_t *pRS)
     btc_util_sha256cat(pBolt->h, pBolt->h, BTC_SZ_SHA256, pBolt->e.pub, BTC_SZ_PUBKEY);
 
     // ss = ECDH(rs, e.priv)
-    btc_util_generate_shared_secret(ss, pRS, pBolt->e.priv);
+    ln_misc_generate_shared_secret(ss, pRS, pBolt->e.priv);
 
     // ck, temp_k1 = HKDF(ck, ss)
     noise_hkdf(pBolt->ck, pBolt->temp_k, pBolt->ck, ss);
@@ -692,7 +692,7 @@ static bool acttwo_sender(ln_self_t *self, utl_buf_t *pBuf, const uint8_t *pRE)
     btc_util_sha256cat(pBolt->h, pBolt->h, BTC_SZ_SHA256, pBolt->e.pub, BTC_SZ_PUBKEY);
 
     // ss = ECDH(re, e.priv)
-    btc_util_generate_shared_secret(ss, pRE, pBolt->e.priv);
+    ln_misc_generate_shared_secret(ss, pRE, pBolt->e.priv);
 
     // ck, temp_k2 = HKDF(ck, ss)
     noise_hkdf(pBolt->ck, pBolt->temp_k, pBolt->ck, ss);
@@ -771,7 +771,7 @@ static bool acttwo_receiver(ln_self_t *self, utl_buf_t *pBuf)
     btc_util_sha256cat(pBolt->h, pBolt->h, BTC_SZ_SHA256, re, BTC_SZ_PUBKEY);
 
     // ss = ECDH(re, e.priv)
-    btc_util_generate_shared_secret(ss, re, pBolt->e.priv);
+    ln_misc_generate_shared_secret(ss, re, pBolt->e.priv);
 
     // ck, temp_k2 = HKDF(ck, ss)
     noise_hkdf(pBolt->ck, pBolt->temp_k, pBolt->ck, ss);
@@ -994,7 +994,7 @@ static bool actthree_receiver(ln_self_t *self, utl_buf_t *pBuf)
     btc_util_sha256cat(pBolt->h, pBolt->h, BTC_SZ_SHA256, c, sizeof(c));
 
     // ss = ECDH(rs, e.priv)
-    btc_util_generate_shared_secret(ss, rs, pBolt->e.priv);
+    ln_misc_generate_shared_secret(ss, rs, pBolt->e.priv);
 
     // ck, temp_k3 = HKDF(ck, ss)
     noise_hkdf(pBolt->ck, pBolt->temp_k, pBolt->ck, ss);

--- a/ln/ln_misc.h
+++ b/ln/ln_misc.h
@@ -124,6 +124,13 @@ void HIDDEN ln_misc_calc_channel_id(uint8_t *pChannelId, const uint8_t *pTxid, u
 uint64_t HIDDEN ln_misc_calc_short_channel_id(uint32_t Height, uint32_t BIndex, uint32_t VIndex);
 
 
+/** MAC計算
+ *
+ *
+ */
+bool HIDDEN ln_misc_calc_mac(uint8_t *pMac, const uint8_t *pKeyStr, int StrLen,  const uint8_t *pMsg, int MsgLen);
+
+
 /** short_channel_idパラメータ取得
  *
  * @param[out]      pHeight         ブロック高
@@ -131,5 +138,12 @@ uint64_t HIDDEN ln_misc_calc_short_channel_id(uint32_t Height, uint32_t BIndex, 
  * @param[out]      pVIndex         funding-txの2-of-2 vout index
  */
 void HIDDEN ln_misc_get_short_channel_id_param(uint32_t *pHeight, uint32_t *pBIndex, uint32_t *pVIndex, uint64_t short_channel_id);
+
+
+/** shared secret生成
+ *
+ *
+ */
+void HIDDEN ln_misc_generate_shared_secret(uint8_t *pResult, const uint8_t *pPubKey, const uint8_t *pPrivKey);
 
 #endif /* LN_MISC_H__ */

--- a/ln/ln_onion.c
+++ b/ln/ln_onion.c
@@ -130,7 +130,7 @@ bool ln_onion_create_packet(uint8_t *pPacket,
     btc_keys_priv2pub(eph_pubkeys, pSessionKey);
 
     //セッション鍵とpaymentPathの先頭から作った共有鍵のSHA256 --> shd_secrets[0]
-    btc_util_generate_shared_secret(shd_secrets, pHopData[0].pubkey, pSessionKey);
+    ln_misc_generate_shared_secret(shd_secrets, pHopData[0].pubkey, pSessionKey);
 
     //eph_pubkeys[0]とshd_secrets[0]から計算 --> blind_factors[0]
     compute_blinding_factor(blind_factors, eph_pubkeys, shd_secrets);
@@ -216,7 +216,7 @@ bool ln_onion_create_packet(uint8_t *pPacket,
         if (AssocLen != 0) {
             memcpy(pPacket + M_SZ_ROUTING_INFO, pAssocData, AssocLen);
         }
-        btc_util_calc_mac(next_hmac, mu_key, M_SZ_KEYLEN, pPacket, M_SZ_ROUTING_INFO + AssocLen);
+        ln_misc_calc_mac(next_hmac, mu_key, M_SZ_KEYLEN, pPacket, M_SZ_ROUTING_INFO + AssocLen);
     }
 
     if (LN_DBG_ONION_CREATE_NORMAL_VERSION()) {
@@ -295,7 +295,7 @@ bool HIDDEN ln_onion_read_packet(uint8_t *pNextPacket, ln_hop_dataout_t *pNextDa
     if (AssocLen != 0) {
         memcpy(p_msg + M_SZ_ROUTING_INFO, pAssocData, AssocLen);
     }
-    btc_util_calc_mac(next_hmac, mu_key, M_SZ_KEYLEN, p_msg, M_SZ_ROUTING_INFO + AssocLen);
+    ln_misc_calc_mac(next_hmac, mu_key, M_SZ_KEYLEN, p_msg, M_SZ_ROUTING_INFO + AssocLen);
     if (memcmp(next_hmac, p_hmac, M_SZ_HMAC) != 0) {
         LOGD("fail: hmac not match\n");
         UTL_DBG_FREE(p_msg);
@@ -406,7 +406,7 @@ void ln_onion_failure_create(utl_buf_t *pNextPacket,
     proto.pos += DATALEN - pReason->len;
 
     //HMAC
-    btc_util_calc_mac(buf_fail.buf, um_key, M_SZ_KEYLEN, buf_fail.buf + M_SZ_HMAC, proto.pos - M_SZ_HMAC);
+    ln_misc_calc_mac(buf_fail.buf, um_key, M_SZ_KEYLEN, buf_fail.buf + M_SZ_HMAC, proto.pos - M_SZ_HMAC);
 
 #ifdef M_DBG_FAIL
     LOGD("um_key=");
@@ -491,7 +491,7 @@ bool ln_onion_failure_read(utl_buf_t *pReason,
                     generate_key(um_key, UM, sizeof(UM), sharedsecret.buf);
 
                     uint8_t hmac[M_SZ_HMAC];
-                    btc_util_calc_mac(hmac, um_key, M_SZ_KEYLEN,
+                    ln_misc_calc_mac(hmac, um_key, M_SZ_KEYLEN,
                                     p_out->buf + M_SZ_HMAC, p_out->len - M_SZ_HMAC);
 
 #ifdef M_DBG_FAIL
@@ -691,7 +691,7 @@ static bool generate_key(uint8_t *pResult, const uint8_t *pKeyStr, int StrLen, c
     //const mbedtls_md_info_t *mdinfo = mbedtls_md_info_from_type(MBEDTLS_MD_SHA256);
     //int ret = mbedtls_md_hmac(mdinfo, pKeyStr, StrLen, pSharedSecret, M_SZ_SHARED_SECRET, pResult);
     //return ret == 0;
-    return btc_util_calc_mac(pResult, pKeyStr, StrLen, pSharedSecret, M_SZ_SHARED_SECRET);
+    return ln_misc_calc_mac(pResult, pKeyStr, StrLen, pSharedSecret, M_SZ_SHARED_SECRET);
 }
 
 


### PR DESCRIPTION
多くの変更が入ったかのように見えるが、行ったのは以下だけである。

* btc.hの中にあり、btc内でしか使用しないものをbtc_local.hに移動
  * ついでにプレフィクスを`btcl_`に変更
* btc.hの中にあり、ln内でしか使用しないものをln_miscに移動