### PR TITLE
allow change ipaddr

### DIFF
--- a/btc/btc.h
+++ b/btc/btc.h
@@ -50,16 +50,16 @@ extern "C" {
 #define BTC_SZ_PUBKEY           (33)            ///< サイズ:圧縮された公開鍵
 #define BTC_SZ_PUBKEY_UNCOMP    (64)            ///< サイズ:圧縮されていない公開鍵
 #define BTC_SZ_PUBKEYHASH       (32)            ///< サイズ:PubKeyHashの最大値
-#define BTC_SZ_ADDR_MAX         (90 + 1)        ///< サイズ:Bitcoinアドレス(26-35)(BECH32:90)
-#define BTC_SZ_WIF_MAX          (55 + 1)        ///< サイズ:秘密鍵のWIF(上限不明)
+#define BTC_SZ_ADDR_MAX         (90)            ///< サイズ:Bitcoinアドレス(26-35)(BECH32:90)
+#define BTC_SZ_WIF_MAX          (55)            ///< サイズ:秘密鍵のWIF(上限不明)
 #define BTC_SZ_TXID             (32)            ///< サイズ:TXID
 #define BTC_SZ_SIGN_RS          (64)            ///< サイズ:RS形式の署名
 #define BTC_SZ_EKEY_SEED        (64)            ///< サイズ:拡張鍵seed
 #define BTC_SZ_EKEY             (82)            ///< サイズ:拡張鍵
 #define BTC_SZ_CHAINCODE        (32)            ///< サイズ:拡張鍵chaincode
-#define BTC_SZ_EKEY_ADDR_MAX    (112 + 1)       ///< サイズ:拡張鍵アドレス長上限
+#define BTC_SZ_EKEY_ADDR_MAX    (112)           ///< サイズ:拡張鍵アドレス長上限
 #define BTC_SZ_WITPROG_P2WPKH   (2 + BTC_SZ_HASH160)    ///< サイズ: witnessProgram(P2WPKH)
-#define BTC_SZ_WITPROG_P2WSH    (2 + BTC_SZ_HASH256)     ///< サイズ: witnessProgram(P2WSH)
+#define BTC_SZ_WITPROG_P2WSH    (2 + BTC_SZ_HASH256)    ///< サイズ: witnessProgram(P2WSH)
 #define BTC_SZ_2OF2             (1 + 34 + 34 + 2)       ///< OP_m 21 [pub1] 21 [pub2] OP_n OP_CHKMULTISIG
 
 #define BTC_PREF                (0)             ///< Prefix: 1:mainnet, 2:testnet

--- a/btc/btc_ekey.c
+++ b/btc/btc_ekey.c
@@ -351,7 +351,7 @@ bool btc_ekey_create_data(uint8_t *pData, char *pAddr, const btc_ekey_t *pEKey)
     bool ret = true;
 
     if (pAddr) {
-        size_t sz = BTC_SZ_EKEY_ADDR_MAX;
+        size_t sz = BTC_SZ_EKEY_ADDR_MAX + 1;
         ret = b58enc(pAddr, &sz, pData, BTC_SZ_EKEY);
     }
 
@@ -440,8 +440,7 @@ bool btc_ekey_read_addr(btc_ekey_t *pEKey, const char *pXAddr)
     uint8_t bin[BTC_SZ_EKEY];
 
     size_t addr_len = strlen(pXAddr);
-    if (addr_len >= BTC_SZ_EKEY_ADDR_MAX) {
-        //BTC_SZ_EKEY_ADDR_MAXは\0も含んだサイズなので、>=になる
+    if (addr_len > BTC_SZ_EKEY_ADDR_MAX) {
         return false;
     }
 

--- a/btc/btc_keys.c
+++ b/btc/btc_keys.c
@@ -119,7 +119,7 @@ bool btc_keys_priv2wif(char *pWifPriv, const uint8_t *pPrivKey)
     btc_util_hash256(buf_sha256, b58, 1 + BTC_SZ_PRIVKEY + 1);
     memcpy(b58 + 1 + BTC_SZ_PRIVKEY + 1, buf_sha256, 4);
 
-    size_t sz = BTC_SZ_WIF_MAX;
+    size_t sz = BTC_SZ_WIF_MAX + 1;
     ret = b58enc(pWifPriv, &sz, b58, sizeof(b58));
     memset(b58, 0, sizeof(b58));        //clear for security
     return ret;

--- a/btc/btc_tx.c
+++ b/btc/btc_tx.c
@@ -1285,7 +1285,7 @@ void btc_print_tx(const btc_tx_t *pTx)
         LOGD2("  scriptPubKey[%u]= ", buf->len);
         DUMPD(buf->buf, buf->len);
         //btc_print_script(buf->buf, buf->len);
-        char addr[BTC_SZ_ADDR_MAX];
+        char addr[BTC_SZ_ADDR_MAX + 1];
         addr[0] = '\0';
         if ( (buf->len == 25) && (buf->buf[0] == OP_DUP) && (buf->buf[1] == OP_HASH160) &&
              (buf->buf[2] == 0x14) && (buf->buf[23] == OP_EQUALVERIFY) && (buf->buf[24] == OP_CHECKSIG) ) {

--- a/btc/btc_util.c
+++ b/btc/btc_util.c
@@ -727,7 +727,7 @@ bool HIDDEN btcl_util_keys_pkh2addr(char *pAddr, const uint8_t *pPubKeyHash, uin
 
     } else {
         uint8_t pkh[1 + BTC_SZ_HASH160 + 4];
-        size_t sz = BTC_SZ_ADDR_MAX;
+        size_t sz = BTC_SZ_ADDR_MAX + 1;
 
         pkh[0] = mPref[Prefix];
         memcpy(pkh + 1, pPubKeyHash, BTC_SZ_HASH160);

--- a/btc/examples/key_address.c
+++ b/btc/examples/key_address.c
@@ -14,7 +14,7 @@ static void pkh_to_p2wpkh(void)
         0x96, 0x15, 0xf2, 0x31, 0x54, 0xc1, 0x87,
     };
 
-    char addr[BTC_SZ_ADDR_MAX];
+    char addr[BTC_SZ_ADDR_MAX + 1];
     utl_buf_t BUF_SPK = { (uint8_t *)SPK, sizeof(SPK) };
     bool ret = btc_keys_spk2addr(addr, &BUF_SPK);
     if (ret) {
@@ -39,7 +39,7 @@ static void bech32wpkh_to_hash(void)
         printf("fail: segwit_addr_decode\n");
     }
 
-    char addr[BTC_SZ_ADDR_MAX];
+    char addr[BTC_SZ_ADDR_MAX + 1];
     ret = segwit_addr_encode(addr, SEGWIT_ADDR_TESTNET, ver, prog, prog_len);
     if (ret) {
         printf("addr: %s\n", addr);

--- a/btc/tests/testinc_ekey.cpp
+++ b/btc/tests/testinc_ekey.cpp
@@ -56,7 +56,7 @@ TEST_F(extendedkey, chain_m)
     const char XPUB0[] = "xpub661MyMwAqRbcFtXgS5sYJABqqG9YLmC4Q1Rdap9gSE8NqtwybGhePY2gZ29ESFjqJoCu1Rupje8YtGqsefD265TMg7usUDFdp6W1EGMcet8";
 
     uint8_t buf_ekey[BTC_SZ_EKEY];
-    char xaddr[BTC_SZ_EKEY_ADDR_MAX];
+    char xaddr[BTC_SZ_EKEY_ADDR_MAX + 1];
 
     bool b = btc_ekey_generate(&ekey, BTC_EKEY_PRIV, 0, 0, NULL, SEED, sizeof(SEED));
     ASSERT_TRUE(b);
@@ -102,7 +102,7 @@ TEST_F(extendedkey, chain_m_0H)
     const char XPUB0H[] = "xpub68Gmy5EdvgibQVfPdqkBBCHxA5htiqg55crXYuXoQRKfDBFA1WEjWgP6LHhwBZeNK1VTsfTFUHCdrfp1bgwQ9xv5ski8PX9rL2dZXvgGDnw";
 
     uint8_t buf_ekey[BTC_SZ_EKEY];
-    char xaddr[BTC_SZ_EKEY_ADDR_MAX];
+    char xaddr[BTC_SZ_EKEY_ADDR_MAX + 1];
 
     //pub用
     memcpy(&ekey_prev, &ekey, sizeof(ekey));
@@ -162,7 +162,7 @@ TEST_F(extendedkey, chain_m_0H_1)
     const char XPUB0H1[] = "xpub6ASuArnXKPbfEwhqN6e3mwBcDTgzisQN1wXN9BJcM47sSikHjJf3UFHKkNAWbWMiGj7Wf5uMash7SyYq527Hqck2AxYysAA7xmALppuCkwQ";
 
     uint8_t buf_ekey[BTC_SZ_EKEY];
-    char xaddr[BTC_SZ_EKEY_ADDR_MAX];
+    char xaddr[BTC_SZ_EKEY_ADDR_MAX + 1];
 
     //pub用
     memcpy(&ekey_prev, &ekey, sizeof(ekey));
@@ -210,7 +210,7 @@ TEST_F(extendedkey, chain_m_0H_1pub)
     const char XPUB0H1[] = "xpub6ASuArnXKPbfEwhqN6e3mwBcDTgzisQN1wXN9BJcM47sSikHjJf3UFHKkNAWbWMiGj7Wf5uMash7SyYq527Hqck2AxYysAA7xmALppuCkwQ";
 
     uint8_t buf_ekey[BTC_SZ_EKEY];
-    char xaddr[BTC_SZ_EKEY_ADDR_MAX];
+    char xaddr[BTC_SZ_EKEY_ADDR_MAX + 1];
 
     bool b = btc_ekey_generate(&ekey_prev, BTC_EKEY_PUB, 2, 1, pub_prev, NULL, 0);
     ASSERT_TRUE(b);
@@ -228,7 +228,7 @@ TEST_F(extendedkey, chain_m_0H_1_2H)
     const char XPUB0H12H[] = "xpub6D4BDPcP2GT577Vvch3R8wDkScZWzQzMMUm3PWbmWvVJrZwQY4VUNgqFJPMM3No2dFDFGTsxxpG5uJh7n7epu4trkrX7x7DogT5Uv6fcLW5";
 
     uint8_t buf_ekey[BTC_SZ_EKEY];
-    char xaddr[BTC_SZ_EKEY_ADDR_MAX];
+    char xaddr[BTC_SZ_EKEY_ADDR_MAX + 1];
 
     //pub用
     memcpy(&ekey_prev, &ekey, sizeof(ekey));
@@ -287,7 +287,7 @@ TEST_F(extendedkey, chain_m_0H_1_2H_2)
     const char XPUB0H12H2[] = "xpub6FHa3pjLCk84BayeJxFW2SP4XRrFd1JYnxeLeU8EqN3vDfZmbqBqaGJAyiLjTAwm6ZLRQUMv1ZACTj37sR62cfN7fe5JnJ7dh8zL4fiyLHV";
 
     uint8_t buf_ekey[BTC_SZ_EKEY];
-    char xaddr[BTC_SZ_EKEY_ADDR_MAX];
+    char xaddr[BTC_SZ_EKEY_ADDR_MAX + 1];
 
     //pub用
     memcpy(&ekey_prev, &ekey, sizeof(ekey));
@@ -335,7 +335,7 @@ TEST_F(extendedkey, chain_m_0H_1_2H_2pub)
     const char XPUB0H12H2[] = "xpub6FHa3pjLCk84BayeJxFW2SP4XRrFd1JYnxeLeU8EqN3vDfZmbqBqaGJAyiLjTAwm6ZLRQUMv1ZACTj37sR62cfN7fe5JnJ7dh8zL4fiyLHV";
 
     uint8_t buf_ekey[BTC_SZ_EKEY];
-    char xaddr[BTC_SZ_EKEY_ADDR_MAX];
+    char xaddr[BTC_SZ_EKEY_ADDR_MAX + 1];
 
     bool b = btc_ekey_generate(&ekey_prev, BTC_EKEY_PUB, 4, 2, pub_prev, NULL, 0);
     ASSERT_TRUE(b);
@@ -355,7 +355,7 @@ TEST_F(extendedkey, chain_m_0H_1_2H_2_1)
     const char XPUB0H12H21[] = "xpub6H1LXWLaKsWFhvm6RVpEL9P4KfRZSW7abD2ttkWP3SSQvnyA8FSVqNTEcYFgJS2UaFcxupHiYkro49S8yGasTvXEYBVPamhGW6cFJodrTHy";
 
     uint8_t buf_ekey[BTC_SZ_EKEY];
-    char xaddr[BTC_SZ_EKEY_ADDR_MAX];
+    char xaddr[BTC_SZ_EKEY_ADDR_MAX + 1];
 
     //pub用
     memcpy(&ekey_prev, &ekey, sizeof(ekey));
@@ -403,7 +403,7 @@ TEST_F(extendedkey, chain_m_0H_1_2H_2_1pub)
     const char XPUB0H12H21[] = "xpub6H1LXWLaKsWFhvm6RVpEL9P4KfRZSW7abD2ttkWP3SSQvnyA8FSVqNTEcYFgJS2UaFcxupHiYkro49S8yGasTvXEYBVPamhGW6cFJodrTHy";
 
     uint8_t buf_ekey[BTC_SZ_EKEY];
-    char xaddr[BTC_SZ_EKEY_ADDR_MAX];
+    char xaddr[BTC_SZ_EKEY_ADDR_MAX + 1];
 
     bool b = btc_ekey_generate(&ekey_prev, BTC_EKEY_PUB, 5, 1000000000, pub_prev, NULL, 0);
     ASSERT_TRUE(b);
@@ -429,7 +429,7 @@ TEST_F(extendedkey, chain_m_master2)
     const char XPUB0[] = "xpub661MyMwAqRbcFtXgS5sYJABqqG9YLmC4Q1Rdap9gSE8NqtwybGhePY2gZ29ESFjqJoCu1Rupje8YtGqsefD265TMg7usUDFdp6W1EGMcet8";
 
     uint8_t buf_ekey[BTC_SZ_EKEY];
-    char xaddr[BTC_SZ_EKEY_ADDR_MAX];
+    char xaddr[BTC_SZ_EKEY_ADDR_MAX + 1];
 
     bool b = btc_ekey_generate(&ekey, BTC_EKEY_PRIV, 0, 0, NULL, SEED, sizeof(SEED));
     ASSERT_TRUE(b);
@@ -550,7 +550,7 @@ TEST_F(extendedkey, bip49)
 
     bool b;
     uint8_t ekey_data[BTC_SZ_EKEY];
-    char ekey_xaddr[BTC_SZ_EKEY_ADDR_MAX];
+    char ekey_xaddr[BTC_SZ_EKEY_ADDR_MAX + 1];
     btc_ekey_t ekey;
 
     btc_term();
@@ -582,7 +582,7 @@ TEST_F(extendedkey, bip49)
 
     uint8_t pubkey[BTC_SZ_PUBKEY];
     btc_keys_priv2pub(pubkey, akey.key);
-    char addr[BTC_SZ_ADDR_MAX];
+    char addr[BTC_SZ_ADDR_MAX + 1];
     b = btc_keys_pub2p2wpkh(addr, pubkey);
     ASSERT_TRUE(b);
     ASSERT_STREQ(B58_ACC0IDX0, addr);

--- a/btc/tests/testinc_keys.cpp
+++ b/btc/tests/testinc_keys.cpp
@@ -118,8 +118,8 @@ TEST_F(keys, keys_1)
     uint8_t pub[BTC_SZ_PUBKEY];
     uint8_t uncomppub[BTC_SZ_PUBKEY_UNCOMP];
     uint8_t pkh2[BTC_SZ_PUBKEYHASH];
-    char addr[BTC_SZ_ADDR_MAX];
-    char waddr[BTC_SZ_ADDR_MAX];
+    char addr[BTC_SZ_ADDR_MAX + 1];
+    char waddr[BTC_SZ_ADDR_MAX + 1];
     btc_chain_t chain;
 
     ret = btc_keys_wif2priv(priv, &chain, WIF);
@@ -127,7 +127,7 @@ TEST_F(keys, keys_1)
     ASSERT_EQ(0, memcmp(PRIV, priv, sizeof(PRIV)));
     ASSERT_EQ(BTC_TESTNET, chain);
 
-    char wif[BTC_SZ_WIF_MAX];
+    char wif[BTC_SZ_WIF_MAX + 1];
     ret = btc_keys_priv2wif(wif, priv);
     ASSERT_TRUE(ret);
     ASSERT_STREQ(WIF, wif);
@@ -233,7 +233,7 @@ TEST_F(keys, p2wpkh_addr)
 {
     bool ret;
     const char ADDR[] = "mtLLAiafrhzcjSZqp2Ts86Gv7PupWnXKUc";
-    char waddr[BTC_SZ_ADDR_MAX];
+    char waddr[BTC_SZ_ADDR_MAX + 1];
     ret = btc_keys_addr2p2wpkh(waddr, ADDR);
     ASSERT_TRUE(ret);
     ASSERT_STREQ("2NCFo5oZuEbXgZdMDzLMA2qQiroHrU6oXSU", waddr);     //bitcoindで計算した値
@@ -423,7 +423,7 @@ TEST_F(keys, wit2p2wsh)
     const utl_buf_t wit = { (uint8_t *)REDEEM, sizeof(REDEEM) };
     const char ADDR[] = "2Mt8fd67GgFMQpeKqn9mZ6VRWHnK6MAzGbD";
 
-    char addr[BTC_SZ_ADDR_MAX];
+    char addr[BTC_SZ_ADDR_MAX + 1];
     bool ret = btc_keys_wit2waddr(addr, &wit);
     ASSERT_TRUE(ret);
     ASSERT_STREQ(ADDR, addr);

--- a/btc/tests/testinc_send.cpp
+++ b/btc/tests/testinc_send.cpp
@@ -292,7 +292,7 @@ TEST_F(send, p2wsh)
     btc_sw_add_vout_p2wsh(&tx, BTC_MBTC2SATOSHI(5.8), &wit);
 
     const char ADDR_2OF2[] = "2MuuDWRBQ5KTxJzAk1qPFZfzeheLcoSu3vy";
-    char addr_2of2[BTC_SZ_ADDR_MAX];
+    char addr_2of2[BTC_SZ_ADDR_MAX + 1];
     btc_keys_wit2waddr(addr_2of2, &wit);
     ASSERT_STREQ(ADDR_2OF2, addr_2of2);
     printf("addr 2of2= %s\n", addr_2of2);

--- a/ln/ln_msg_anno.c
+++ b/ln/ln_msg_anno.c
@@ -43,13 +43,13 @@
  ********************************************************************/
 
 #ifdef DEVELOPER_MODE
-#define DBG_PRINT_CREATE_CNL
 #define DBG_PRINT_READ_CNL
-#define DBG_PRINT_CREATE_NOD
 #define DBG_PRINT_READ_NOD
-#define DBG_PRINT_CREATE_UPD
 #define DBG_PRINT_READ_UPD
 #endif
+#define DBG_PRINT_CREATE_CNL
+#define DBG_PRINT_CREATE_NOD
+#define DBG_PRINT_CREATE_UPD
 #define DBG_PRINT_CREATE_SIG
 #define DBG_PRINT_READ_SIG
 

--- a/ptarmcli/ptarmcli.c
+++ b/ptarmcli/ptarmcli.c
@@ -256,7 +256,7 @@ int main(int argc, char *argv[])
     uint16_t port = 0;
     if (optind == argc) {
         if (ln_lmdb_have_dbdir()) {
-            char wif[BTC_SZ_WIF_MAX] = "";
+            char wif[BTC_SZ_WIF_MAX + 1] = "";
             char alias[LN_SZ_ALIAS + 1] = "";
 
             (void)ln_db_init(wif, alias, &port, false);

--- a/ptarmd/btcrpc.h
+++ b/ptarmd/btcrpc.h
@@ -177,7 +177,7 @@ bool btcrpc_check_unspent(const uint8_t *pPeerId, bool *pUnspent, uint64_t *pSat
  * @param[out]  pAddr       address
  * @retval  true        取得成功
  */
-bool btcrpc_getnewaddress(char pAddr[BTC_SZ_ADDR_MAX]);
+bool btcrpc_getnewaddress(char pAddr[BTC_SZ_ADDR_MAX + 1]);
 
 
 /** [bitcoin IF]estimatefee

--- a/ptarmd/btcrpc_bitcoind.c
+++ b/ptarmd/btcrpc_bitcoind.c
@@ -472,7 +472,7 @@ bool btcrpc_check_unspent(const uint8_t *pPeerId, bool *pUnspent, uint64_t *pSat
 }
 
 
-bool btcrpc_getnewaddress(char pAddr[BTC_SZ_ADDR_MAX])
+bool btcrpc_getnewaddress(char pAddr[BTC_SZ_ADDR_MAX + 1])
 {
     bool result = false;
     bool ret;
@@ -483,7 +483,7 @@ bool btcrpc_getnewaddress(char pAddr[BTC_SZ_ADDR_MAX])
     ret = getnewaddress_rpc(&p_root, &p_result, &p_json);
     if (ret) {
         if (json_is_string(p_result)) {
-            if (strlen(json_string_value(p_result)) < BTC_SZ_ADDR_MAX) {
+            if (strlen(json_string_value(p_result)) <= BTC_SZ_ADDR_MAX) {
                 strcpy(pAddr,  (const char *)json_string_value(p_result));
                 result = true;
             }
@@ -1427,14 +1427,14 @@ int main(int argc, char *argv[])
 //    fprintf(stderr, "confirmations = %d(%d)\n", (int)conf, b);
 
 //    fprintf(stderr, "-getnewaddress-------------------------\n");
-//    char addr[BTC_SZ_ADDR_MAX];
+//    char addr[BTC_SZ_ADDR_MAX + 1];
 //    ret = btcrpc_getnewaddress(addr);
 //    if (ret) {
 //        fprintf(stderr, "addr=%s\n", addr);
 //    }
 
 //    fprintf(stderr, "-dumpprivkey-------------------------\n");
-//    char wif[BTC_SZ_WIF_MAX];
+//    char wif[BTC_SZ_WIF_MAX + 1];
 //    ret = btcrpc_dumpprivkey(wif, addr);
 //    if (ret) {
 //        fprintf(stderr, "wif=%s\n", wif);

--- a/ptarmd/btcrpc_bitcoinj.c
+++ b/ptarmd/btcrpc_bitcoinj.c
@@ -571,7 +571,7 @@ bool btcrpc_check_unspent(const uint8_t *pPeerId, bool *pUnspent, uint64_t *pSat
 }
 
 
-bool btcrpc_getnewaddress(char pAddr[BTC_SZ_ADDR_MAX])
+bool btcrpc_getnewaddress(char pAddr[BTC_SZ_ADDR_MAX + 1])
 {
     LOGD_BTCTRACE("\n");
 

--- a/ptarmd/cmd_json.c
+++ b/ptarmd/cmd_json.c
@@ -1330,7 +1330,7 @@ static cJSON *cmd_walletback(jrpc_context *ctx, cJSON *params, cJSON *id)
 
     LOGD("$$$ [JSONRPC]walletback\n");
 
-    char addr[BTC_SZ_ADDR_MAX];
+    char addr[BTC_SZ_ADDR_MAX + 1];
     ret = btcrpc_getnewaddress(addr);
     if (!ret) {
         ctx->error_code = RPCERR_BLOCKCHAIN;
@@ -1368,7 +1368,7 @@ static cJSON *cmd_getnewaddress(jrpc_context *ctx, cJSON *params, cJSON *id)
 
     cJSON *result = NULL;
     bool ret;
-    char addr[BTC_SZ_ADDR_MAX];
+    char addr[BTC_SZ_ADDR_MAX + 1];
 
     LOGD("$$$ [JSONRPC]getnewaddress\n");
 

--- a/ptarmd/lnapp.c
+++ b/ptarmd/lnapp.c
@@ -1777,7 +1777,7 @@ static void poll_funding_wait(lnapp_conf_t *p_conf)
             // send `channel_update` for private/before publish channel
             send_cnlupd_before_announce(p_conf);
 
-            char close_addr[BTC_SZ_ADDR_MAX];
+            char close_addr[BTC_SZ_ADDR_MAX + 1];
             ret = btc_keys_spk2addr(close_addr, ln_shutdown_scriptpk_local(p_conf->p_self));
             if (!ret) {
                 utl_misc_bin2str(close_addr,
@@ -3474,7 +3474,7 @@ static void send_queue_clear(lnapp_conf_t *p_conf)
 
 static bool getnewaddress(utl_buf_t *pBuf)
 {
-    char addr[BTC_SZ_ADDR_MAX];
+    char addr[BTC_SZ_ADDR_MAX + 1];
     if (!btcrpc_getnewaddress(addr)) {
         return false;
     }

--- a/ptarmd/ptarmd_main.c
+++ b/ptarmd/ptarmd_main.c
@@ -41,7 +41,7 @@
 #ifndef USE_SPV
 #define M_OPTSTRING     "p:n:a:c:d:xNh"
 #else
-#define M_OPTSTRING     "p:n:mtrd:xNh"
+#define M_OPTSTRING     "p:n:a:mtrd:xNh"
 #endif
 
 
@@ -131,7 +131,6 @@ int main(int argc, char *argv[])
             strncpy(p_alias, optarg, LN_SZ_ALIAS);
             p_alias[LN_SZ_ALIAS] = '\0';
             break;
-#ifndef USE_SPV
         case 'a':
             //ip address
             {
@@ -140,9 +139,14 @@ int main(int argc, char *argv[])
                 if (addrret) {
                     p_addr->type = LN_NODEDESC_IPV4;
                     memcpy(p_addr->addrinfo.addr, ipbin, sizeof(ipbin));
+                    LOGD("ipv4=");
+                    DUMPD(p_addr->addrinfo.addr, sizeof(p_addr->addrinfo.ipv4.addr));
+                } else {
+                    LOGE("fail: ipv4(%s)\n", optarg);
                 }
             }
             break;
+#ifndef USE_SPV
         case 'c':
             //load btcconf file
             bret = conf_btcrpc_load(optarg, &rpc_conf);

--- a/showdb/showdb.c
+++ b/showdb/showdb.c
@@ -972,7 +972,7 @@ static void dumpit_version(MDB_txn *txn, MDB_dbi dbi)
     if (showflag == SHOW_VERSION) {
         int retval;
         int32_t version;
-        char wif[BTC_SZ_WIF_MAX] = "";
+        char wif[BTC_SZ_WIF_MAX + 1] = "";
         char alias[LN_SZ_ALIAS + 1] = "";
         uint16_t port = 0;
         uint8_t genesis[BTC_SZ_HASH256];


### PR DESCRIPTION
DB作成後にIPアドレス/ポート番号の変更を可能とする。

* `ptarmd -p -a`未指定時
  * 新規
    - `port=9735`
    - `addr=NONE`
  * DBあり
    - `port=前回`
    - `addr=前回`
* `ptarmd -p指定`
  - `port=指定値`
* `ptarmd -a指定`
  * routing可能なアドレス... `addr=指定値`
  * それ以外... `addr=前回`