### PR TITLE
ptarmd: change `btcrpc_getnewaddress`'s output format

### DIFF
--- a/ptarmd/btcrpc.h
+++ b/ptarmd/btcrpc.h
@@ -175,10 +175,10 @@ bool btcrpc_check_unspent(bool *pUnspent, uint64_t *pSat, const uint8_t *pTxid, 
 
 /** [bitcoin IF]getnewaddress
  *
- * @param[out]  pBuf        生成したScriptPubKey
+ * @param[out]  pAddr       address
  * @retval  true        取得成功
  */
-bool btcrpc_getnewaddress(utl_buf_t *pBuf);
+bool btcrpc_getnewaddress(char pAddr[BTC_SZ_ADDR_MAX]);
 
 
 /** [bitcoin IF]estimatefee

--- a/ptarmd/btcrpc_bitcoind.c
+++ b/ptarmd/btcrpc_bitcoind.c
@@ -457,7 +457,7 @@ bool btcrpc_check_unspent(bool *pUnspent, uint64_t *pSat, const uint8_t *pTxid, 
 }
 
 
-bool btcrpc_getnewaddress(utl_buf_t *pBuf)
+bool btcrpc_getnewaddress(char pAddr[BTC_SZ_ADDR_MAX])
 {
     bool result = false;
     bool ret;
@@ -468,9 +468,10 @@ bool btcrpc_getnewaddress(utl_buf_t *pBuf)
     ret = getnewaddress_rpc(&p_root, &p_result, &p_json);
     if (ret) {
         if (json_is_string(p_result)) {
-            char addr[BTC_SZ_ADDR_MAX];
-            strcpy(addr,  (const char *)json_string_value(p_result));
-            result = btc_keys_addr2spk(pBuf, addr);
+            if (strlen(json_string_value(p_result)) < BTC_SZ_ADDR_MAX) {
+                strcpy(pAddr,  (const char *)json_string_value(p_result));
+                result = true;
+            }
         }
     } else {
         LOGD("fail: getnewaddress_rpc()\n");

--- a/ptarmd/lnapp.c
+++ b/ptarmd/lnapp.c
@@ -256,6 +256,8 @@ static void send_queue_push(lnapp_conf_t *p_conf, const utl_buf_t *pBuf);
 static void send_queue_flush(lnapp_conf_t *p_conf);
 static void send_queue_clear(lnapp_conf_t *p_conf);
 
+static bool getnewaddress(utl_buf_t *pBuf);
+
 static void show_self_param(const ln_self_t *self, FILE *fp, const char *msg, int line);
 
 
@@ -994,7 +996,7 @@ static void *thread_main_start(void *pArg)
     //送金先
     if (ln_shutdown_scriptpk_local(p_self)->len == 0) {
         utl_buf_t buf = UTL_BUF_INIT;
-        ret = btcrpc_getnewaddress(&buf);
+        ret = getnewaddress(&buf);
         if (!ret) {
             LOGD("fail: create address\n");
             goto LABEL_JOIN;
@@ -1411,7 +1413,7 @@ static bool send_open_channel(lnapp_conf_t *p_conf, const funding_conf_t *pFundi
     LOGD("  funding_sat: %" PRIu64 "\n", pFunding->funding_sat);
     LOGD("  push_sat: %" PRIu64 "\n", pFunding->push_sat);
 
-    bool ret = btcrpc_getnewaddress(&fundin.change_spk);
+    bool ret = getnewaddress(&fundin.change_spk);
     if (!ret) {
         LOGD("fail: getnewaddress\n");
         return false;
@@ -3591,6 +3593,16 @@ static void send_queue_clear(lnapp_conf_t *p_conf)
         utl_buf_free((utl_buf_t *)p);
     }
     utl_buf_free(&p_conf->buf_sendque);
+}
+
+
+static bool getnewaddress(utl_buf_t *pBuf)
+{
+    char addr[BTC_SZ_ADDR_MAX];
+    if (!btcrpc_getnewaddress(addr)) {
+        return false;
+    }
+    return btc_keys_addr2spk(pBuf, addr);
 }
 
 


### PR DESCRIPTION
のちほどptarmcliにgetnewaddressだけを行うコマンドを追加したいがため。