### PR TITLE
ptarmcli -c --initialroutesync

### DIFF
--- a/ln/ln.c
+++ b/ln/ln.c
@@ -810,7 +810,7 @@ void ln_recv_idle_proc(ln_self_t *self)
  * localfeaturesは、自分がサポートするfeature(odd bits)と、要求するfeature(even bits)を送信する。
  *
  */
-bool ln_init_create(ln_self_t *self, utl_buf_t *pInit, bool bHaveCnl)
+bool ln_init_create(ln_self_t *self, utl_buf_t *pInit, bool bInitRouteSync, bool bHaveCnl)
 {
     (void)bHaveCnl;
 
@@ -822,7 +822,7 @@ bool ln_init_create(ln_self_t *self, utl_buf_t *pInit, bool bHaveCnl)
     ln_init_t msg;
 
     utl_buf_init(&msg.globalfeatures);
-    self->lfeature_local = mInitLocalFeatures[0];
+    self->lfeature_local = mInitLocalFeatures[0] | (bInitRouteSync ? LN_INIT_LF_ROUTE_SYNC : 0);
     utl_buf_alloccopy(&msg.localfeatures, &self->lfeature_local, sizeof(self->lfeature_local));
     LOGD("localfeatures: ");
     DUMPD(msg.localfeatures.buf, msg.localfeatures.len);

--- a/ln/ln.h
+++ b/ln/ln.h
@@ -1427,7 +1427,7 @@ void ln_recv_idle_proc(ln_self_t *self);
  * @param[in]           bHaveCnl        true:チャネル開設済み
  * retval       true    成功
  */
-bool ln_init_create(ln_self_t *self, utl_buf_t *pInit, bool bHaveCnl);
+bool ln_init_create(ln_self_t *self, utl_buf_t *pInit, bool bInitRouteSync, bool bHaveCnl);
 
 
 /** channel_reestablishメッセージ作成

--- a/ptarmcli/ptarmcli.c
+++ b/ptarmcli/ptarmcli.c
@@ -54,6 +54,7 @@
 #define M_OPT_GETNEWADDRESS         '\x03'
 #define M_OPT_GETBALANCE            '\x04'
 #define M_OPT_EMPTYWALLET           '\x05'
+#define M_OPT_INITROUTESYNC         '\x06'
 #define M_OPT_DEBUG                 '\x1f'
 
 #define BUFFER_SIZE     (256 * 1024)
@@ -92,6 +93,7 @@ static char         mBuf[BUFFER_SIZE];
 static bool         mTcpSend;
 static char         mAddr[256];
 static char         mErrStr[256];
+static char         mInitRouteSync[16];
 
 
 /********************************************************************
@@ -123,6 +125,7 @@ static void optfunc_estimatefundingfee(int *pOption, bool *pConn);
 static void optfunc_walletback(int *pOption, bool *pConn);
 static void optfunc_getbalance(int *pOption, bool *pConn);
 static void optfunc_emptywallet(int *pOption, bool *pConn);
+static void optfunc_initroutesync(int *pOption, bool *pConn);
 
 static void connect_rpc(void);
 static void stop_rpc(void);
@@ -162,6 +165,7 @@ static const struct {
     { M_OPT_GETNEWADDRESS,      optfunc_getnewaddress },
     { M_OPT_GETBALANCE,         optfunc_getbalance },
     { M_OPT_EMPTYWALLET,        optfunc_emptywallet },
+    { M_OPT_INITROUTESYNC,      optfunc_initroutesync },
     { M_OPT_DEBUG,              optfunc_debug },
 };
 
@@ -178,6 +182,7 @@ int main(int argc, char *argv[])
         { "getnewaddress", no_argument, NULL, M_OPT_GETNEWADDRESS },
         { "getbalance", no_argument, NULL, M_OPT_GETBALANCE },
         { "emptywallet", required_argument, NULL, M_OPT_EMPTYWALLET },
+        { "initroutesync", no_argument, NULL, M_OPT_INITROUTESYNC },
         { "debug", required_argument, NULL, M_OPT_DEBUG },
         { 0, 0, 0, 0 }
     };
@@ -186,6 +191,7 @@ int main(int argc, char *argv[])
     bool conn = false;
     mAddr[0] = '\0';
     mTcpSend = true;
+    mInitRouteSync[0] = '\0';
     int opt;
     while ((opt = getopt_long(argc, argv, "c:hta:lq::f:i:e:mp:r:R:x::wg::s:X:W", OPTIONS, NULL)) != -1) {
         for (size_t lp = 0; lp < ARRAY_SIZE(OPTION_FUNCS); lp++) {
@@ -861,6 +867,16 @@ static void optfunc_emptywallet(int *pOption, bool *pConn)
 }
 
 
+static void optfunc_initroutesync(int *pOption, bool *pConn)
+{
+    (void)pConn;
+
+    M_CHK_CONN
+
+    strcpy(mInitRouteSync, ",1");
+}
+
+
 /********************************************************************
  * others
  ********************************************************************/
@@ -873,9 +889,10 @@ static void connect_rpc(void)
             M_QQ("params") ":[ "
                 //peer_nodeid, peer_addr, peer_port
                 M_QQ("%s") "," M_QQ("%s") ",%d"
+                "%s"
             " ]"
         "}",
-            mPeerNodeId, mPeerAddr, mPeerPort);
+            mPeerNodeId, mPeerAddr, mPeerPort, mInitRouteSync);
 }
 
 

--- a/ptarmd/lnapp.c
+++ b/ptarmd/lnapp.c
@@ -1265,7 +1265,7 @@ static bool exchange_init(lnapp_conf_t *p_conf)
 {
     utl_buf_t buf_bolt = UTL_BUF_INIT;
 
-    bool ret = ln_init_create(p_conf->p_self, &buf_bolt, true);     //channel announceあり
+    bool ret = ln_init_create(p_conf->p_self, &buf_bolt, p_conf->routesync == PTARMD_ROUTESYNC_INIT, true);     //channel announceあり
     if (!ret) {
         LOGD("fail: create\n");
         return false;

--- a/ptarmd/lnapp.h
+++ b/ptarmd/lnapp.h
@@ -80,6 +80,7 @@ typedef struct lnapp_conf_t {
     //制御内容通知
     bool            initiator;                  ///< true:Noise Protocol handshakeのinitiator
     uint8_t         node_id[BTC_SZ_PUBKEY];     ///< 接続先(initiator==true時)
+    uint8_t         routesync;                  ///< initial_routing_sync
 
     //lnappワーク
     volatile bool   loop;                   ///< true:channel動作中

--- a/ptarmd/p2p_cli.c
+++ b/ptarmd/p2p_cli.c
@@ -196,6 +196,7 @@ bool p2p_cli_start(const peer_conn_t *pConn, jrpc_context *ctx)
     //mAppConf[idx].cmd = DCMD_CONNECT;
     strcpy(mAppConf[idx].conn_str, pConn->ipaddr);
     mAppConf[idx].conn_port = pConn->port;
+    mAppConf[idx].routesync = pConn->routesync;
 
     //store for reconnection
     if (!p2p_cli_store_peer_conn(pConn)) {

--- a/ptarmd/ptarmd.c
+++ b/ptarmd/ptarmd.c
@@ -392,7 +392,7 @@ char *ptarmd_error_str(int ErrCode)
         { RPCERR_ERROR,                     "error" },
         { RPCERR_NOCONN,                    "not connected" },
         { RPCERR_ALCONN,                    "already connected" },
-        { RPCERR_NOCHANN,                   "no channel" },
+        { RPCERR_NOCHANNEL,                 "no channel" },
         { RPCERR_PARSE,                     "parse param" },
         { RPCERR_NOINIT,                    "no init or init not end" },
         { RPCERR_BLOCKCHAIN,                "fail blockchain access" },

--- a/ptarmd/ptarmd.h
+++ b/ptarmd/ptarmd.h
@@ -71,7 +71,7 @@ extern "C" {
 #define RPCERR_ERROR                (-10000)
 #define RPCERR_NOCONN               (-10001)
 #define RPCERR_ALCONN               (-10002)
-#define RPCERR_NOCHANN              (-10003)
+#define RPCERR_NOCHANNEL            (-10003)
 #define RPCERR_PARSE                (-10004)
 #define RPCERR_NOINIT               (-10005)
 #define RPCERR_BLOCKCHAIN           (-10006)
@@ -150,6 +150,17 @@ typedef enum {
 } ptarmd_event_t;
 
 
+/** @enum   ptarmd_routesync_t
+ *  @brief  route sync method
+ */
+typedef enum {
+    PTARMD_ROUTESYNC_NONE,
+    PTARMD_ROUTESYNC_INIT,      ///< initial_routing_sync
+    //
+    PTARMD_ROUTESYNC_MAX = PTARMD_ROUTESYNC_INIT
+} ptarmd_routesync_t;
+
+
 /** @struct     peer_conn_t
  *  @brief      peer接続情報
  *  @note
@@ -157,9 +168,10 @@ typedef enum {
  */
 typedef struct {
     //peer
-    char        ipaddr[SZ_IPV4_LEN + 1];
-    uint16_t    port;
-    uint8_t     node_id[BTC_SZ_PUBKEY];
+    char                ipaddr[SZ_IPV4_LEN + 1];
+    uint16_t            port;
+    uint8_t             node_id[BTC_SZ_PUBKEY];
+    ptarmd_routesync_t  routesync;
 } peer_conn_t;
 
 


### PR DESCRIPTION
`init.localfeatures.initial_routing_sync`を0に変更したため、接続要求時に`initial_routing_sync=ON`を指示できるように変更。

おそらくだが、serverとして接続されるときは`initial_routing_sync=OFF`で、clientとして接続しに行くときに指定できるのがよいのではなかろうか。
ただ、lndなどは再接続要求が比較的早いため、`ptarmd`を起動して手間取っていると相手から接続されてしまう。そういう場合は、手動で切断してから再接続する想定にしている。
内部で切断して再接続することもできるが、少なくとも今の段階ではわかりづらくなるため、やめておいた。今後の課題とする。