### PR TITLE
utl (2)

### DIFF
--- a/btc/btc_tx.c
+++ b/btc/btc_tx.c
@@ -23,13 +23,13 @@
  *  @brief  bitcoin処理: トランザクション生成関連
  */
 #ifdef PTARM_USE_PRINTFUNC
-#include <time.h>
 #endif  //PTARM_USE_PRINTFUNC
 
 #include "mbedtls/asn1write.h"
 #include "mbedtls/ecdsa.h"
 
 #include "utl_dbg.h"
+#include "utl_time.h"
 
 #include "btc_local.h"
 #include "segwit_addr.h"
@@ -1319,8 +1319,8 @@ void btc_print_tx(const btc_tx_t *pTx)
         LOGD2("block height\n");
     } else {
         //epoch second
-        time_t tm = pTx->locktime;
-        LOGD2("epoch second: %s", ctime(&tm));
+        char time[UTL_SZ_TIME_FMT_STR + 1];
+        LOGD2("epoch second: %s", utl_time_fmt(time, pTx->locktime));
     }
     LOGD2("======================================\n");
 }

--- a/btc/tests/test_main.cpp
+++ b/btc/tests/test_main.cpp
@@ -12,6 +12,7 @@ extern "C" {
 #include "../../utl/utl_dbg.c"
 #include "../../utl/utl_buf.c"
 #include "../../utl/utl_push.c"
+#include "../../utl/utl_time.c"
 #undef LOG_TAG
 #include "btc.c"
 #include "btc_ekey.c"

--- a/install/new_nodedir.sh
+++ b/install/new_nodedir.sh
@@ -7,7 +7,7 @@ if [ ${#1} -gt 0 ]; then
 fi
 
 if [ -d $NODEDIR ]; then
-    OLDDIR=${NODEDIR}_`date +%Y%m%d%H%M%S`
+    OLDDIR=${NODEDIR}_`date -u +%Y%m%d%H%M%S`
     mv $NODEDIR $OLDDIR
     echo "exist \"$NODEDIR\" --> move \"$OLDDIR\""
 fi

--- a/install/pay_fundin.sh
+++ b/install/pay_fundin.sh
@@ -11,7 +11,7 @@ if [ $# -ne 3 ]; then
 	return 1
 fi
 
-FUNDIN_CONF=fund_`date +%Y%m%d%H%M%S`.conf
+FUNDIN_CONF=fund_`date -u +%Y%m%d%H%M%S`.conf
 FUNDIN_BTC=`echo "scale=10; $1/100000000" | bc`
 FUNDIN_BTC=`printf "%.8f" $FUNDIN_BTC`
 FUND_SAT=$2

--- a/install/script/closed.sh
+++ b/install/script/closed.sh
@@ -3,5 +3,5 @@
 #   $1: short_channel_id
 #   $2: node_id
 #   $3: closing_txid
-DATE=`date +"%Y-%m-%dT%H:%M:%S.%N"`
+DATE=`date -u +"%Y-%m-%dT%H:%M:%S.%N"`
 echo { \"method\": \"closed\", \"short_channel_id\": \"$1\", \"node_id\": \"$2\", \"date\": \"$DATE\", \"debug\": \"closing_txid=$3\" } | jq -c .

--- a/install/script/connected.sh
+++ b/install/script/connected.sh
@@ -3,7 +3,7 @@
 #   $1: short_channel_id
 #   $2: node_id
 #   $3: peer_id
-DATE=`date +"%Y-%m-%dT%H:%M:%S.%N"`
+DATE=`date -u +"%Y-%m-%dT%H:%M:%S.%N"`
 echo { \"method\": \"connected\", \"short_channel_id\": \"$1\", \"node_id\": \"$2\", \"date\": \"$DATE\", \"debug\": \"peer_id=$3\" } | jq -c .
 
 ##自動fundingしたいnode_idを列挙

--- a/install/script/disconnected.sh
+++ b/install/script/disconnected.sh
@@ -3,5 +3,5 @@
 #   $1: short_channel_id
 #   $2: node_id
 #   $3: peer_id
-DATE=`date +"%Y-%m-%dT%H:%M:%S.%N"`
+DATE=`date -u +"%Y-%m-%dT%H:%M:%S.%N"`
 echo { \"method\": \"disconnected\", \"short_channel_id\": \"$1\", \"node_id\": \"$2\", \"date\": \"$DATE\", \"debug\": \"peer_id=$3\" } | jq -c .

--- a/install/script/error.sh
+++ b/install/script/error.sh
@@ -3,7 +3,7 @@
 #   $1: short_channel_id
 #   $2: node_id
 #   $3: err_str
-DATE=`date +"%Y-%m-%dT%H:%M:%S.%N"`
+DATE=`date -u +"%Y-%m-%dT%H:%M:%S.%N"`
 echo "{ \"method\": \"error\", \"short_channel_id\": \"$1\", \"node_id\": \"$2\", \"date\": \"$DATE\", \"err_str\": \"$3\" }" | jq -c .
 
 # echo "from $2($1):" >> err_$1.log

--- a/install/script/established.sh
+++ b/install/script/established.sh
@@ -4,7 +4,7 @@
 #   $2: node_id
 #   $3: our_msat
 #   $4: funding_txid
-DATE=`date +"%Y-%m-%dT%H:%M:%S.%N"`
+DATE=`date -u +"%Y-%m-%dT%H:%M:%S.%N"`
 echo { \"method\": \"established\", \"short_channel_id\": \"$1\", \"node_id\": \"$2\", \"date\": \"$DATE\", \"our_msat\": $3, \"debug\": \"funding_txid=$4\" } | jq -c .
 
 ## our_msat

--- a/install/script/fail.sh
+++ b/install/script/fail.sh
@@ -2,5 +2,5 @@
 #   method: fail
 #   $1: short_channel_id
 #   $2: node_id
-DATE=`date +"%Y-%m-%dT%H:%M:%S.%N"`
+DATE=`date -u +"%Y-%m-%dT%H:%M:%S.%N"`
 echo { \"method\": \"fail\", \"short_channel_id\": \"$1\", \"node_id\": \"$2\", \"date\": \"$DATE\" } | jq -c .

--- a/install/script/forward.sh
+++ b/install/script/forward.sh
@@ -5,5 +5,5 @@
 #   $3: amt_to_forward
 #   $4: outgoing_cltv_value
 #   $5: payment_hash
-DATE=`date +"%Y-%m-%dT%H:%M:%S.%N"`
+DATE=`date -u +"%Y-%m-%dT%H:%M:%S.%N"`
 echo { \"method\": \"forward\", \"short_channel_id\": \"$1\", \"node_id\": \"$2\", \"date\": \"$DATE\", \"amt_to_forward\": $3, \"debug\": \"outgoing_cltv_value=$4, payment_hash=$5\" } | jq -c .

--- a/install/script/fulfill.sh
+++ b/install/script/fulfill.sh
@@ -4,5 +4,5 @@
 #   $2: node_id
 #   $3: payment_hash
 #   $4: payment_preimage
-DATE=`date +"%Y-%m-%dT%H:%M:%S.%N"`
+DATE=`date -u +"%Y-%m-%dT%H:%M:%S.%N"`
 echo { \"method\": \"fulfill\", \"short_channel_id\": \"$1\", \"node_id\": \"$2\", \"date\": \"$DATE\", \"debug\": \"payment_hash=$3, payment_preimage=$4\" } | jq -c .

--- a/install/script/htlcchanged.sh
+++ b/install/script/htlcchanged.sh
@@ -3,7 +3,7 @@
 #   $1: short_channel_id
 #   $2: node_id
 #   $3: our_msat
-DATE=`date +"%Y-%m-%dT%H:%M:%S.%N"`
+DATE=`date -u +"%Y-%m-%dT%H:%M:%S.%N"`
 echo { \"method\": \"htlc_changed\", \"short_channel_id\": \"$1\", \"node_id\": \"$2\", \"date\": \"$DATE\", \"our_msat\": $3\" } | jq -c .
 
 ## changes in amount

--- a/install/script/payment.sh
+++ b/install/script/payment.sh
@@ -5,5 +5,5 @@
 #   $3: amt_to_forward
 #   $4: outgoing_cltv_value
 #   $5: payment_hash
-DATE=`date +"%Y-%m-%dT%H:%M:%S.%N"`
+DATE=`date -u +"%Y-%m-%dT%H:%M:%S.%N"`
 echo { \"method\": \"payment\", \"short_channel_id\": \"$1\", \"node_id\": \"$2\", \"date\": \"$DATE\", \"amt_to_forward\": $3, \"debug\": \"outgoing_cltv_value=$4, payment_hash=$5\" } | jq -c .

--- a/install/script/started.sh
+++ b/install/script/started.sh
@@ -2,5 +2,5 @@
 #   method: started
 #   $1: 0
 #   $2: node_id
-DATE=`date +"%Y-%m-%dT%H:%M:%S.%N"`
+DATE=`date -u +"%Y-%m-%dT%H:%M:%S.%N"`
 echo { \"method\": \"started\", \"short_channel_id\": \"$1\", \"node_id\": \"$2\" } | jq -c .

--- a/ln/ln.c
+++ b/ln/ln.c
@@ -33,6 +33,7 @@
 #include "utl_misc.h"
 #include "utl_buf.h"
 #include "utl_dbg.h"
+#include "utl_time.h"
 
 #include "ln_db.h"
 #include "ln_misc.h"
@@ -3967,9 +3968,8 @@ static bool recv_channel_update(ln_self_t *self, const uint8_t *pData, uint16_t 
         uint64_t now = (uint64_t)time(NULL);
         if (ln_db_annocnlupd_is_prune(now, upd.timestamp)) {
             //ret = false;
-            char tmstr[UTL_SZ_DTSTR + 1];
-            utl_misc_strftime(tmstr, upd.timestamp);
-            LOGD("older channel: not save(%016" PRIx64 "): %s\n", upd.short_channel_id, tmstr);
+            char time[UTL_SZ_TIME_FMT_STR + 1];
+            LOGD("older channel: not save(%016" PRIx64 "): %s\n", upd.short_channel_id, utl_time_fmt(time, upd.timestamp));
             return true;
         }
     } else {

--- a/ln/ln_msg_anno.c
+++ b/ln/ln_msg_anno.c
@@ -31,6 +31,8 @@
 #include <unistd.h>
 #include <assert.h>
 
+#include "utl_time.h"
+
 #include "ln_msg_anno.h"
 #include "ln_misc.h"
 #include "ln_node.h"
@@ -730,8 +732,8 @@ static void node_announce_print(const ln_node_announce_t *pMsg)
 {
 #ifdef PTARM_DEBUG
     LOGD("-[node_announcement]-------------------------------\n");
-    time_t t = (time_t)pMsg->timestamp;
-    LOGD("timestamp: %lu : %s", (unsigned long)t, ctime(&t));
+    char time[UTL_SZ_TIME_FMT_STR + 1];
+    LOGD("timestamp: %lu : %s", (unsigned long)pMsg->timestamp, utl_time_fmt(time, pMsg->timestamp));
     if (pMsg->p_node_id != NULL) {
         LOGD("p_node_id: ");
         DUMPD(pMsg->p_node_id, BTC_SZ_PUBKEY);
@@ -940,8 +942,8 @@ void HIDDEN ln_msg_cnl_update_print(const ln_cnl_update_t *pMsg)
     //LOGD("p_node_signature: ");
     //DUMPD(pMsg->signature, LN_SZ_SIGNATURE);
     LOGD("short_channel_id: %016" PRIx64 "\n", pMsg->short_channel_id);
-    time_t t = (time_t)pMsg->timestamp;
-    LOGD("timestamp: %lu : %s", (unsigned long)t, ctime(&t));
+    char time[UTL_SZ_TIME_FMT_STR + 1];
+    LOGD("timestamp: %lu : %s", (unsigned long)pMsg->timestamp, utl_time_fmt(time, pMsg->timestamp));
     LOGD("flags= 0x%04x\n", pMsg->flags);
     LOGD("    direction: %s\n", ln_cnlupd_direction(pMsg) ? "node_2" : "node_1");
     LOGD("    %s\n", ln_cnlupd_enable(pMsg) ? "enable" : "disable");

--- a/ln/ln_segwit_addr.c
+++ b/ln/ln_segwit_addr.c
@@ -12,6 +12,7 @@
 #include "segwit_addr.h"
 
 #include "utl_dbg.h"
+#include "utl_time.h"
 
 #include "ln_node.h"
 #include "ln_misc.h"
@@ -472,7 +473,8 @@ bool ln_invoice_decode(ln_invoice_t **pp_invoice_data, const char* invoice) {
     //timestamp(7 chars)
     tm = (time_t)ln_convert_be64(data, 7);
     p_invoice_data->timestamp = (uint64_t)tm;
-    //LOGD("timestamp= %" PRIu64 " : %s", (uint64_t)tm, ctime(&tm));
+    char time[UTL_SZ_TIME_FMT_STR + 1];
+    LOGD("timestamp= %" PRIu64 " : %s", (uint64_t)tm, utl_time_fmt(time, tm));
 
     //tagged fields
     ret = true;

--- a/ln/tests/test_main.cpp
+++ b/ln/tests/test_main.cpp
@@ -13,6 +13,7 @@ extern "C" {
 #include "../../utl/utl_dbg.c"
 #include "../../utl/utl_buf.c"
 #include "../../utl/utl_push.c"
+#include "../../utl/utl_time.c"
 #undef LOG_TAG
 #include "../../btc/btc.c"
 #include "../../btc/btc_ekey.c"

--- a/ln/tests/testinc_bech32.cpp
+++ b/ln/tests/testinc_bech32.cpp
@@ -101,8 +101,8 @@ static struct valid_invoice_data ln_valid_invoice[] = {
 //         fprintf(stderr, "unknown hrp_type\n");
 //     }
 //     fprintf(stderr, "amount_msat=%" PRIu64 "\n", p_invoice_data->amount_msat);
-//     time_t tm = (time_t)p_invoice_data->timestamp;
-//     fprintf(stderr, "timestamp= %" PRIu64 " : %s", (uint64_t)p_invoice_data->timestamp, ctime(&tm));
+//     char time[UTL_SZ_TIME_FMT_STR + 1];
+//     fprintf(stderr, "timestamp= %" PRIu64 " : %s", (uint64_t)p_invoice_data->timestamp, utl_time_fmt(time, p_invoice_data->timestamp));
 //     fprintf(stderr, "min_final_cltv_expiry=%u\n", p_invoice_data->min_final_cltv_expiry);
 //     fprintf(stderr, "pubkey=");
 //     for (int lp = 0; lp < BTC_SZ_PUBKEY; lp++) {

--- a/ptarmcli/ptarmcli.c
+++ b/ptarmcli/ptarmcli.c
@@ -30,11 +30,13 @@
 
 #include <jansson.h>
 
+#include "utl_misc.h"
+#include "utl_time.h"
+
 #include "ptarmd.h"
 #include "ln_db.h"
 #include "ln_db_lmdb.h"
 #include "conf.h"
-#include "utl_misc.h"
 #include "ln_segwit_addr.h"
 
 
@@ -968,7 +970,8 @@ static void routepay(int *pOption, bool bPrevSkip)
     }
     printf("amount_msat=%" PRIu64 "\n", p_invoice_data->amount_msat);
     time_t tm = (time_t)p_invoice_data->timestamp;
-    printf("timestamp= %" PRIu64 " : %s", (uint64_t)p_invoice_data->timestamp, ctime(&tm));
+    char time[UTL_SZ_TIME_FMT_STR + 1];
+    printf("timestamp= %" PRIu64 " : %s", (uint64_t)p_invoice_data->timestamp, utl_time_fmt(time, tm));
     printf("min_final_cltv_expiry=%u\n", p_invoice_data->min_final_cltv_expiry);
     printf("payee=");
     for (int lp = 0; lp < BTC_SZ_PUBKEY; lp++) {

--- a/ptarmd/lnapp.c
+++ b/ptarmd/lnapp.c
@@ -55,13 +55,15 @@
 
 #include "cJSON.h"
 
+#include "utl_addr.h"
+#include "utl_time.h"
+
 #include "ptarmd.h"
 #include "cmd_json.h"
 #include "lnapp.h"
 #include "conf.h"
 #include "btcrpc.h"
 #include "ln_db.h"
-#include "utl_addr.h"
 
 #include "monitoring.h"
 
@@ -765,9 +767,8 @@ void lnapp_save_event(const uint8_t *pChannelId, const char *pFormat, ...)
     }
     FILE *fp = fopen(fname, "a");
     if (fp != NULL) {
-        char date[50];
-        utl_misc_datetime(date, sizeof(date));
-        fprintf(fp, "[%s]", date);
+        char time[UTL_SZ_TIME_FMT_STR + 1];
+        fprintf(fp, "[%s]", utl_time_str_time(time));
 
         va_list ap;
         va_start(ap, pFormat);
@@ -1044,9 +1045,8 @@ static void *thread_main_start(void *pArg)
 
         FILE *fp = fopen(FNAME_CONN_LOG, "a");
         if (fp) {
-            char date[50];
-            utl_misc_datetime(date, sizeof(date));
-            fprintf(fp, "[%s]OK: %s@%s:%" PRIu16 "\n", date, peer_id, p_conf->conn_str, p_conf->conn_port);
+            char time[UTL_SZ_TIME_FMT_STR + 1];
+            fprintf(fp, "[%s]OK: %s@%s:%" PRIu16 "\n", utl_time_str_time(time), peer_id, p_conf->conn_str, p_conf->conn_port);
             fclose(fp);
         }
     }
@@ -2101,9 +2101,8 @@ static bool send_anno_pre_upd(uint64_t short_channel_id, uint32_t timestamp, uin
     uint64_t now = (uint64_t)time(NULL);
     if (ln_db_annocnlupd_is_prune(now, timestamp)) {
         //古いため送信しない
-        char tmstr[UTL_SZ_DTSTR + 1];
-        utl_misc_strftime(tmstr, timestamp);
-        LOGD("older channel_update: prune(%016" PRIx64 "): %s(now=%" PRIu32 ", tm=%" PRIu32 ")\n", short_channel_id, tmstr, now, timestamp);
+        char time[UTL_SZ_TIME_FMT_STR + 1];
+        LOGD("older channel_update: prune(%016" PRIx64 "): %s(now=%" PRIu32 ", tm=%" PRIu32 ")\n", short_channel_id, utl_time_fmt(time, timestamp), now, timestamp);
         ret = false;
     }
 

--- a/ptarmd/lnapp.c
+++ b/ptarmd/lnapp.c
@@ -1663,7 +1663,7 @@ static void *thread_poll_start(void *pArg)
 
         poll_ping(p_conf);
 
-        if (utl_misc_all_zero(ln_funding_txid(p_conf->p_self), BTC_SZ_TXID)) {
+        if (utl_misc_is_all_zero(ln_funding_txid(p_conf->p_self), BTC_SZ_TXID)) {
             //fundingしていない
             continue;
         }
@@ -1675,7 +1675,7 @@ static void *thread_poll_start(void *pArg)
 #ifndef USE_SPV
 #else
                 const uint8_t *oldhash = ln_funding_blockhash(p_conf->p_self);
-                if (utl_misc_all_zero(oldhash, BTC_SZ_HASH256)) {
+                if (utl_misc_is_all_zero(oldhash, BTC_SZ_HASH256)) {
                     int32_t bheight = 0;
                     int32_t bindex = 0;
                     uint8_t mined_hash[BTC_SZ_HASH256];

--- a/ptarmd/p2p_cli.c
+++ b/ptarmd/p2p_cli.c
@@ -37,6 +37,8 @@
 
 #include "cJSON.h"
 
+#include "utl_time.h"
+
 #include "ptarmd.h"
 #include "p2p_cli.h"
 #include "lnapp.h"
@@ -173,9 +175,8 @@ bool p2p_cli_start(const peer_conn_t *pConn, jrpc_context *ctx)
             char peer_id[BTC_SZ_PUBKEY * 2 + 1];
             utl_misc_bin2str(peer_id, pConn->node_id, BTC_SZ_PUBKEY);
 
-            char date[50];
-            utl_misc_datetime(date, sizeof(date));
-            fprintf(fp, "[%s]fail: %s@%s:%" PRIu16 "\n", date, peer_id, pConn->ipaddr, pConn->port);
+            char time[UTL_SZ_TIME_FMT_STR + 1];
+            fprintf(fp, "[%s]fail: %s@%s:%" PRIu16 "\n", utl_time_str_time(time), peer_id, pConn->ipaddr, pConn->port);
             fclose(fp);
         }
 

--- a/ptarmd/ptarmd.c
+++ b/ptarmd/ptarmd.c
@@ -314,7 +314,7 @@ void ptarmd_nodefail_add(
     LOGD("ipaddr(%d)=%s:%" PRIu16 " node_id: ", NodeDesc, pAddr, Port);
     DUMPD(pNodeId, BTC_SZ_PUBKEY);
 
-    if ( utl_misc_all_zero(pNodeId, BTC_SZ_PUBKEY) ||
+    if ( utl_misc_is_all_zero(pNodeId, BTC_SZ_PUBKEY) ||
          ptarmd_nodefail_get(pNodeId, pAddr, Port, LN_NODEDESC_IPV4, false) ) {
         //登録の必要なし
         LOGD("no save\n");

--- a/ptarmd/tests/test_main.cpp
+++ b/ptarmd/tests/test_main.cpp
@@ -12,6 +12,7 @@ extern "C" {
 #include "../../utl/utl_buf.c"
 #include "../../utl/utl_push.c"
 #include "../../utl/utl_addr.c"
+#include "../../utl/utl_time.c"
 //評価対象本体
 #undef LOG_TAG
 #include "lnapp.c"

--- a/showdb/showdb.c
+++ b/showdb/showdb.c
@@ -36,6 +36,8 @@
 #include <getopt.h>
 #include <assert.h>
 
+#include "utl_time.h"
+
 #include "ptarmd.h"
 #include "ln_db.h"
 #include "ln_db_lmdb.h"
@@ -953,9 +955,8 @@ static void dumpit_preimage(MDB_txn *txn, MDB_dbi dbi)
                 printf("\",\n");
                 printf(INDENT1 M_QQ("amount") ": %" PRIu64 ",\n", preimg.amount_msat);
                 printf(INDENT1 M_QQ("expiry") ": %" PRIu32 "\n", preimg.expiry);
-                char dtstr[UTL_SZ_DTSTR];
-                utl_misc_strftime(dtstr, preimg.creation_time);
-                printf(INDENT1 M_QQ("creation") ": %s\n", dtstr);
+                char time[UTL_SZ_TIME_FMT_STR + 1];
+                printf(INDENT1 M_QQ("creation") ": %s\n", utl_time_fmt(time, preimg.creation_time));
                 printf("}");
                 cnt4++;
             }

--- a/utl/Makefile
+++ b/utl/Makefile
@@ -47,6 +47,7 @@ C_SOURCE_FILES += $(PRJ_PATH)/utl_str.c
 C_SOURCE_FILES += $(PRJ_PATH)/utl_jsonrpc.c
 C_SOURCE_FILES += $(PRJ_PATH)/utl_addr.c
 C_SOURCE_FILES += $(PRJ_PATH)/utl_log.c
+C_SOURCE_FILES += $(PRJ_PATH)/utl_time.c
 
 
 #includes common to all targets

--- a/utl/tests/test_utl.cpp
+++ b/utl/tests/test_utl.cpp
@@ -37,10 +37,11 @@ TEST_F(utl, first)
 }
 
 
-#include "testinc_buf.cpp"
-#include "testinc_push.cpp"
-#include "testinc_net.cpp"
-#include "testinc_str.cpp"
-#include "testinc_opts.cpp"
-#include "testinc_jsonrpc.cpp"
 #include "testinc_addr.cpp"
+#include "testinc_buf.cpp"
+#include "testinc_jsonrpc.cpp"
+#include "testinc_misc.cpp"
+#include "testinc_net.cpp"
+#include "testinc_opts.cpp"
+#include "testinc_push.cpp"
+#include "testinc_str.cpp"

--- a/utl/tests/test_utl.cpp
+++ b/utl/tests/test_utl.cpp
@@ -17,6 +17,7 @@ extern "C" {
 #include "utl_opts.c"
 #include "utl_jsonrpc.c"
 #include "utl_addr.c"
+#include "utl_time.c"
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -45,3 +46,5 @@ TEST_F(utl, first)
 #include "testinc_opts.cpp"
 #include "testinc_push.cpp"
 #include "testinc_str.cpp"
+#include "testinc_time.cpp"
+

--- a/utl/tests/testinc_buf.cpp
+++ b/utl/tests/testinc_buf.cpp
@@ -54,7 +54,7 @@ TEST_F(buf, alloc)
     utl_buf_t buf;
     InitDummy(&buf);
 
-    utl_buf_alloc(&buf, 10);
+    ASSERT_TRUE(utl_buf_alloc(&buf, 10));
     ASSERT_TRUE(NULL != buf.buf);
     ASSERT_EQ(10, buf.len);
 
@@ -68,11 +68,11 @@ TEST_F(buf, realloc)
     utl_buf_t buf;
     InitDummy(&buf);
 
-    utl_buf_alloc(&buf, 10);
+    ASSERT_TRUE(utl_buf_alloc(&buf, 10));
     ASSERT_TRUE(NULL != buf.buf);
     ASSERT_EQ(10, buf.len);
 
-    utl_buf_realloc(&buf, 20);
+    ASSERT_TRUE(utl_buf_realloc(&buf, 20));
     ASSERT_TRUE(NULL != buf.buf);
     ASSERT_EQ(20, buf.len);
 
@@ -89,7 +89,7 @@ TEST_F(buf, alloccopy)
     const uint8_t BUF[] = {
         0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
     };
-    utl_buf_alloccopy(&buf, BUF, sizeof(BUF));
+    ASSERT_TRUE(utl_buf_alloccopy(&buf, BUF, sizeof(BUF)));
     ASSERT_TRUE(NULL != buf.buf);
     ASSERT_NE(BUF, buf.buf);
     ASSERT_EQ(sizeof(BUF), buf.len);
@@ -117,9 +117,9 @@ TEST_F(buf, cmp)
         0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
     };
 
-    utl_buf_alloccopy(&buf, BUF, sizeof(BUF));
-    utl_buf_alloccopy(&buf2, BUF2, sizeof(BUF2));
-    utl_buf_alloccopy(&buf3, BUF2, sizeof(BUF2));
+    ASSERT_TRUE(utl_buf_alloccopy(&buf, BUF, sizeof(BUF)));
+    ASSERT_TRUE(utl_buf_alloccopy(&buf2, BUF2, sizeof(BUF2)));
+    ASSERT_TRUE(utl_buf_alloccopy(&buf3, BUF2, sizeof(BUF2)));
 
     ASSERT_TRUE(utl_buf_cmp(&buf, &buf));
     ASSERT_FALSE(utl_buf_cmp(&buf, &buf2));

--- a/utl/tests/testinc_misc.cpp
+++ b/utl/tests/testinc_misc.cpp
@@ -1,0 +1,85 @@
+////////////////////////////////////////////////////////////////////////
+//FAKE関数
+
+//FAKE_VALUE_FUNC(int, external_function, int);
+
+////////////////////////////////////////////////////////////////////////
+
+class misc: public testing::Test {
+protected:
+    virtual void SetUp() {
+        //RESET_FAKE(external_function)
+        utl_dbg_malloc_cnt_reset();
+    }
+
+    virtual void TearDown() {
+        ASSERT_EQ(0, utl_dbg_malloc_cnt());
+    }
+
+public:
+    static void DumpBin(const uint8_t *pData, uint16_t Len)
+    {
+        for (uint16_t lp = 0; lp < Len; lp++) {
+            printf("%02x", pData[lp]);
+        }
+        printf("\n");
+    }
+};
+
+////////////////////////////////////////////////////////////////////////
+
+TEST_F(misc, valid)
+{
+    {
+        uint8_t bin[64];
+        const char *s = "01";
+        uint8_t result[] = {
+            0x01,
+        };
+        uint32_t len = ARRAY_SIZE(result);
+        ASSERT_TRUE(utl_misc_str2bin(bin, len, s));
+        ASSERT_EQ(0, memcmp(bin, result, len));
+    }
+    {
+        uint8_t bin[64];
+        const char *s = "0123456789abcdefABCDEF";
+        uint8_t result[] = {
+            0x01, 0x23, 0x45, 0x67, 0x89,
+            0xab, 0xcd, 0xef,
+            0xAB, 0xCD, 0xEF,
+        };
+        uint32_t len = ARRAY_SIZE(result);
+        ASSERT_TRUE(utl_misc_str2bin(bin, len, s));
+        ASSERT_EQ(0, memcmp(bin, result, len));
+    }
+}
+
+TEST_F(misc, invalid_len)
+{
+    {
+        uint8_t bin[64];
+        const char *s = "0123456789abcdefABCDE";
+        ASSERT_FALSE(utl_misc_str2bin(bin, 10, s));
+        ASSERT_FALSE(utl_misc_str2bin(bin, 11, s));
+    }
+    {
+        uint8_t bin[64];
+        const char *s = "1";
+        ASSERT_FALSE(utl_misc_str2bin(bin, 0, s));
+        ASSERT_FALSE(utl_misc_str2bin(bin, 1, s));
+    }
+}
+
+TEST_F(misc, invalid_chars)
+{
+    {
+        uint8_t bin[64];
+        const char *s = "g0";
+        ASSERT_FALSE(utl_misc_str2bin(bin, 1, s));
+    }
+    {
+        uint8_t bin[64];
+        const char *s = "0g";
+        ASSERT_FALSE(utl_misc_str2bin(bin, 1, s));
+    }
+}

--- a/utl/tests/testinc_push.cpp
+++ b/utl/tests/testinc_push.cpp
@@ -33,7 +33,7 @@ TEST_F(push, init)
     utl_push_t pushbuf;
     utl_buf_t buf;
 
-    utl_push_init(&pushbuf, &buf, 5);
+    ASSERT_TRUE(utl_push_init(&pushbuf, &buf, 5));
 
     ASSERT_EQ(0, pushbuf.pos);
     ASSERT_TRUE(NULL != buf.buf);
@@ -48,7 +48,7 @@ TEST_F(push, init_zero)
     utl_push_t pushbuf;
     utl_buf_t buf;
 
-    utl_push_init(&pushbuf, &buf, 0);
+    ASSERT_TRUE(utl_push_init(&pushbuf, &buf, 0));
 
     ASSERT_EQ(0, pushbuf.pos);
     ASSERT_TRUE(NULL == buf.buf);
@@ -61,10 +61,10 @@ TEST_F(push, data_in1)
     utl_push_t pushbuf;
     utl_buf_t buf;
 
-    utl_push_init(&pushbuf, &buf, 5);
+    ASSERT_TRUE(utl_push_init(&pushbuf, &buf, 5));
 
     const uint8_t DATA[] = { 1, 2, 3 };
-    utl_push_data(&pushbuf, DATA, sizeof(DATA));
+    ASSERT_TRUE(utl_push_data(&pushbuf, DATA, sizeof(DATA)));
 
     ASSERT_EQ(3, pushbuf.pos);
     ASSERT_EQ(0, memcmp(DATA, buf.buf, sizeof(DATA)));
@@ -79,13 +79,13 @@ TEST_F(push, data_in2)
     utl_push_t pushbuf;
     utl_buf_t buf;
 
-    utl_push_init(&pushbuf, &buf, 5);
+    ASSERT_TRUE(utl_push_init(&pushbuf, &buf, 5));
 
     const uint8_t DATA1[] = { 1, 2, 3 };
-    utl_push_data(&pushbuf, DATA1, sizeof(DATA1));
+    ASSERT_TRUE(utl_push_data(&pushbuf, DATA1, sizeof(DATA1)));
 
     const uint8_t DATA2[] = { 4, 5 };
-    utl_push_data(&pushbuf, DATA2, sizeof(DATA2));
+    ASSERT_TRUE(utl_push_data(&pushbuf, DATA2, sizeof(DATA2)));
 
     ASSERT_EQ(5, pushbuf.pos);
     const uint8_t DATA[] = { 1, 2, 3, 4, 5 };
@@ -101,10 +101,10 @@ TEST_F(push, data_expand1)
     utl_push_t pushbuf;
     utl_buf_t buf;
 
-    utl_push_init(&pushbuf, &buf, 5);
+    ASSERT_TRUE(utl_push_init(&pushbuf, &buf, 5));
 
     const uint8_t DATA[] = { 1, 2, 3, 4, 5, 6 };
-    utl_push_data(&pushbuf, DATA, sizeof(DATA));
+    ASSERT_TRUE(utl_push_data(&pushbuf, DATA, sizeof(DATA)));
 
     ASSERT_EQ(6, pushbuf.pos);
     ASSERT_EQ(0, memcmp(DATA, buf.buf, sizeof(DATA)));
@@ -119,17 +119,17 @@ TEST_F(push, data_expand2)
     utl_push_t pushbuf;
     utl_buf_t buf;
 
-    utl_push_init(&pushbuf, &buf, 5);
+    ASSERT_TRUE(utl_push_init(&pushbuf, &buf, 5));
 
     const uint8_t DATA[] = { 1, 2, 3, 4, 5, 6 };
-    utl_push_data(&pushbuf, DATA, sizeof(DATA));
+    ASSERT_TRUE(utl_push_data(&pushbuf, DATA, sizeof(DATA)));
 
     ASSERT_EQ(6, pushbuf.pos);
     ASSERT_EQ(0, memcmp(DATA, buf.buf, sizeof(DATA)));
     ASSERT_EQ(6, buf.len);
 
     const uint8_t DATA2[] = { 7, 8, 9, 10 };
-    utl_push_data(&pushbuf, DATA2, sizeof(DATA2));
+    ASSERT_TRUE(utl_push_data(&pushbuf, DATA2, sizeof(DATA2)));
 
     ASSERT_EQ(10, pushbuf.pos);
     const uint8_t DATA_ALL[] = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
@@ -145,7 +145,7 @@ TEST_F(push, value0)
     utl_push_t pushbuf;
     utl_buf_t buf;
 
-    utl_push_init(&pushbuf, &buf, 5);
+    ASSERT_TRUE(utl_push_init(&pushbuf, &buf, 5));
 
     ASSERT_TRUE(utl_push_value(&pushbuf, 0));
 
@@ -161,7 +161,7 @@ TEST_F(push, value01_10)
     utl_push_t pushbuf;
     utl_buf_t buf;
 
-    utl_push_init(&pushbuf, &buf, 5);
+    ASSERT_TRUE(utl_push_init(&pushbuf, &buf, 5));
 
     ASSERT_TRUE(utl_push_value(&pushbuf, 0x01));
     ASSERT_TRUE(utl_push_value(&pushbuf, 0x10));
@@ -179,7 +179,7 @@ TEST_F(push, value11_7f)
     utl_push_t pushbuf;
     utl_buf_t buf;
 
-    utl_push_init(&pushbuf, &buf, 5);
+    ASSERT_TRUE(utl_push_init(&pushbuf, &buf, 5));
 
     ASSERT_TRUE(utl_push_value(&pushbuf, 0x11));
     ASSERT_TRUE(utl_push_value(&pushbuf, 0x7f));
@@ -199,7 +199,7 @@ TEST_F(push, value80_7fff)
     utl_push_t pushbuf;
     utl_buf_t buf;
 
-    utl_push_init(&pushbuf, &buf, 5);
+    ASSERT_TRUE(utl_push_init(&pushbuf, &buf, 5));
 
     ASSERT_TRUE(utl_push_value(&pushbuf, 0x80));
     ASSERT_TRUE(utl_push_value(&pushbuf, 0x7fff));
@@ -221,7 +221,7 @@ TEST_F(push, value8000_7fffff)
     utl_push_t pushbuf;
     utl_buf_t buf;
 
-    utl_push_init(&pushbuf, &buf, 5);
+    ASSERT_TRUE(utl_push_init(&pushbuf, &buf, 5));
 
     ASSERT_TRUE(utl_push_value(&pushbuf, 0x8000));
     ASSERT_TRUE(utl_push_value(&pushbuf, 0x7fffff));
@@ -245,7 +245,7 @@ TEST_F(push, value800000_7fffffff)
     utl_push_t pushbuf;
     utl_buf_t buf;
 
-    utl_push_init(&pushbuf, &buf, 5);
+    ASSERT_TRUE(utl_push_init(&pushbuf, &buf, 5));
 
     ASSERT_TRUE(utl_push_value(&pushbuf, 0x800000));
     ASSERT_TRUE(utl_push_value(&pushbuf, 0x7fffffff));
@@ -271,7 +271,7 @@ TEST_F(push, value80000000_7fffffffff)
     utl_push_t pushbuf;
     utl_buf_t buf;
 
-    utl_push_init(&pushbuf, &buf, 5);
+    ASSERT_TRUE(utl_push_init(&pushbuf, &buf, 5));
 
     ASSERT_TRUE(utl_push_value(&pushbuf, 0x80000000));
     ASSERT_TRUE(utl_push_value(&pushbuf, 0x7fffffffff));
@@ -298,7 +298,7 @@ TEST_F(push, invalid_value8000000000)
     utl_push_t pushbuf;
     utl_buf_t buf;
 
-    utl_push_init(&pushbuf, &buf, 16);
+    ASSERT_TRUE(utl_push_init(&pushbuf, &buf, 16));
 
     ASSERT_FALSE(utl_push_value(&pushbuf, 0x8000000000));
 
@@ -310,9 +310,9 @@ TEST_F(push, trim0)
     utl_push_t pushbuf;
     utl_buf_t buf;
 
-    utl_push_init(&pushbuf, &buf, 5);
+    ASSERT_TRUE(utl_push_init(&pushbuf, &buf, 5));
 
-    utl_push_trim(&pushbuf);
+    ASSERT_TRUE(utl_push_trim(&pushbuf));
 
     ASSERT_EQ(0, pushbuf.pos);
     ASSERT_EQ(0, buf.len);
@@ -326,16 +326,16 @@ TEST_F(push, trim)
     utl_push_t pushbuf;
     utl_buf_t buf;
 
-    utl_push_init(&pushbuf, &buf, 5);
+    ASSERT_TRUE(utl_push_init(&pushbuf, &buf, 5));
 
     const uint8_t DATA[] = { 1, 2, 3 };
-    utl_push_data(&pushbuf, DATA, sizeof(DATA));
+    ASSERT_TRUE(utl_push_data(&pushbuf, DATA, sizeof(DATA)));
 
     ASSERT_EQ(3, pushbuf.pos);
     ASSERT_EQ(0, memcmp(DATA, buf.buf, sizeof(DATA)));
     ASSERT_EQ(5, buf.len);
 
-    utl_push_trim(&pushbuf);
+    ASSERT_TRUE(utl_push_trim(&pushbuf));
 
     ASSERT_EQ(3, pushbuf.pos);
     ASSERT_EQ(0, memcmp(DATA, buf.buf, sizeof(DATA)));

--- a/utl/tests/testinc_time.cpp
+++ b/utl/tests/testinc_time.cpp
@@ -1,0 +1,51 @@
+////////////////////////////////////////////////////////////////////////
+//FAKE関数
+
+//FAKE_VALUE_FUNC(int, external_function, int);
+
+////////////////////////////////////////////////////////////////////////
+
+class time: public testing::Test {
+protected:
+    virtual void SetUp() {
+        //RESET_FAKE(external_function)
+        utl_dbg_malloc_cnt_reset();
+    }
+
+    virtual void TearDown() {
+        ASSERT_EQ(0, utl_dbg_malloc_cnt());
+    }
+
+public:
+    static void DumpBin(const uint8_t *pData, uint16_t Len)
+    {
+        for (uint16_t lp = 0; lp < Len; lp++) {
+            printf("%02x", pData[lp]);
+        }
+        printf("\n");
+    }
+};
+
+////////////////////////////////////////////////////////////////////////
+
+TEST_F(time, time)
+{
+    utl_time_time();
+}
+
+TEST_F(time, str_time)
+{
+    char str[UTL_SZ_TIME_FMT_STR + 1] = {0};
+    const char *ret = utl_time_str_time(str);
+    ASSERT_EQ(str, ret);
+}
+
+TEST_F(time, fmt)
+{
+    char str[UTL_SZ_TIME_FMT_STR + 1] = {0};
+    const char *result_str = "2018-12-18T07:42:35Z";
+    time_t t = 1545118955;
+    const char *ret = utl_time_fmt(str, t);
+    ASSERT_EQ(0, strcmp(str, result_str));
+    ASSERT_EQ(str, ret);
+}

--- a/utl/utl_buf.c
+++ b/utl/utl_buf.c
@@ -53,28 +53,31 @@ void utl_buf_free(utl_buf_t *pBuf)
 }
 
 
-void utl_buf_alloc(utl_buf_t *pBuf, uint32_t Size)
+bool utl_buf_alloc(utl_buf_t *pBuf, uint32_t Size)
 {
     pBuf->len = Size;
     pBuf->buf = (uint8_t *)UTL_DBG_MALLOC(Size);
+    return pBuf->buf != NULL;
 }
 
 
-void utl_buf_realloc(utl_buf_t *pBuf, uint32_t Size)
+bool utl_buf_realloc(utl_buf_t *pBuf, uint32_t Size)
 {
     pBuf->len = Size;
     pBuf->buf = (uint8_t *)UTL_DBG_REALLOC(pBuf->buf, Size);
+    return pBuf->buf != NULL;
 }
 
 
-void utl_buf_alloccopy(utl_buf_t *pBuf, const uint8_t *pData, uint32_t Len)
+bool utl_buf_alloccopy(utl_buf_t *pBuf, const uint8_t *pData, uint32_t Len)
 {
     if (Len > 0) {
-        utl_buf_alloc(pBuf, Len);
+        if (!utl_buf_alloc(pBuf, Len)) return false;
         memcpy(pBuf->buf, pData, Len);
     } else {
         utl_buf_init(pBuf);
     }
+    return true;
 }
 
 

--- a/utl/utl_buf.h
+++ b/utl/utl_buf.h
@@ -78,19 +78,21 @@ void utl_buf_free(utl_buf_t *pBuf);
  *
  * @param[out]      pBuf        処理対象
  * @param[in]       Size        確保するメモリサイズ
+ * @return          true        success
  *
  * @note
  *      - #utl_buf_init()の代わりに使用できるが、元の領域は解放しない
  */
-void utl_buf_alloc(utl_buf_t *pBuf, uint32_t Size);
+bool utl_buf_alloc(utl_buf_t *pBuf, uint32_t Size);
 
 
 /** #utl_buf_t へのメモリ再確保
  *
  * @param[out]      pBuf        処理対象
  * @param[in]       Size        確保するメモリサイズ
+ * @return          true        success
  */
-void utl_buf_realloc(utl_buf_t *pBuf, uint32_t Size);
+bool utl_buf_realloc(utl_buf_t *pBuf, uint32_t Size);
 
 
 /** #utl_buf_t へのメモリ確保及びデータコピー
@@ -98,18 +100,19 @@ void utl_buf_realloc(utl_buf_t *pBuf, uint32_t Size);
  * @param[out]      pBuf        処理対象
  * @param[in]       pData       対象データ
  * @param[in]       Len         pData長
+ * @return          true        success
  *
  * @note
  *      - #utl_buf_init()の代わりに使用できるが、元の領域は解放しない
  */
-void utl_buf_alloccopy(utl_buf_t *pBuf, const uint8_t *pData, uint32_t Len);
+bool utl_buf_alloccopy(utl_buf_t *pBuf, const uint8_t *pData, uint32_t Len);
 
 
 /** #utl_buf_t の比較
  *
  * @param[in]       pBuf1       比較対象1
  * @param[in]       pBuf2       比較対象2
- * @retval      true        一致
+ * @retval          true        一致
  */
 bool utl_buf_cmp(const utl_buf_t *pBuf1, const utl_buf_t *pBuf2);
 

--- a/utl/utl_log.c
+++ b/utl/utl_log.c
@@ -14,6 +14,7 @@
 #include "utl_misc.h"
 #define LOG_TAG "dummy"
 #include "utl_log.h"
+#include "utl_time.h"
 
 #define FNAME_MAX       (50)
 
@@ -106,13 +107,11 @@ void utl_log_write(int Pri, const char* pFname, int Line, int Flag, const char *
 
     //write log
     va_list ap;
-    time_t now = time(NULL);
-    char tmstr[UTL_SZ_DTSTR + 1];
-    utl_misc_strftime(tmstr, (uint32_t)now);
 
     va_start(ap, pFmt);
     if (Flag) {
-        fprintf(mFp, "%s(%5d)[%c/%s][%s:%d:%s]", tmstr, (int)tid(), M_MARK[Pri - 1], pTag, pFname, Line, pFunc);
+        char time[UTL_SZ_TIME_FMT_STR + 1];
+        fprintf(mFp, "%s(%5d)[%c/%s][%s:%d:%s]", utl_time_str_time(time), (int)tid(), M_MARK[Pri - 1], pTag, pFname, Line, pFunc);
     }
     vfprintf(mFp, pFmt, ap);
     va_end(ap);

--- a/utl/utl_misc.c
+++ b/utl/utl_misc.c
@@ -104,7 +104,7 @@ void utl_misc_datetime(char *pDateTime, size_t Len)
 }
 
 
-bool utl_misc_all_zero(const void *pData, size_t Len)
+bool utl_misc_is_all_zero(const void *pData, size_t Len)
 {
     bool ret = true;
     const uint8_t *p = (const uint8_t *)pData;

--- a/utl/utl_misc.c
+++ b/utl/utl_misc.c
@@ -23,7 +23,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdarg.h>
-#include <time.h>
 #include <sys/socket.h>
 #include <arpa/inet.h>
 #include <ctype.h>
@@ -83,15 +82,6 @@ bool utl_misc_str2bin_rev(uint8_t *pBin, uint32_t BinLen, const char *pStr)
 }
 
 
-void utl_misc_datetime(char *pDateTime, size_t Len)
-{
-    struct tm tmval;
-    time_t now = time(NULL);
-    gmtime_r(&now, &tmval);
-    strftime(pDateTime, Len, "%d %b %Y %T %z", &tmval);
-}
-
-
 bool utl_misc_is_all_zero(const void *pData, size_t Len)
 {
     bool ret = true;
@@ -103,13 +93,6 @@ bool utl_misc_is_all_zero(const void *pData, size_t Len)
         }
     }
     return ret;
-}
-
-
-void utl_misc_strftime(char *pTmStr, uint32_t Tm)
-{
-    time_t tm = (time_t)Tm;
-    strftime(pTmStr, UTL_SZ_DTSTR + 1, "%Y/%m/%d %H:%M:%S", localtime(&tm));
 }
 
 

--- a/utl/utl_misc.c
+++ b/utl/utl_misc.c
@@ -26,6 +26,7 @@
 #include <time.h>
 #include <sys/socket.h>
 #include <arpa/inet.h>
+#include <ctype.h>
 
 #include "utl_local.h"
 #include "utl_misc.h"
@@ -55,25 +56,12 @@ bool utl_misc_str2bin(uint8_t *pBin, uint32_t BinLen, const char *pStr)
     for (lp = 0; lp < BinLen; lp++) {
         str[0] = *(pStr + 2 * lp);
         str[1] = *(pStr + 2 * lp + 1);
-        if (!str[0]) {
-            //偶数文字で\0ならばOK
-            break;
-        }
-        if (!str[1]) {
-            //奇数文字で\0ならばNG
-            LOGD("fail: odd length\n");
+        if (!isxdigit(str[0]) || !isxdigit(str[1])) {
+            LOGD("fail: str=%s\n", str);
             ret = false;
             break;
         }
-        char *endp = NULL;
-        uint8_t bin = (uint8_t)strtoul(str, &endp, 16);
-        if ((endp != NULL) && (*endp != 0x00)) {
-            //変換失敗
-            LOGD("fail: *endp = %p(%02x)\n", endp, *endp);
-            ret = false;
-            break;
-        }
-        pBin[lp] = bin;
+        pBin[lp] = (uint8_t)strtoul(str, NULL, 16);
     }
 
     return ret;

--- a/utl/utl_misc.h
+++ b/utl/utl_misc.h
@@ -41,8 +41,6 @@ extern "C" {
  * macros
  **************************************************************************/
 
-#define UTL_SZ_DTSTR          (19)            ///< サイズ:utl_misc_strftime()  // 2018/06/12 09:36:36
-
 
 /**************************************************************************
  * prototypes
@@ -77,14 +75,6 @@ bool utl_misc_str2bin(uint8_t *pBin, uint32_t BinLen, const char *pStr);
 bool utl_misc_str2bin_rev(uint8_t *pBin, uint32_t BinLen, const char *pStr);
 
 
-/** 現在日時取得
- *
- * @param[out]      pDateTime       現在日時
- * @param[in]       Len             pDataTimeバッファサイズ
- */
-void utl_misc_datetime(char *pDateTime, size_t Len);
-
-
 /** 全データが0x00かのチェック
  *
  * @param[in]       pData               チェック対象
@@ -110,12 +100,6 @@ void utl_misc_bin2str(char *pStr, const uint8_t *pBin, uint32_t BinLen);
  * @param[in]       BinLen      pBin長
  */
 void utl_misc_bin2str_rev(char *pStr, const uint8_t *pBin, uint32_t BinLen);
-
-
-/** 日時文字列
- *
- */
-void utl_misc_strftime(char *pTmStr, uint32_t Tm);
 
 
 /** convert uint8_t[] --> uint16_t

--- a/utl/utl_misc.h
+++ b/utl/utl_misc.h
@@ -91,7 +91,7 @@ void utl_misc_datetime(char *pDateTime, size_t Len);
  * @param[in]       Len                 pData長
  * @retval  true    全データが0x00
  */
-bool utl_misc_all_zero(const void *pData, size_t Len);
+bool utl_misc_is_all_zero(const void *pData, size_t Len);
 
 
 /** 16進数文字列に変換

--- a/utl/utl_opts.c
+++ b/utl/utl_opts.c
@@ -90,6 +90,7 @@ bool utl_opts_parse(utl_opt_t *opts, int argc, const char* const argv[])
         if (info->is_set) goto LABEL_EXIT;
         if (info->arg && p) {
             info->param = UTL_DBG_STRDUP(p + 1);
+            if (!info->param) goto LABEL_EXIT;
         } else if (!info->arg && !p) {
         } else {
             goto LABEL_EXIT;
@@ -101,6 +102,7 @@ bool utl_opts_parse(utl_opt_t *opts, int argc, const char* const argv[])
         utl_opt_t *info = &opts[i];
         if (!info->is_set && info->param_default) {
             info->param = UTL_DBG_STRDUP(info->param_default);
+            if (!info->param) goto LABEL_EXIT;
             info->is_set = true;
         }
     }

--- a/utl/utl_push.h
+++ b/utl/utl_push.h
@@ -60,13 +60,14 @@ typedef struct {
  * @param[out]  pPush       処理対象
  * @param[in]   pBuf        更新していくutl_buf_t
  * @param[in]   Size        初期サイズ
+ * @return      true        success
  *
  * @note
  *      - データ追加時に初期サイズより領域が必要になれば拡張しているが、
  *          realloc()を繰り返すことになるので、必要なサイズ以上を確保した方が望ましい。
  *      - pDataは解放せず初期化して使用するため、必要なら先に解放すること。
  */
-void utl_push_init(utl_push_t *pPush, utl_buf_t *pBuf, uint32_t Size);
+bool utl_push_init(utl_push_t *pPush, utl_buf_t *pBuf, uint32_t Size);
 
 
 /** データ追加
@@ -74,12 +75,13 @@ void utl_push_init(utl_push_t *pPush, utl_buf_t *pBuf, uint32_t Size);
  * @param[out]  pPush       処理対象
  * @param[in]   pData       追加データ
  * @param[in]   Len         pData長
+ * @return      true        success
  *
  * @note
  *      - 初期化時のサイズからあふれる場合、realloc()して拡張する。
  *      - そのまま追加するため、OP_PUSHDATAxなどは呼び出し元で行うこと。
  */
-void utl_push_data(utl_push_t *pPush, const void *pData, uint32_t Len);
+bool utl_push_data(utl_push_t *pPush, const void *pData, uint32_t Len);
 
 
 /** Push unsigned integer to the stack
@@ -100,8 +102,9 @@ bool utl_push_value(utl_push_t *pPush, uint64_t Value);
  * utl_buf_tのサイズをutl_push_tで管理しているサイズにあわせる。
  *
  * @param[out]  pPush       処理対象
+ * @return      true        success
  */
-void utl_push_trim(utl_push_t *pPush);
+bool utl_push_trim(utl_push_t *pPush);
 
 
 #ifdef __cplusplus

--- a/utl/utl_time.c
+++ b/utl/utl_time.c
@@ -1,0 +1,64 @@
+/*
+ *  Copyright (C) 2017, Nayuta, Inc. All Rights Reserved
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+#include <time.h>
+#include <stdio.h>
+
+#include "utl_time.h"
+
+
+/**************************************************************************
+ * private variables
+ **************************************************************************/
+
+
+/**************************************************************************
+ * public functions
+ **************************************************************************/
+
+time_t utl_time_time(void)
+{
+    return time(NULL);
+}
+
+
+const char *utl_time_str_time(char pStr[UTL_SZ_TIME_FMT_STR + 1])
+{
+    utl_time_fmt(pStr, time(NULL));
+    return pStr;
+}
+
+
+const char *utl_time_fmt(char pStr[UTL_SZ_TIME_FMT_STR + 1], time_t Time)
+{
+    struct tm tmval;
+    gmtime_r(&Time, &tmval);
+    sprintf(pStr, "%04d-%02d-%02dT%02d:%02d:%02dZ",
+        tmval.tm_year + 1900,
+        tmval.tm_mon + 1,
+        tmval.tm_mday,
+        tmval.tm_hour,
+        tmval.tm_min,
+        tmval.tm_sec);
+    return pStr;
+}
+
+

--- a/utl/utl_time.h
+++ b/utl/utl_time.h
@@ -1,0 +1,78 @@
+/*
+ *  Copyright (C) 2017, Nayuta, Inc. All Rights Reserved
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+/**
+ * @file    utl_time.h
+ * @brief   utl_time
+ */
+#ifndef UTL_TIME_H__
+#define UTL_TIME_H__
+
+#include <stdint.h>
+#include <inttypes.h>
+#include <stdbool.h>
+#include <time.h>
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif  //__cplusplus
+
+/**************************************************************************
+ * macros
+ **************************************************************************/
+
+#define UTL_SZ_TIME_FMT_STR         (20)            ///< e.g. "2014-10-10T04:50:40Z"
+
+
+/**************************************************************************
+ * prototypes
+ **************************************************************************/
+
+/** get current time
+ *
+ * @return          current time (unix time)
+ */
+time_t utl_time_time(void);
+
+
+/** get current time
+ *
+ * @param[out]      pStr        current time (string formated)
+ * @return          pStr addr
+ */
+const char *utl_time_str_time(char pStr[UTL_SZ_TIME_FMT_STR + 1]);
+
+
+/** format unix time
+ *
+ * @param[out]      pStr        string formated time
+ * @param[in]       Time        unix time
+ * @return          pStr addr
+ */
+const char *utl_time_fmt(char pStr[UTL_SZ_TIME_FMT_STR + 1], time_t Time);
+
+
+#ifdef __cplusplus
+}
+#endif  //__cplusplus
+
+#endif /* UTL_TIME_H__ */


### PR DESCRIPTION
- `utl_misc_all_zero`だと0埋めのようなので`utl_misc_is_all_zero`にリネイムした
- `utl_misc_str2bin`の処理が冗長だったのでリファクタリング。テストも追加
- `utl_time`。UTCベースの関数を作成
- メモリ確保失敗のハンドリング。とりあえず`utl`だけ