### PR TITLE
readonly channel search

### DIFF
--- a/ln/ln_db.h
+++ b/ln/ln_db.h
@@ -210,6 +210,7 @@ bool ln_db_self_del_prm(const ln_self_t *self, void *p_db_param);
  *      - 戻り値がtrueの場合、検索関数のselfは解放しない。必要があれば#ln_term()を実行すること。
  */
 bool ln_db_self_search(ln_db_func_cmp_t pFunc, void *pFuncParam);
+bool ln_db_self_search_readonly(ln_db_func_cmp_t pFunc, void *pFuncParam);
 
 
 /** closeフラグ保存

--- a/ln/ln_db_lmdb.c
+++ b/ln/ln_db_lmdb.c
@@ -4082,7 +4082,7 @@ static bool self_search(ln_db_func_cmp_t pFunc, void *pFuncParam, bool bWritable
     int             retval;
     lmdb_cursor_t   cur;
 
-    LOGD("self cursor open\n");
+    LOGD("self cursor open(writable=%d)\n", bWritable);
     retval = self_cursor_open(&cur, bWritable);
     if (retval != 0) {
         LOGD("fail: open\n");
@@ -4120,7 +4120,7 @@ static bool self_search(ln_db_func_cmp_t pFunc, void *pFuncParam, bool bWritable
     UTL_DBG_FREE(p_self);
 
 LABEL_EXIT:
-    LOGD("result=%d\n", result);
+    LOGD("result=%d(writable=%d)\n", result, bWritable);
     return result;
 }
 

--- a/ln/ln_node.c
+++ b/ln/ln_node.c
@@ -190,7 +190,7 @@ bool ln_node_search_channel(ln_self_t *self, const uint8_t *pNodeId)
 
     prm.p_node_id = pNodeId;
     prm.p_self = self;
-    bool detect = ln_db_self_search(comp_func_cnl, &prm);
+    bool detect = ln_db_self_search_readonly(comp_func_cnl, &prm);
 
     LOGD("  --> detect=%d\n", detect);
 
@@ -220,7 +220,7 @@ bool ln_node_search_nodeanno(ln_node_announce_t *pNodeAnno, const uint8_t *pNode
 uint64_t ln_node_total_msat(void)
 {
     uint64_t amount = 0;
-    ln_db_self_search(comp_func_total_msat, &amount);
+    ln_db_self_search_readonly(comp_func_total_msat, &amount);
     return amount;
 }
 
@@ -257,7 +257,7 @@ bool HIDDEN ln_node_search_nodeid(uint8_t *pNodeId, uint64_t ShortChannelId)
     comp_param_srcnodeid_t param;
     param.p_node_id = pNodeId;
     param.short_channel_id = ShortChannelId;
-    bool ret = ln_db_self_search(comp_func_srch_nodeid, &param);
+    bool ret = ln_db_self_search_readonly(comp_func_srch_nodeid, &param);
     LOGD("ret=%d\n", ret);
     return ret;
 }

--- a/ln/ln_routing.cpp
+++ b/ln/ln_routing.cpp
@@ -285,7 +285,7 @@ static bool loaddb(nodes_result_t *p_result, const uint8_t *pPayerId)
 
     prm_self.p_result = p_result;
     prm_self.p_payer = pPayerId;
-    ln_db_self_search(comp_func_self, &prm_self);
+    ln_db_self_search_readonly(comp_func_self, &prm_self);
 
     //channel_anno
     void *p_cur;

--- a/ln/tests/testinc_ln.cpp
+++ b/ln/tests/testinc_ln.cpp
@@ -7,6 +7,7 @@ FAKE_VALUE_FUNC(bool, ln_db_preimg_cur_open, void **);
 FAKE_VALUE_FUNC(bool, ln_db_preimg_cur_get, void *, bool *, ln_db_preimg_t *);
 FAKE_VOID_FUNC(ln_db_preimg_cur_close, void *);
 FAKE_VALUE_FUNC(bool, ln_db_self_search, ln_db_func_cmp_t, void *);
+FAKE_VALUE_FUNC(bool, ln_db_self_search_readonly, ln_db_func_cmp_t, void *);
 
 ////////////////////////////////////////////////////////////////////////
 
@@ -19,6 +20,7 @@ protected:
         RESET_FAKE(ln_db_preimg_cur_get)
         RESET_FAKE(ln_db_preimg_cur_close)
         RESET_FAKE(ln_db_self_search)
+        RESET_FAKE(ln_db_self_search_readonly)
         utl_dbg_malloc_cnt_reset();
         btc_init(BTC_TESTNET, false);
     }

--- a/ptarmd/cmd_json.c
+++ b/ptarmd/cmd_json.c
@@ -1108,7 +1108,7 @@ static cJSON *cmd_getcommittx(jrpc_context *ctx, cJSON *params, cJSON *id)
     prm.b_local = true;
     prm.p_nodeid = conn.node_id;
     prm.result = result;
-    ln_db_self_search(comp_func_getcommittx, &prm);
+    ln_db_self_search_readonly(comp_func_getcommittx, &prm);
 
 LABEL_EXIT:
     if (index < 0) {
@@ -1739,7 +1739,7 @@ static void create_bolt11_rfield(ln_fieldr_t **ppFieldR, uint8_t *pFieldRNum)
 
     prm.pp_field = ppFieldR;
     prm.p_fieldnum = pFieldRNum;
-    ln_db_self_search(comp_func_cnl, &prm);
+    ln_db_self_search_readonly(comp_func_cnl, &prm);
 
     if (*pFieldRNum != 0) {
         LOGD("add r_field: %d\n", *pFieldRNum);


### PR DESCRIPTION
add `ln_db_self_search_readonly()` for readonly channel search

DBがロックすることがあったので、明示的に分けた。