### PR TITLE
skip r-field containing routeskip DB

### DIFF
--- a/ln/ln.c
+++ b/ln/ln.c
@@ -1311,11 +1311,11 @@ bool ln_set_add_htlc(ln_self_t *self,
 
         *pHtlcId = self->cnl_add_htlc[idx].id;
         LOGD("HTLC add : next htlc_num=%d, prev_short_channel_id=%" PRIu64 "\n", self->htlc_num, self->cnl_add_htlc[idx].prev_short_channel_id);
+        LOGD("           self->cnl_add_htlc[%d].flag = 0x%02x\n", idx, self->cnl_add_htlc[idx].flag);
     } else {
         M_SET_ERR(self, LNERR_MSG_ERROR, "create update_add_htlc");
     }
 
-    LOGD("END: self->cnl_add_htlc[%d].flag = 0x%02x\n", idx, self->cnl_add_htlc[idx].flag);
     return ret;
 }
 
@@ -3157,7 +3157,7 @@ static bool recv_update_fail_malformed_htlc(ln_self_t *self, const uint8_t *pDat
         //  ここでは受信したfailure_codeでエラーを作る。
         //
         // BOLT#02
-        //  if the sha256_of_onion in update_fail_malformed_htlc doesn't match the onion it sent: 
+        //  if the sha256_of_onion in update_fail_malformed_htlc doesn't match the onion it sent:
         //      MAY retry or choose an alternate error response.
         if ( (self->cnl_add_htlc[idx].flag & LN_HTLC_FLAG_SEND) &&
              (self->cnl_add_htlc[idx].id == mal_htlc.id)) {
@@ -4645,8 +4645,8 @@ LABEL_EXIT:
 
 
 /** commitment_signed作成
- * 
- * 
+ *
+ *
  */
 static bool create_commit_signed(ln_self_t *self, utl_buf_t *pCommSig)
 {
@@ -5666,7 +5666,7 @@ static void set_error(ln_self_t *self, int Err, const char *pFormat, ...)
 
 
 /** commitment_number状態
- * 
+ *
  *  @retval 0   state-A: local.commit_num <  remote.commit_num
  *  @retval 1   state-B: local.commit_num >  remote.commit_num
  *  @retval 2   state-C: local.commit_num == remote.commit_num

--- a/ln/ln_routing.cpp
+++ b/ln/ln_routing.cpp
@@ -370,12 +370,18 @@ lnerr_route_t ln_routing_calculate(
     }
 
     if (AddNum > 0) {
+        //r-filedの追加
         int node_num = rt_res.node_num;
         rt_res.node_num += AddNum;
         rt_res.p_nodes = (nodes_t *)realloc(rt_res.p_nodes, sizeof(nodes_t) * rt_res.node_num);
 
         for (uint8_t lp = 0; lp < AddNum; lp++) {
             nodes_t *p_nodes = &rt_res.p_nodes[node_num];
+
+            bool bret = ln_db_routeskip_search(pAddRoute[lp].short_channel_id);
+            if (bret) {
+                continue;
+            }
 
             // add_node(0) --> payee(1)
             p_nodes->short_channel_id = pAddRoute[lp].short_channel_id;

--- a/ptarmd/cmd_json.c
+++ b/ptarmd/cmd_json.c
@@ -1408,7 +1408,7 @@ static int cmd_routepay_proc2(
                 LOGD("start payment\n");
                 err = 0;
             } else {
-                LOGD("fail: lnapp_payment\n");
+                LOGD("fail: lnapp_payment(0x%016" PRIx64 "\n", pRouteResult->hop_datain[0].short_channel_id);
                 ln_db_routeskip_save(pRouteResult->hop_datain[0].short_channel_id, true);
             }
         } else {
@@ -1551,7 +1551,7 @@ static bool json_connect(cJSON *params, int *pIndex, peer_conn_t *pConn)
 
 
 /** not public channel情報からr field情報を作成
- * 
+ *
  * channel_announcementする前や、channel_announcementしない場合、invoiceのr fieldに経路情報を追加することで、
  * announcementしていない部分の経路を知らせることができる。
  * ただ、その経路は自分へ向いているため、channelの相手が送信するchannel_updateの情報を追加することになる。


### PR DESCRIPTION
fix #790 

送金できないshort_channel_idがDBにあり、それと一致するチャネルはroutingから除外するようにしている。
このバグは、r-fieldを除外していなかったために発生していた。