### PR TITLE
issue #778 part1

### DIFF
--- a/ln/ln_db.h
+++ b/ln/ln_db.h
@@ -264,13 +264,6 @@ static inline bool ln_db_annocnlupd_is_prune(uint64_t Now, uint32_t TimesStamp) 
 bool ln_db_annocnlall_del(uint64_t short_channel_id);
 
 
-/** channel_announcementのないchannel_update削除
- *
- *
- */
-void ln_db_annocnl_del_orphan(void);
-
-
 /********************************************************************
  * node_announcement
  ********************************************************************/
@@ -357,6 +350,14 @@ bool ln_db_annocnlinfo_search_nodeid(void *pCur, uint64_t ShortChannelId, char T
  * @retval  true    成功
  */
 bool ln_db_annocnl_cur_get(void *pCur, uint64_t *pShortChannelId, char *pType, uint32_t *pTimeStamp, utl_buf_t *pBuf);
+
+
+/** ln_db_annocnl_cur_get()したDBの削除
+ *
+ * @param[in]       pCur
+ * @retval  true    成功
+ */
+bool ln_db_annocnl_cur_del(void *pCur);
 
 
 /** node_announcement取得

--- a/ln/ln_node.c
+++ b/ln/ln_node.c
@@ -238,38 +238,6 @@ void HIDDEN ln_node_create_key(char *pWif, uint8_t *pPubKey)
 }
 
 
-bool HIDDEN ln_node_recv_node_announcement(ln_self_t *self, const uint8_t *pData, uint16_t Len)
-{
-    bool ret;
-    ln_node_announce_t anno;
-    uint8_t node_id[BTC_SZ_PUBKEY];
-    char node_alias[LN_SZ_ALIAS + 1];
-
-    anno.p_node_id = node_id;
-    anno.p_alias = node_alias;
-    ret = ln_msg_node_announce_read(&anno, pData, Len);
-    if (!ret) {
-        LOGD("fail: read message\n");
-        return false;
-    }
-
-    LOGV("node_id:");
-    DUMPV(node_id, sizeof(node_id));
-
-    utl_buf_t buf_ann;
-    buf_ann.buf = (CONST_CAST uint8_t *)pData;
-    buf_ann.len = Len;
-    ret = ln_db_annonod_save(&buf_ann, &anno, ln_their_node_id(self));
-    if (ret) {
-        ln_cb_update_annodb_t anno;
-        anno.anno = LN_CB_UPDATE_ANNODB_NODE_ANNO;
-        (*self->p_callback)(self, LN_CB_UPDATE_ANNODB, &anno);
-    }
-
-    return true;
-}
-
-
 void HIDDEN ln_node_generate_shared_secret(uint8_t *pResult, const uint8_t *pPubKey)
 {
     uint8_t pub[BTC_SZ_PUBKEY];

--- a/ln/ln_node.h
+++ b/ln/ln_node.h
@@ -41,16 +41,6 @@
 void HIDDEN ln_node_create_key(char *pWif, uint8_t *pPubKey);
 
 
-/** node_announcement受信
- *
- * @param[in,out]       self            channel情報
- * @param[in]           pData           受信データ
- * @param[in]           Len             pData長
- * @retval      true    解析成功
- */
-bool HIDDEN ln_node_recv_node_announcement(ln_self_t *self, const uint8_t *pData, uint16_t Len);
-
-
 /** 共有鍵生成
  *
  */

--- a/ptarmd/lnapp.h
+++ b/ptarmd/lnapp.h
@@ -111,13 +111,14 @@ typedef struct lnapp_conf_t {
     //send announcement
     uint64_t        last_anno_cnl;                      ///< [#send_channel_anno()]最後にannouncementしたchannel
     uint64_t        last_annocnl_sci;                   ///< [#send_channel_anno()]最後にcur_getしたchannel_announcementのshort_channel_id
-    bool            annodb_updated;                     ///< flag to notify annodb update
-    bool            annodb_cont;
+    bool            annodb_updated;                     ///< true: flag to notify annodb update
+    bool            annodb_cont;                        ///< true: announcement連続送信中
     time_t          annodb_stamp;                       ///< last annodb_updated change true
     bool            annodb_dummy;                       ///< true: 初回にdummy送信する(終わったらfalseに設定される)
+                                                        //      dummy送信＝initial_routing_syncしない場合に、全部送信したと見なさせる処理
 
     int             err;            ///< last error
-    char            *p_errstr;      ///< last error string
+    char            *p_errstr;      ///< last error string(malloc)
 
 } lnapp_conf_t;
 


### PR DESCRIPTION
issue #778 part1

channel data didn't match after initial_routing_sync.

* remove orphan channel except own channel

調査したところ、単独のchannel_updateが不一致の原因のように見える。
まずは、自分が持っていない単独のchannel_updateだけ削除するしくみを用意する。