### PR TITLE
Fix a buffer overflow in the C reference decoder

### DIFF
--- a/btc/segwit_addr.c
+++ b/btc/segwit_addr.c
@@ -137,7 +137,7 @@ bool bech32_decode(char* hrp, uint8_t *data, size_t *data_len, const char *input
         ++(*data_len);
     }
     hrp_len = input_len - (1 + *data_len);
-    if (hrp_len < 1 || *data_len < 6) {
+    if (1 + *data_len >= input_len || *data_len < 6) {
         return false;
     }
     *(data_len) -= 6;

--- a/btc/tests/testinc_bech32.cpp
+++ b/btc/tests/testinc_bech32.cpp
@@ -136,6 +136,7 @@ static const char* invalid_address[] = {
     "BC13W508D6QEJXTDG4Y5R3ZARVARY0C5XW7KN40WF2",
     "bc1rw5uspcuh",
     "bc10w508d6qejxtdg4y5r3zarvary0c5xw7kw508d6qejxtdg4y5r3zarvary0c5xw7kw5rljs90",
+    "bca0w508d6qejxtdg4y5r3zarvary0c5xw7kw508d6qejxtdg4y5r3zarvary0c5xw7kw5rljs90234567789035",
     "BC1QR508D6QEJXTDG4Y5R3ZARVARYV98GJ9P",
     "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sL5k7",
     "bc1zw508d6qejxtdg4y5r3zarvaryvqyzf3du",


### PR DESCRIPTION
Merged original segwit_addr.c fix
> https://github.com/sipa/bech32/commit/2b0aac650ce560fb2b2a2bebeacaa5c87d7e5938
> Fix a buffer overflow in the C reference decoder
>
> Thanks to Christian Reitter and Dr. Jochen Hoenicke for discovering this issue
> and suggesting a fix.