### PR TITLE
add channel_update.htlc_maximum_msat(only receive)

### DIFF
--- a/ln/ln.c
+++ b/ln/ln.c
@@ -5548,6 +5548,8 @@ static bool create_channel_update(
     pUpd->fee_base_msat = self->anno_prm.fee_base_msat;
     pUpd->fee_prop_millionths = self->anno_prm.fee_prop_millionths;
     pUpd->flags = Flag | ln_sort_to_dir(sort_nodeid(self, NULL));
+#warning channel_update.htlc_maximum_msat not supported
+    pUpd->htlc_maximum_msat = 0;
     bool ret = ln_msg_cnl_update_create(pCnlUpd, pUpd);
 
     return ret;

--- a/ln/ln.h
+++ b/ln/ln.h
@@ -798,6 +798,7 @@ typedef struct {
     uint64_t    htlc_minimum_msat;                  ///< 8:  htlc_minimum_msat
     uint32_t    fee_base_msat;                      ///< 4:  fee_base_msat
     uint32_t    fee_prop_millionths;                ///< 4:  fee_proportional_millionths
+    uint64_t    htlc_maximum_msat;                  ///< 8:  htlc_maximum_msat(option_channel_htlc_max)
 } ln_cnl_update_t;
 
 

--- a/ln/ln_msg_anno.c
+++ b/ln/ln_msg_anno.c
@@ -896,10 +896,12 @@ bool ln_msg_cnl_update_read(ln_cnl_update_t *pMsg, const uint8_t *pData, uint16_
     pMsg->fee_prop_millionths = ln_misc_get32be(pData + pos);
     pos += sizeof(uint32_t);
 
+    //        [8:htlc_maximum_msat] (option_channel_htlc_max)
     if (Len >= pos + sizeof(uint64_t)) {
-        uint64_t htlc_maximum_msat = ln_misc_get64be(pData + pos);
-        //LOGD("htlc_maximum_msat: %" PRIu64 "\n", htlc_maximum_msat);
+        pMsg->htlc_maximum_msat = ln_misc_get64be(pData + pos);
         pos += sizeof(uint64_t);
+    } else {
+        pMsg->htlc_maximum_msat = 0;
     }
 
     assert(Len >= pos);
@@ -947,6 +949,9 @@ void HIDDEN ln_msg_cnl_update_print(const ln_cnl_update_t *pMsg)
     LOGD("htlc_minimum_msat= %" PRIu64 "\n", pMsg->htlc_minimum_msat);
     LOGD("fee_base_msat= %u\n", pMsg->fee_base_msat);
     LOGD("fee_prop_millionths= %u\n", pMsg->fee_prop_millionths);
+    if (pMsg->htlc_maximum_msat > 0) {
+        LOGD("htlc_maximum_msat= %" PRIu64 "\n", pMsg->htlc_maximum_msat);
+    }
     LOGD("--------------------------------\n");
 #endif  //PTARM_DEBUG
 }


### PR DESCRIPTION
`channel_update`の受信用に`htlc_maximum_msat`を追加。
未使用。