### PR TITLE
fix close1

### DIFF
--- a/ln/ln.c
+++ b/ln/ln.c
@@ -768,12 +768,6 @@ bool ln_noise_dec_msg(ln_self_t *self, utl_buf_t *pBuf)
 }
 
 
-/*
- * BOLTのメッセージはデータ長が載っていない。
- * socket通信はwrite()した回数とrecv()の数は一致せず、ストリームになっているため、
- * 今回のように「受信したパケットを全部解析する」というやり方は合わない。
- * そう思っていたが、Noise Protocolによって全パケット受信してから解析するため、問題ない。
- */
 bool ln_recv(ln_self_t *self, const uint8_t *pData, uint16_t Len)
 {
     bool ret = false;
@@ -845,12 +839,6 @@ void ln_recv_idle_proc(ln_self_t *self)
 }
 
 
-/*
- * init作成
- *
- * localfeaturesは、自分がサポートするfeature(odd bits)と、要求するfeature(even bits)を送信する。
- *
- */
 bool ln_init_create(ln_self_t *self, utl_buf_t *pInit, bool bInitRouteSync, bool bHaveCnl)
 {
     (void)bHaveCnl;
@@ -880,7 +868,6 @@ bool ln_init_create(ln_self_t *self, utl_buf_t *pInit, bool bInitRouteSync, bool
 }
 
 
-//channel_reestablish作成
 bool ln_channel_reestablish_create(ln_self_t *self, utl_buf_t *pReEst)
 {
     ln_channel_reestablish_t msg;
@@ -1153,7 +1140,6 @@ uint64_t ln_estimate_fundingtx_fee(uint32_t Feerate)
 #endif
 
 
-//open_channel生成
 bool ln_open_channel_create(ln_self_t *self, utl_buf_t *pOpen,
             const ln_fundin_t *pFundin, uint64_t FundingSat, uint64_t PushSat, uint32_t FeeRate)
 {
@@ -1229,7 +1215,6 @@ void ln_open_channel_clr_announce(ln_self_t *self)
 }
 
 
-//announcement_signaturesを交換すると channel_announcementが完成する。
 bool ln_announce_signs_create(ln_self_t *self, utl_buf_t *pBufAnnoSigns)
 {
     bool ret;

--- a/ln/ln_local.h
+++ b/ln/ln_local.h
@@ -112,9 +112,6 @@
 #define MSGTYPE_CHANNEL_UPDATE              ((uint16_t)0x0102)
 #define MSGTYPE_ANNOUNCEMENT_SIGNATURES     ((uint16_t)0x0103)
 
-#define MSGTYPE_IS_PINGPONG(type)           (((type) == MSGTYPE_PING) || (type) == MSGTYPE_PONG)
-#define MSGTYPE_IS_ANNOUNCE(type)           ((MSGTYPE_CHANNEL_ANNOUNCEMENT <= (type)) && ((type) <= MSGTYPE_CHANNEL_UPDATE))
-
 #define CHANNEL_FLAGS_ANNOCNL       (1 << 0)
 #define CHANNEL_FLAGS_MASK          CHANNEL_FLAGS_ANNOCNL   ///< open_channel.channel_flagsのBOLT定義あり
 #define CHANNEL_FLAGS_VALUE         CHANNEL_FLAGS_ANNOCNL   ///< TODO:open_channel.channel_flags

--- a/ptarmd/cmd_json.c
+++ b/ptarmd/cmd_json.c
@@ -202,6 +202,7 @@ void cmd_json_start(uint16_t Port)
     jrpc_register_procedure(&mJrpc, cmd_getbalance,  "getbalance", NULL);
     jrpc_register_procedure(&mJrpc, cmd_emptywallet, "emptywallet", NULL);
 #endif
+    LOGD("[start]jrpc_server\n");
     jrpc_server_run(&mJrpc);
     jrpc_server_destroy(&mJrpc);
 


### PR DESCRIPTION
fix close: part1

`shutdown`交換後は`closing_signed`以外は受け付けないと考えていたときの名残を削除。
正確には、以下の条件が成立する場合をエラーと考えていた。
* `shutdown`交換後
* 受信typeが以下のいずれでもない
  * `closing_signed`
  * announcement系
  * `ping` or `pong`
  * `error`