### PR TITLE
keep error

### DIFF
--- a/ln/ln.c
+++ b/ln/ln.c
@@ -6232,7 +6232,7 @@ static bool set_add_htlc(ln_self_t *self,
             clear_htlc(&self->cnl_add_htlc[idx]);
         }
     } else {
-        M_SET_ERR(self, LNERR_MSG_ERROR, "create update_add_htlc");
+        LOGD("fail: create update_add_htlc\n");
     }
 
     return ret;

--- a/ptarmd/lnapp.c
+++ b/ptarmd/lnapp.c
@@ -1353,7 +1353,8 @@ static bool exchange_init(lnapp_conf_t *p_conf)
         utl_misc_msleep(M_WAIT_RECV_MSG_MSEC);
         count--;
     }
-    return p_conf->loop && (count > 0);
+    LOGD("loop:%d, count:%d, flag_recv=%02x\n", p_conf->loop, count, p_conf->flag_recv);
+    return p_conf->loop && ((p_conf->flag_recv & RECV_MSG_INIT) != 0);
 }
 
 
@@ -1380,7 +1381,8 @@ static bool exchange_reestablish(lnapp_conf_t *p_conf)
         utl_misc_msleep(M_WAIT_RECV_MSG_MSEC);
         count--;
     }
-    return p_conf->loop && (count > 0);
+    LOGD("loop:%d, count:%d, flag_recv=%02x\n", p_conf->loop, count, p_conf->flag_recv);
+    return p_conf->loop && ((p_conf->flag_recv & RECV_MSG_REESTABLISH) != 0);
 }
 
 

--- a/ptarmd/lnapp.h
+++ b/ptarmd/lnapp.h
@@ -90,7 +90,8 @@ typedef struct lnapp_conf_t {
     uint8_t         ping_counter;           ///< 無送受信時にping送信するカウンタ(カウントアップ)
     bool            funding_waiting;        ///< true:funding_txの安定待ち
     uint32_t        funding_confirm;        ///< funding_txのconfirmation数
-    uint8_t         flag_recv;              ///< 受信フラグ(RECV_MSG_xxx)
+
+    volatile uint8_t    flag_recv;          ///< 受信フラグ(RECV_MSG_xxx)
 
     //BOLT送信キュー
     utl_buf_t       buf_sendque;            ///< send data array before noise encode


### PR DESCRIPTION
keep payment error for `ptarmcli getinfo`

* `ptarmcli getinfo`で最後に発生したpaymentエラーを出力させているが、BOLT4チェックで失敗した後に共通エラーメッセージで上書きしていたため、エラー原因がわからなくなっていた。
* routingエラーの状況が分からなかったため、invoiceログに作成したルートは追記するようにした。

Squashed commit of the following:

commit 43b5bac6380d401c08cba9c9e865f16277f56d88
Merge: 942ebba e9ef47f
Author: ueno <ueno@nayuta.co>
Date:   Mon Dec 24 11:19:28 2018 +0900

    Merge branch 'development' into spv/unilateral5

commit 942ebba2f4b572730485737648004c3431685459
Author: ueno <ueno@nayuta.co>
Date:   Mon Dec 24 11:07:23 2018 +0900

    change exchange judge

commit eff653440387e0a8e74b43b42b9f837226c19305
Author: ueno <ueno@nayuta.co>
Date:   Mon Dec 24 01:20:36 2018 +0900

    log: channel_reestablish

    issue #101

commit 6040b04e5c1bdb5fcd22968b251a62546a8db0fa
Author: ueno <ueno@nayuta.co>
Date:   Sun Dec 23 12:04:59 2018 +0900

    keep BOLT4 error

commit 25f4c5453d985c7b1b74d84cb2811ae7770323a5
Author: ueno <ueno@nayuta.co>
Date:   Sun Dec 23 12:03:37 2018 +0900

    save invoice log at routing