### PR TITLE
change `max_htlc_value_in_flight_msat` value

### DIFF
--- a/install/default_conf.sh
+++ b/install/default_conf.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 echo "cltv_expiry_delta=36\nhtlc_minimum_msat=0\nfee_base_msat=10\nfee_prop_millionths=100" > anno.conf
-echo "dust_limit_sat=546\nmax_htlc_value_in_flight_msat=18446744073709551615\nchannel_reserve_sat=700\nhtlc_minimum_msat=0\nto_self_delay=40\nmax_accepted_htlcs=6\nmin_depth=1\nlocalfeatures=2" > channel.conf
+echo "dust_limit_sat=546\nmax_htlc_value_in_flight_msat=4294967295\nchannel_reserve_sat=700\nhtlc_minimum_msat=0\nto_self_delay=40\nmax_accepted_htlcs=6\nmin_depth=1\nlocalfeatures=2" > channel.conf

--- a/ptarmd/conf.c
+++ b/ptarmd/conf.c
@@ -43,7 +43,7 @@
 
 //  establish
 #define M_DUST_LIMIT_SAT                (546)
-#define M_MAX_HTLC_VALUE_IN_FLIGHT_MSAT (INT64_MAX)
+#define M_MAX_HTLC_VALUE_IN_FLIGHT_MSAT (UINT32_MAX)
 #define M_CHANNEL_RESERVE_SAT           (700)
 #define M_HTLC_MINIMUM_MSAT_EST         (0)
 #define M_TO_SELF_DELAY                 (40)


### PR DESCRIPTION
default `max_htlc_value_in_flight_msat` = UINT32_MAX

follow BOLT#7
https://github.com/lightningnetwork/lightning-rfc/commit/4c12ae8a27846f47d4c837b1b1fcc9c5b7aed175