### PR TITLE
btc: btc_tx: separate signature functions into `btc_sig.[ch]`

### DIFF
--- a/btc/Makefile
+++ b/btc/Makefile
@@ -41,6 +41,7 @@ C_SOURCE_FILES += $(PRJ_PATH)/btc.c
 C_SOURCE_FILES += $(PRJ_PATH)/btc_extkey.c
 C_SOURCE_FILES += $(PRJ_PATH)/btc_util.c
 C_SOURCE_FILES += $(PRJ_PATH)/btc_keys.c
+C_SOURCE_FILES += $(PRJ_PATH)/btc_sig.c
 C_SOURCE_FILES += $(PRJ_PATH)/btc_tx.c
 C_SOURCE_FILES += $(PRJ_PATH)/btc_sw.c
 C_SOURCE_FILES += $(PRJ_PATH)/segwit_addr.c

--- a/btc/btc.h
+++ b/btc/btc.h
@@ -143,6 +143,9 @@ extern "C" {
 #define OP_2                    (0x52)
 #define OP_16                   (0x60)
 
+#define _OP_PUSHDATA_X_MIN      (0x01)
+#define _OP_PUSHDATA_X_MAX      (0x4b)
+
 #define SIGHASH_ALL             (0x01)
 
 #define VARINT_1BYTE_MAX        (0xfc)
@@ -459,7 +462,7 @@ bool btc_keys_create2of2(utl_buf_t *pRedeem, const uint8_t *pPubKey1, const uint
  * @note
  *      - 公開鍵はソートしない
  */
-bool btc_keys_createmulti(utl_buf_t *pRedeem, const uint8_t *pPubKeys[], uint8_t Num, uint8_t M);
+bool btc_keys_create_multisig(utl_buf_t *pRedeem, const uint8_t *pPubKeys[], uint8_t Num, uint8_t M);
 
 
 /** BitcoinアドレスからHash(PKH/SH/WPKH/WSH)を求める
@@ -686,7 +689,7 @@ bool btc_tx_set_vin_p2pkh(btc_tx_t *pTx, int Index, const utl_buf_t *pSig, const
  * @note
  *      - 対象のvinは既に追加されていること(addではなく、置き換える動作)
  */
-bool btc_tx_set_vin_p2sh_multi(btc_tx_t *pTx, int Index, const utl_buf_t *pSigs[], uint8_t Num, const utl_buf_t *pRedeem);
+bool btc_tx_set_vin_p2sh_multisig(btc_tx_t *pTx, int Index, const utl_buf_t *pSigs[], uint8_t Num, const utl_buf_t *pRedeem);
 
 
 /* convert tx from data array to #btc_tx_t
@@ -741,7 +744,7 @@ bool btc_tx_sighash(btc_tx_t *pTx, uint8_t *pTxHash, const utl_buf_t *pScriptPks
  *      - pSigは、成功かどうかにかかわらず#utl_buf_init()される
  *      - 成功時、pSigは #utl_buf_alloccopy() でメモリ確保するので、使用後は #utl_buf_free()で解放すること
  */
-bool btc_tx_sign(utl_buf_t *pSig, const uint8_t *pTxHash, const uint8_t *pPrivKey);
+bool btc_sig_sign(utl_buf_t *pSig, const uint8_t *pTxHash, const uint8_t *pPrivKey);
 
 
 /** 署名計算(r/s)
@@ -751,7 +754,7 @@ bool btc_tx_sign(utl_buf_t *pSig, const uint8_t *pTxHash, const uint8_t *pPrivKe
  * @param[in]       pPrivKey    秘密鍵
  * @return          true        成功
  */
-bool btc_tx_sign_rs(uint8_t *pRS, const uint8_t *pTxHash, const uint8_t *pPrivKey);
+bool btc_sig_sign_rs(uint8_t *pRS, const uint8_t *pTxHash, const uint8_t *pPrivKey);
 
 
 /** 署名チェック
@@ -764,7 +767,21 @@ bool btc_tx_sign_rs(uint8_t *pRS, const uint8_t *pTxHash, const uint8_t *pPrivKe
  * @note
  *      - pSigの末尾にハッシュタイプが入っていること
  */
-bool btc_tx_verify(const utl_buf_t *pSig, const uint8_t *pTxHash, const uint8_t *pPubKey);
+bool btc_sig_verify(const utl_buf_t *pSig, const uint8_t *pTxHash, const uint8_t *pPubKey);
+
+
+/** 署名チェック
+ *
+ * @param[in]       pSig        署名(ハッシュタイプあり)
+ * @param[in]       Len         length of pSig
+ * @param[in]       pTxHash     トランザクションハッシュ
+ * @param[in]       pPubKey     公開鍵
+ * @return          true:チェックOK
+ *
+ * @note
+ *      - pSigの末尾にハッシュタイプが入っていること
+ */
+bool btc_sig_verify_2(const uint8_t *pSig, uint32_t Len, const uint8_t *pTxHash, const uint8_t *pPubKey);
 
 
 /** 署名チェック(r/s)
@@ -774,7 +791,7 @@ bool btc_tx_verify(const utl_buf_t *pSig, const uint8_t *pTxHash, const uint8_t 
  * @param[in]       pPubKey     公開鍵
  * @return          true:チェックOK
  */
-bool btc_tx_verify_rs(const uint8_t *pRS, const uint8_t *pTxHash, const uint8_t *pPubKey);
+bool btc_sig_verify_rs(const uint8_t *pRS, const uint8_t *pTxHash, const uint8_t *pPubKey);
 
 
 /** P2PKH署名書込み
@@ -787,7 +804,7 @@ bool btc_tx_verify_rs(const uint8_t *pRS, const uint8_t *pTxHash, const uint8_t 
  * @return      true    成功
  *
  * @note
- *      - #btc_tx_sign()と#btc_tx_set_vin_p2pkh()をまとめて実施
+ *      - #btc_sig_sign()と#btc_tx_set_vin_p2pkh()をまとめて実施
  *      - pPubKeyは、既にあるなら計算を省略したいので引数にしている
  *          - 使ってみて、計算済みになることが少ないなら、引数から削除する予定
  */

--- a/btc/btc_keys.c
+++ b/btc/btc_keys.c
@@ -331,7 +331,7 @@ bool btc_keys_create2of2(utl_buf_t *pRedeem, const uint8_t *pPubKey1, const uint
 }
 
 
-bool btc_keys_createmulti(utl_buf_t *pRedeem, const uint8_t *pPubKeys[], uint8_t Num, uint8_t M)
+bool btc_keys_create_multisig(utl_buf_t *pRedeem, const uint8_t *pPubKeys[], uint8_t Num, uint8_t M)
 {
     if (Num > 16) return false;
     if (M > 16) return false;

--- a/btc/btc_sig.c
+++ b/btc/btc_sig.c
@@ -1,0 +1,436 @@
+/*
+ *  Copyright (C) 2017, Nayuta, Inc. All Rights Reserved
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+/** @file   btc_sig.c
+ *  @brief  btc_sig
+ */
+#include "mbedtls/asn1write.h"
+#include "mbedtls/ecdsa.h"
+
+#include "utl_dbg.h"
+#include "utl_int.h"
+
+#include "btc_local.h"
+
+
+/**************************************************************************
+ * prototypes
+ **************************************************************************/
+
+static bool is_valid_signature_encoding(const uint8_t *sig, uint16_t size);
+static int sign_rs(mbedtls_mpi *p_r, mbedtls_mpi *p_s, const uint8_t *pTxHash, const uint8_t *pPrivKey);
+static int rs_to_asn1( const mbedtls_mpi *r, const mbedtls_mpi *s, unsigned char *sig, size_t *slen );
+
+
+/**************************************************************************
+ * public functions
+ **************************************************************************/
+
+bool btc_sig_sign(utl_buf_t *pSig, const uint8_t *pTxHash, const uint8_t *pPrivKey)
+{
+    int ret;
+    bool bret;
+    mbedtls_mpi r, s;
+    unsigned char sig[MBEDTLS_ECDSA_MAX_LEN + 1];   //sig + hashtype(1)
+    size_t slen = 0;
+
+    utl_buf_init(pSig);
+
+    ret = sign_rs(&r, &s, pTxHash, pPrivKey);
+    if (ret) {
+        assert(0);
+        goto LABEL_EXIT;
+    }
+
+    ret = rs_to_asn1(&r, &s, sig, &slen);
+    if (ret) {
+        assert(0);
+        goto LABEL_EXIT;
+    }
+
+    //hashtype
+    sig[slen] = SIGHASH_ALL;
+    slen++;
+
+    bret = is_valid_signature_encoding(sig, slen);
+    if (!bret) {
+        assert(0);
+        ret = -1;
+        goto LABEL_EXIT;
+    }
+
+    bret = utl_buf_alloccopy(pSig, sig, slen);
+    if (!bret) {
+        ret = -1;
+        goto LABEL_EXIT;
+    }
+
+LABEL_EXIT:
+    mbedtls_mpi_free(&r);
+    mbedtls_mpi_free(&s);
+
+    if (ret) {
+        LOGD("fail\n");
+    }
+    return ret == 0;
+}
+
+
+bool btc_sig_sign_rs(uint8_t *pRS, const uint8_t *pTxHash, const uint8_t *pPrivKey)
+{
+    int ret;
+    mbedtls_mpi r, s;
+
+    ret = sign_rs(&r, &s, pTxHash, pPrivKey);
+    if (ret) {
+        assert(0);
+        goto LABEL_EXIT;
+    }
+
+    ret = mbedtls_mpi_write_binary(&r, pRS, 32);
+    if (ret) {
+        assert(0);
+        goto LABEL_EXIT;
+    }
+    ret = mbedtls_mpi_write_binary(&s, pRS + 32, 32);
+    if (ret) {
+        assert(0);
+        goto LABEL_EXIT;
+    }
+
+LABEL_EXIT:
+    mbedtls_mpi_free(&r);
+    mbedtls_mpi_free(&s);
+
+    if (ret) {
+        LOGD("fail\n");
+    }
+    return ret == 0;
+}
+
+
+bool btc_sig_verify(const utl_buf_t *pSig, const uint8_t *pTxHash, const uint8_t *pPubKey)
+{
+    return btc_sig_verify_2(pSig->buf, pSig->len, pTxHash, pPubKey);
+}
+
+bool btc_sig_verify_2(const uint8_t *pSig, uint32_t Len, const uint8_t *pTxHash, const uint8_t *pPubKey)
+{
+    int ret;
+    bool bret;
+    mbedtls_ecp_keypair keypair;
+    mbedtls_ecp_keypair_init(&keypair);
+    mbedtls_ecp_group_load(&(keypair.grp), MBEDTLS_ECP_DP_SECP256K1);
+
+    if (pSig[Len - 1] != SIGHASH_ALL) {
+        LOGD("fail: not SIGHASH_ALL\n");
+        ret = -1;
+        goto LABEL_EXIT;
+    }
+
+    bret = is_valid_signature_encoding(pSig, Len);
+    if (!bret) {
+        LOGD("fail: invalid sig\n");
+        ret = -1;
+        goto LABEL_EXIT;
+    }
+
+    ret = btcl_util_set_keypair(&keypair, pPubKey);
+    if (ret) {
+        LOGD("fail keypair\n");
+        goto LABEL_EXIT;
+    }
+
+    ret = mbedtls_ecdsa_read_signature((mbedtls_ecdsa_context *)&keypair,
+                pTxHash, BTC_SZ_HASH256, pSig, Len - 1);
+    if (ret) {
+        LOGD("fail vefiry sig\n");
+        goto LABEL_EXIT;
+    }
+
+
+LABEL_EXIT:
+    mbedtls_ecp_keypair_free(&keypair);
+
+    if (ret == 0) {
+        LOGD("ok: verify\n");
+    } else {
+        LOGD("fail ret=%d\n", ret);
+        LOGD("pSig: ");
+        DUMPD(pSig, Len);
+        LOGD("txhash: ");
+        DUMPD(pTxHash, BTC_SZ_HASH256);
+        LOGD("pub: ");
+        DUMPD(pPubKey, BTC_SZ_PUBKEY);
+    }
+    return ret == 0;
+}
+
+
+bool btc_sig_verify_rs(const uint8_t *pRS, const uint8_t *pTxHash, const uint8_t *pPubKey)
+{
+    int ret;
+    mbedtls_mpi r, s;
+    mbedtls_ecp_keypair keypair;
+    mbedtls_ecp_keypair_init(&keypair);
+    mbedtls_ecp_group_load(&(keypair.grp), MBEDTLS_ECP_DP_SECP256K1);
+
+    mbedtls_mpi_init(&r);
+    mbedtls_mpi_init(&s);
+
+    ret = mbedtls_mpi_read_binary(&r, pRS, 32);
+    if (ret) {
+        assert(0);
+        goto LABEL_EXIT;
+    }
+    ret = mbedtls_mpi_read_binary(&s, pRS + 32, 32);
+    if (ret) {
+        assert(0);
+        goto LABEL_EXIT;
+    }
+
+    ret = btcl_util_set_keypair(&keypair, pPubKey);
+    if (ret) {
+        LOGD("fail keypair\n");
+        goto LABEL_EXIT;
+    }
+
+    ret = mbedtls_ecdsa_verify(&keypair.grp, pTxHash, BTC_SZ_HASH256, &keypair.Q, &r, &s);
+    if (ret) {
+        LOGD("fail verify\n");
+        goto LABEL_EXIT;
+    }
+
+LABEL_EXIT:
+    mbedtls_ecp_keypair_free(&keypair);
+    mbedtls_mpi_free( &r );
+    mbedtls_mpi_free( &s );
+
+    if (ret == 0) {
+        //LOGD("ok: verify\n");
+    } else {
+        LOGD("fail ret=%d\n", ret);
+        LOGD("txhash: ");
+        DUMPD(pTxHash, BTC_SZ_HASH256);
+        LOGD("pub: ");
+        DUMPD(pPubKey, BTC_SZ_PUBKEY);
+    }
+    return ret == 0;
+}
+
+
+/**************************************************************************
+ * private functions
+ **************************************************************************/
+
+/** BIP66署名データチェック
+ *
+ * @param[in]       sig         署名データ(HashType付き)
+ * @param[in]       size        sigサイズ
+ * @return      true:BIP66チェックOK
+ *
+ * @note
+ *      - https://github.com/bitcoin/bips/blob/master/bip-0066.mediawiki
+ */
+static bool is_valid_signature_encoding(const uint8_t *sig, uint16_t size)
+{
+    // Format: 0x30 [total-length] 0x02 [R-length] [R] 0x02 [S-length] [S] [sighash]
+    // * total-length: 1-byte length descriptor of everything that follows,
+    //   excluding the sighash byte.
+    // * R-length: 1-byte length descriptor of the R value that follows.
+    // * R: arbitrary-length big-endian encoded R value. It must use the shortest
+    //   possible encoding for a positive integers (which means no null bytes at
+    //   the start, except a single one when the next byte has its highest bit set).
+    // * S-length: 1-byte length descriptor of the S value that follows.
+    // * S: arbitrary-length big-endian encoded S value. The same rules apply.
+    // * sighash: 1-byte value indicating what data is hashed (not part of the DER
+    //   signature)
+
+    // Minimum and maximum size constraints.
+    if (size < 9) {
+        LOGD("fail: invalid sig\n");
+        return false;
+    }
+    if (size > 73) {
+        LOGD("fail: invalid sig\n");
+        return false;
+    }
+
+    // A signature is of type 0x30 (compound).
+    if (sig[0] != 0x30) {
+        LOGD("fail: invalid sig\n");
+        return false;
+    }
+
+    // Make sure the length covers the entire signature.
+    if (sig[1] != size - 3) {
+        LOGD("fail: invalid sig\n");
+        return false;
+    }
+
+    // Extract the length of the R element.
+    unsigned int lenR = sig[3];
+
+    // Make sure the length of the S element is still inside the signature.
+    if (5 + lenR >= size) {
+        LOGD("fail: invalid sig\n");
+        return false;
+    }
+
+    // Extract the length of the S element.
+    unsigned int lenS = sig[5 + lenR];
+
+    // Verify that the length of the signature matches the sum of the length
+    // of the elements.
+    if ((size_t)(lenR + lenS + 7) != size) {
+        LOGD("fail: invalid sig\n");
+        return false;
+    }
+
+    // Check whether the R element is an integer.
+    if (sig[2] != 0x02) {
+        LOGD("fail: invalid sig\n");
+        return false;
+    }
+
+    // Zero-length integers are not allowed for R.
+    if (lenR == 0) {
+        LOGD("fail: invalid sig\n");
+        return false;
+    }
+
+    // Negative numbers are not allowed for R.
+    if (sig[4] & 0x80) {
+        LOGD("fail: invalid sig\n");
+        return false;
+    }
+
+    // Null bytes at the start of R are not allowed, unless R would
+    // otherwise be interpreted as a negative number.
+    if (lenR > 1 && (sig[4] == 0x00) && !(sig[5] & 0x80)) {
+        LOGD("fail: invalid sig\n");
+        return false;
+    }
+
+    // Check whether the S element is an integer.
+    if (sig[lenR + 4] != 0x02) {
+        LOGD("fail: invalid sig\n");
+        return false;
+    }
+
+    // Zero-length integers are not allowed for S.
+    if (lenS == 0) {
+        LOGD("fail: invalid sig\n");
+        return false;
+    }
+
+    // Negative numbers are not allowed for S.
+    if (sig[lenR + 6] & 0x80) {
+        LOGD("fail: invalid sig\n");
+        return false;
+    }
+
+    // Null bytes at the start of S are not allowed, unless S would otherwise be
+    // interpreted as a negative number.
+    if (lenS > 1 && (sig[lenR + 6] == 0x00) && !(sig[lenR + 7] & 0x80)) {
+        LOGD("fail: invalid sig\n");
+        return false;
+    }
+
+    return true;
+}
+
+
+/** Sign to the hash
+ *
+ */
+static int sign_rs(mbedtls_mpi *p_r, mbedtls_mpi *p_s, const uint8_t *pTxHash, const uint8_t *pPrivKey)
+{
+    int ret;
+    mbedtls_ecp_keypair keypair;
+
+    mbedtls_mpi_init(p_r);
+    mbedtls_mpi_init(p_s);
+    mbedtls_ecp_keypair_init(&keypair);
+    mbedtls_ecp_group_load(&(keypair.grp), MBEDTLS_ECP_DP_SECP256K1);
+    ret = mbedtls_mpi_read_binary(&keypair.d, pPrivKey, BTC_SZ_PRIVKEY);
+    if (ret) {
+        LOGD("FAIL: ecdsa_sign: %d\n", ret);
+        assert(0);
+        goto LABEL_EXIT;
+    }
+
+    ret = mbedtls_ecdsa_sign_det(&keypair.grp, p_r, p_s, &keypair.d,
+                    pTxHash, BTC_SZ_HASH256, MBEDTLS_MD_SHA256);
+    if (ret) {
+        LOGD("FAIL: ecdsa_sign: %d\n", ret);
+        assert(0);
+        goto LABEL_EXIT;
+    }
+
+    //"canonical" ECDSA signature by BIP-62
+    // we use `s < (N/2)`
+    mbedtls_mpi half_n;
+    mbedtls_mpi_init(&half_n);
+    mbedtls_mpi_copy(&half_n, &keypair.grp.N);
+    mbedtls_mpi_shift_r(&half_n, 1);
+    if (mbedtls_mpi_cmp_mpi(p_s, &half_n) == 1) {
+        ret = mbedtls_mpi_sub_mpi(p_s, &keypair.grp.N, p_s);
+        if (ret) {
+            LOGD("FAIL: ecdsa_sign: %d\n", ret);
+            assert(0);
+            goto LABEL_EXIT;
+        }
+    }
+    mbedtls_mpi_free(&half_n);
+
+LABEL_EXIT:
+    mbedtls_ecp_keypair_free(&keypair);
+
+    return ret;
+}
+
+
+/** Convert a signature to ASN.1 DER
+ *
+ */
+static int rs_to_asn1(const mbedtls_mpi *r, const mbedtls_mpi *s, unsigned char *sig, size_t *slen)
+{
+    int ret;    //use in MBEDTLS_ASN1_CHK_ADD
+    unsigned char buf[MBEDTLS_ECDSA_MAX_LEN];
+    unsigned char *p = buf + sizeof(buf);
+    size_t len = 0;
+
+    //see is_valid_signature_encoding()
+    // mbedtls_asn1_write_mpi() works backwards in data buffer
+    MBEDTLS_ASN1_CHK_ADD(len, mbedtls_asn1_write_mpi(&p, buf, s));
+    MBEDTLS_ASN1_CHK_ADD(len, mbedtls_asn1_write_mpi(&p, buf, r));
+    MBEDTLS_ASN1_CHK_ADD(len, mbedtls_asn1_write_len(&p, buf, len));
+    MBEDTLS_ASN1_CHK_ADD(len, mbedtls_asn1_write_tag(&p, buf,
+        MBEDTLS_ASN1_CONSTRUCTED | MBEDTLS_ASN1_SEQUENCE ));
+
+    memcpy(sig, p, len);
+    *slen = len;
+
+    return (0);
+}
+
+

--- a/btc/btc_sw.c
+++ b/btc/btc_sw.c
@@ -346,7 +346,7 @@ bool btc_sw_verify_p2wpkh(const btc_tx_t *pTx, int Index, uint64_t Value, const 
     uint8_t txhash[BTC_SZ_HASH256];
     ret = btc_sw_sighash(txhash, pTx, Index, Value, &script_code);
     if (ret) {
-        ret = btc_tx_verify(p_sig, txhash, p_pub->buf);
+        ret = btc_sig_verify(p_sig, txhash, p_pub->buf);
     }
     if (ret) {
         //pubKeyHashチェック
@@ -477,20 +477,20 @@ bool btc_sw_verify_2of2(const btc_tx_t *pTx, int Index, const uint8_t *pTxHash, 
     //署名チェック
     //      2-of-2なので、順番通りに全一致
 #if 1
-    bool ret = btc_tx_verify(sig1, pTxHash, pub1);
+    bool ret = btc_sig_verify(sig1, pTxHash, pub1);
     if (ret) {
-        ret = btc_tx_verify(sig2, pTxHash, pub2);
+        ret = btc_sig_verify(sig2, pTxHash, pub2);
         if (!ret) {
-            LOGD("fail: btc_tx_verify(sig2)\n");
+            LOGD("fail: btc_sig_verify(sig2)\n");
         }
     } else {
-        LOGD("fail: btc_tx_verify(sig1)\n");
+        LOGD("fail: btc_sig_verify(sig1)\n");
     }
 #else
-    bool ret1 = btc_tx_verify(sig1, pTxHash, pub1);
-    bool ret2 = btc_tx_verify(sig2, pTxHash, pub2);
-    bool ret3 = btc_tx_verify(sig1, pTxHash, pub2);
-    bool ret4 = btc_tx_verify(sig2, pTxHash, pub1);
+    bool ret1 = btc_sig_verify(sig1, pTxHash, pub1);
+    bool ret2 = btc_sig_verify(sig2, pTxHash, pub2);
+    bool ret3 = btc_sig_verify(sig1, pTxHash, pub2);
+    bool ret4 = btc_sig_verify(sig2, pTxHash, pub1);
     bool ret = ret1 && ret2;
     printf("txhash=");
     DUMPD(pTxHash, BTC_SZ_HASH256);

--- a/btc/btc_tx.c
+++ b/btc/btc_tx.c
@@ -53,8 +53,7 @@ typedef struct {
 
 static bool is_valid_signature_encoding(const uint8_t *sig, uint16_t size);
 static int sign_rs(mbedtls_mpi *p_r, mbedtls_mpi *p_s, const uint8_t *pTxHash, const uint8_t *pPrivKey);
-static int ecdsa_signature_to_asn1( const mbedtls_mpi *r, const mbedtls_mpi *s,
-                                    unsigned char *sig, size_t *slen );
+static int rs_to_asn1( const mbedtls_mpi *r, const mbedtls_mpi *s, unsigned char *sig, size_t *slen );
 static void tx_buf_init(tx_buf *pBuf, const uint8_t *pData, uint32_t Len);
 static const uint8_t *tx_buf_get_pos(tx_buf *pBuf);
 static bool tx_buf_read(tx_buf *pBuf, uint8_t *pData, uint32_t Len);
@@ -66,7 +65,6 @@ static uint32_t tx_buf_remains(tx_buf *pBuf);
 static bool tx_buf_read_varint(tx_buf *pBuf, uint64_t *pValue);
 
 static bool recover_pubkey(uint8_t *pPubKey, int *pRecId, const uint8_t *pRS, const uint8_t *pTxHash, const uint8_t *pOrgPubKey);
-
 static int get_varint(uint16_t *pLen, const uint8_t *pData);
 
 
@@ -358,7 +356,7 @@ bool btc_tx_set_vin_p2pkh(btc_tx_t *pTx, int Index, const utl_buf_t *pSig, const
 }
 
 
-bool btc_tx_set_vin_p2sh_multi(btc_tx_t *pTx, int Index, const utl_buf_t *pSigs[], uint8_t Num, const utl_buf_t *pRedeem)
+bool btc_tx_set_vin_p2sh_multisig(btc_tx_t *pTx, int Index, const utl_buf_t *pSigs[], uint8_t Num, const utl_buf_t *pRedeem)
 {
     if (!Num) return false;
     if (!pRedeem->len) return false;
@@ -600,177 +598,6 @@ LABEL_EXIT:
 }
 
 
-bool btc_tx_sign(utl_buf_t *pSig, const uint8_t *pTxHash, const uint8_t *pPrivKey)
-{
-    int ret;
-    bool bret;
-    mbedtls_mpi r, s;
-    unsigned char sig[MBEDTLS_ECDSA_MAX_LEN + 1];   //141 + 1 byte
-    size_t slen = 0;
-
-    utl_buf_init(pSig);
-
-    ret = sign_rs(&r, &s, pTxHash, pPrivKey);
-    if (ret) {
-        assert(0);
-        goto LABEL_EXIT;
-    }
-
-    ret = ecdsa_signature_to_asn1(&r, &s, sig, &slen);
-    if (ret) {
-        assert(0);
-        goto LABEL_EXIT;
-    }
-
-    //HashType
-    sig[slen] = SIGHASH_ALL;
-    slen++;
-    bret = is_valid_signature_encoding(sig, slen);
-    if (!bret) {
-        assert(0);
-        ret = -1;
-        goto LABEL_EXIT;
-    }
-    utl_buf_alloccopy(pSig, sig, slen);
-
-LABEL_EXIT:
-    mbedtls_mpi_free( &r );
-    mbedtls_mpi_free( &s );
-
-    if (ret) {
-        LOGD("fail\n");
-    }
-    return ret == 0;
-}
-
-
-bool btc_tx_sign_rs(uint8_t *pRS, const uint8_t *pTxHash, const uint8_t *pPrivKey)
-{
-    int ret;
-    mbedtls_mpi r, s;
-
-    ret = sign_rs(&r, &s, pTxHash, pPrivKey);
-    if (ret) {
-        assert(0);
-        goto LABEL_EXIT;
-    }
-
-    ret = mbedtls_mpi_write_binary(&r, pRS, 32);
-    if (ret) {
-        assert(0);
-        goto LABEL_EXIT;
-    }
-    ret = mbedtls_mpi_write_binary(&s, pRS + 32, 32);
-    if (ret) {
-        assert(0);
-        goto LABEL_EXIT;
-    }
-
-LABEL_EXIT:
-    mbedtls_mpi_free( &r );
-    mbedtls_mpi_free( &s );
-
-    if (ret) {
-        LOGD("fail\n");
-    }
-    return ret == 0;
-}
-
-
-bool btc_tx_verify(const utl_buf_t *pSig, const uint8_t *pTxHash, const uint8_t *pPubKey)
-{
-    int ret;
-    bool bret;
-    mbedtls_ecp_keypair keypair;
-    mbedtls_ecp_keypair_init(&keypair);
-    mbedtls_ecp_group_load(&(keypair.grp), MBEDTLS_ECP_DP_SECP256K1);
-
-    if (pSig->buf[pSig->len - 1] != SIGHASH_ALL) {
-        //assert(0);
-        LOGD("fail: not SIGHASH_ALL\n");
-        ret = -1;
-        goto LABEL_EXIT;
-    }
-    bret = is_valid_signature_encoding(pSig->buf, pSig->len);
-    if (!bret) {
-        //assert(0);
-        LOGD("fail: invalid signature\n");
-        ret = -1;
-        goto LABEL_EXIT;
-    }
-
-    ret = btcl_util_set_keypair(&keypair, pPubKey);
-    if (!ret) {
-        ret = mbedtls_ecdsa_read_signature((mbedtls_ecdsa_context *)&keypair,
-                    pTxHash, BTC_SZ_HASH256,
-                    pSig->buf, pSig->len - 1);
-    } else {
-        LOGD("fail keypair\n");
-    }
-
-LABEL_EXIT:
-    mbedtls_ecp_keypair_free(&keypair);
-
-    if (ret == 0) {
-        LOGD("ok: verify\n");
-    } else {
-        LOGD("fail ret=%d\n", ret);
-        LOGD("pSig: ");
-        DUMPD(pSig->buf, pSig->len);
-        LOGD("txhash: ");
-        DUMPD(pTxHash, BTC_SZ_HASH256);
-        LOGD("pub: ");
-        DUMPD(pPubKey, BTC_SZ_PUBKEY);
-    }
-    return ret == 0;
-}
-
-
-bool btc_tx_verify_rs(const uint8_t *pRS, const uint8_t *pTxHash, const uint8_t *pPubKey)
-{
-    int ret;
-    mbedtls_mpi r, s;
-    mbedtls_ecp_keypair keypair;
-    mbedtls_ecp_keypair_init(&keypair);
-    mbedtls_ecp_group_load(&(keypair.grp), MBEDTLS_ECP_DP_SECP256K1);
-
-    mbedtls_mpi_init(&r);
-    mbedtls_mpi_init(&s);
-    ret = mbedtls_mpi_read_binary(&r, pRS, 32);
-    if (ret) {
-        assert(0);
-        goto LABEL_EXIT;
-    }
-    ret = mbedtls_mpi_read_binary(&s, pRS + 32, 32);
-    if (ret) {
-        assert(0);
-        goto LABEL_EXIT;
-    }
-    ret = btcl_util_set_keypair(&keypair, pPubKey);
-    if (!ret) {
-        ret = mbedtls_ecdsa_verify(&keypair.grp, pTxHash, BTC_SZ_HASH256, &keypair.Q, &r, &s);
-    } else {
-        LOGD("fail keypair\n");
-    }
-
-LABEL_EXIT:
-    mbedtls_ecp_keypair_free(&keypair);
-    mbedtls_mpi_free( &r );
-    mbedtls_mpi_free( &s );
-
-    if (ret == 0) {
-        //LOGD("ok: verify\n");
-    } else {
-        LOGD("fail ret=%d\n", ret);
-        LOGD("txhash: ");
-        DUMPD(pTxHash, BTC_SZ_HASH256);
-        LOGD("pub: ");
-        DUMPD(pPubKey, BTC_SZ_PUBKEY);
-    }
-    return ret == 0;
-}
-
-
 bool btc_tx_sign_p2pkh(btc_tx_t *pTx, int Index,
                 const uint8_t *pTxHash, const uint8_t *pPrivKey, const uint8_t *pPubKey)
 {
@@ -787,9 +614,14 @@ bool btc_tx_sign_p2pkh(btc_tx_t *pTx, int Index,
         pPubKey = pubkey;
     }
 
-    ret = btc_tx_sign(&sigbuf, pTxHash, pPrivKey);
-    if (ret) {
-        btc_tx_set_vin_p2pkh(pTx, Index, &sigbuf, pPubKey);
+    ret = btc_sig_sign(&sigbuf, pTxHash, pPrivKey);
+    if (!ret) {
+        goto LABEL_EXIT;
+    }
+
+    ret = btc_tx_set_vin_p2pkh(pTx, Index, &sigbuf, pPubKey);
+    if (!ret) {
+        goto LABEL_EXIT;
     }
 
 LABEL_EXIT:
@@ -801,24 +633,36 @@ LABEL_EXIT:
 
 bool btc_tx_verify_p2pkh(const btc_tx_t *pTx, int Index, const uint8_t *pTxHash, const uint8_t *pPubKeyHash)
 {
-    bool ret;
+    //scriptSig(P2PKH): <sig> <pubKey>
+
+    bool ret = false;
 
     const utl_buf_t *p_scriptsig = (const utl_buf_t *)&(pTx->vin[Index].script);
-    const uint8_t *p = p_scriptsig->buf;
-    const utl_buf_t sig = { (CONST_CAST uint8_t *)(p + 1), *p };      //P2PKHの署名は1byte長で収まる
-    p += *p + 1;
-    if (*p != BTC_SZ_PUBKEY) {
-        assert(0);
-        ret = false;
-        goto LABEL_EXIT;
-    }
-    p++;
-    ret = btc_tx_verify(&sig, pTxHash, p);
-    if (ret) {
-        uint8_t pkh[BTC_SZ_HASH_MAX];
-        btc_util_hash160(pkh, p, BTC_SZ_PUBKEY);
-        ret = (memcmp(pkh, pPubKeyHash, BTC_SZ_HASH160) == 0);
-    }
+    uint8_t *buf = p_scriptsig->buf;
+
+    uint32_t sig_len;
+    const uint8_t *sig;
+    uint32_t pubkey_len;
+    uint8_t *pubkey;
+
+    if (p_scriptsig->len < 1) goto LABEL_EXIT;
+    sig_len = *buf;
+    sig = buf + 1;
+    if (sig_len < _OP_PUSHDATA_X_MIN) goto LABEL_EXIT;
+    if (sig_len > _OP_PUSHDATA_X_MAX) goto LABEL_EXIT;
+    if (p_scriptsig->len < 1 + sig_len + 1) goto LABEL_EXIT;
+    pubkey_len = *(buf + 1 + sig_len);
+    pubkey = buf + 1 + sig_len + 1;
+    if (pubkey_len != BTC_SZ_PUBKEY) goto LABEL_EXIT;
+    if (p_scriptsig->len != 1 + sig_len + 1 + pubkey_len) goto LABEL_EXIT;
+
+    uint8_t pkh[BTC_SZ_HASH160];
+    btc_util_hash160(pkh, pubkey, BTC_SZ_PUBKEY);
+    if (memcmp(pkh, pPubKeyHash, BTC_SZ_HASH160)) goto LABEL_EXIT;
+
+    if (!btc_sig_verify_2(sig, sig_len, pTxHash, pubkey)) goto LABEL_EXIT;
+
+    ret = true;
 
 LABEL_EXIT:
     return ret;
@@ -827,10 +671,10 @@ LABEL_EXIT:
 
 bool btc_tx_verify_p2pkh_spk(const btc_tx_t *pTx, int Index, const uint8_t *pTxHash, const utl_buf_t *pScriptPk)
 {
+    //scriptPubKey(P2PKH): DUP HASH160 0x14 <20 bytes> EQUALVERIFY CHECKSIG
+
     bool ret = false;
 
-    //P2PKHのscriptPubKey
-    //  DUP HASH160 0x14 <20 bytes> EQUALVERIFY CHECKSIG
     if (pScriptPk->len != 3 + BTC_SZ_HASH160 + 2) {
         assert(0);
         goto LABEL_EXIT;
@@ -983,7 +827,7 @@ bool btc_tx_verify_p2sh_multisig(const btc_tx_t *pTx, int Index, const uint8_t *
                 const utl_buf_t sig = { p_scriptsig->buf + sigpos + 1, *(p_scriptsig->buf + sigpos) };
                 ret = *(p_scriptsig->buf + pubpos_now) == BTC_SZ_PUBKEY;
                 if (ret) {
-                    ret = btc_tx_verify(&sig, pTxHash, p_scriptsig->buf + pubpos_now + 1);
+                    ret = btc_sig_verify(&sig, pTxHash, p_scriptsig->buf + pubpos_now + 1);
                 }
                 if (ret) {
                     ok_cnt++;
@@ -1337,193 +1181,6 @@ void btc_print_script(const uint8_t *pData, uint16_t Len)
  * private functions
  **************************************************************************/
 
-/** BIP66署名データチェック
- *
- * @param[in]       sig         署名データ(HashType付き)
- * @param[in]       size        sigサイズ
- * @return      true:BIP66チェックOK
- *
- * @note
- *      - https://github.com/bitcoin/bips/blob/master/bip-0066.mediawiki
- */
-static bool is_valid_signature_encoding(const uint8_t *sig, uint16_t size)
-{
-    // Format: 0x30 [total-length] 0x02 [R-length] [R] 0x02 [S-length] [S] [sighash]
-    // * total-length: 1-byte length descriptor of everything that follows,
-    //   excluding the sighash byte.
-    // * R-length: 1-byte length descriptor of the R value that follows.
-    // * R: arbitrary-length big-endian encoded R value. It must use the shortest
-    //   possible encoding for a positive integers (which means no null bytes at
-    //   the start, except a single one when the next byte has its highest bit set).
-    // * S-length: 1-byte length descriptor of the S value that follows.
-    // * S: arbitrary-length big-endian encoded S value. The same rules apply.
-    // * sighash: 1-byte value indicating what data is hashed (not part of the DER
-    //   signature)
-
-    // Minimum and maximum size constraints.
-    if (size < 9) {
-        LOGD("fail: is_valid_signature_encoding(%d)\n" ,__LINE__);
-        return false;
-    }
-    if (size > 73) {
-        LOGD("fail: is_valid_signature_encoding(%d)\n" ,__LINE__);
-        return false;
-    }
-
-    // A signature is of type 0x30 (compound).
-    if (sig[0] != 0x30) {
-        LOGD("fail: is_valid_signature_encoding(%d - %02x)\n" ,__LINE__, sig[0]);
-        return false;
-    }
-
-    // Make sure the length covers the entire signature.
-    if (sig[1] != size - 3) {
-        LOGD("fail: is_valid_signature_encoding(%d)\n" ,__LINE__);
-        return false;
-    }
-
-    // Extract the length of the R element.
-    unsigned int lenR = sig[3];
-
-    // Make sure the length of the S element is still inside the signature.
-    if (5 + lenR >= size) {
-        LOGD("fail: is_valid_signature_encoding(%d)\n" ,__LINE__);
-        return false;
-    }
-
-    // Extract the length of the S element.
-    unsigned int lenS = sig[5 + lenR];
-
-    // Verify that the length of the signature matches the sum of the length
-    // of the elements.
-    if ((size_t)(lenR + lenS + 7) != size) {
-        LOGD("fail: is_valid_signature_encoding(%d)\n" ,__LINE__);
-        return false;
-    }
-
-    // Check whether the R element is an integer.
-    if (sig[2] != 0x02) {
-        LOGD("fail: is_valid_signature_encoding(%d)\n" ,__LINE__);
-        return false;
-    }
-
-    // Zero-length integers are not allowed for R.
-    if (lenR == 0) {
-        LOGD("fail: is_valid_signature_encoding(%d)\n" ,__LINE__);
-        return false;
-    }
-
-    // Negative numbers are not allowed for R.
-    if (sig[4] & 0x80) {
-        LOGD("fail: is_valid_signature_encoding(%d)\n" ,__LINE__);
-        return false;
-    }
-
-    // Null bytes at the start of R are not allowed, unless R would
-    // otherwise be interpreted as a negative number.
-    if (lenR > 1 && (sig[4] == 0x00) && !(sig[5] & 0x80)) {
-        LOGD("fail: is_valid_signature_encoding(%d)\n" ,__LINE__);
-        return false;
-    }
-
-    // Check whether the S element is an integer.
-    if (sig[lenR + 4] != 0x02) {
-        LOGD("fail: is_valid_signature_encoding(%d)\n" ,__LINE__);
-        return false;
-    }
-
-    // Zero-length integers are not allowed for S.
-    if (lenS == 0) {
-        LOGD("fail: is_valid_signature_encoding(%d)\n" ,__LINE__);
-        return false;
-    }
-
-    // Negative numbers are not allowed for S.
-    if (sig[lenR + 6] & 0x80) {
-        LOGD("fail: is_valid_signature_encoding(%d)\n" ,__LINE__);
-        return false;
-    }
-
-    // Null bytes at the start of S are not allowed, unless S would otherwise be
-    // interpreted as a negative number.
-    if (lenS > 1 && (sig[lenR + 6] == 0x00) && !(sig[lenR + 7] & 0x80)) {
-        LOGD("fail: is_valid_signature_encoding(%d)\n" ,__LINE__);
-        return false;
-    }
-
-    return true;
-}
-
-
-/** 署名r/s
- *
- */
-static int sign_rs(mbedtls_mpi *p_r, mbedtls_mpi *p_s, const uint8_t *pTxHash, const uint8_t *pPrivKey)
-{
-    int ret;
-    mbedtls_ecp_keypair keypair;
-
-    mbedtls_mpi_init(p_r);
-    mbedtls_mpi_init(p_s);
-    mbedtls_ecp_keypair_init(&keypair);
-    mbedtls_ecp_group_load(&(keypair.grp), MBEDTLS_ECP_DP_SECP256K1);
-    ret = mbedtls_mpi_read_binary(&keypair.d, pPrivKey, BTC_SZ_PRIVKEY);
-    if (ret) {
-        LOGD("FAIL: ecdsa_sign: %d\n", ret);
-        assert(0);
-        goto LABEL_EXIT;
-    }
-
-    //canonizeするため、ecdsa.cのmbedtls_ecdsa_write_signature()をまねる
-    ret = mbedtls_ecdsa_sign_det(&keypair.grp, p_r, p_s, &keypair.d,
-                    pTxHash, BTC_SZ_HASH256, MBEDTLS_MD_SHA256);
-    if (ret) {
-        LOGD("FAIL: ecdsa_sign: %d\n", ret);
-        assert(0);
-        goto LABEL_EXIT;
-    }
-    mbedtls_mpi half_n;
-    mbedtls_mpi_init(&half_n);
-    mbedtls_mpi_copy(&half_n, &keypair.grp.N);
-    mbedtls_mpi_shift_r(&half_n, 1);
-    if (mbedtls_mpi_cmp_mpi(p_s, &half_n) == 1) {
-        mbedtls_mpi_sub_mpi(p_s, &keypair.grp.N, p_s);
-    }
-    mbedtls_mpi_free(&half_n);
-
-LABEL_EXIT:
-    mbedtls_ecp_keypair_free(&keypair);
-
-    return ret;
-}
-
-
-//署名canonize処理用(mbedtls ecdsa.cからコピー)
-/*
- * Convert a signature (given by context) to ASN.1
- */
-static int ecdsa_signature_to_asn1( const mbedtls_mpi *r, const mbedtls_mpi *s,
-                                    unsigned char *sig, size_t *slen )
-{
-    int ret;        //MBEDTLS_ASN1_CHK_ADDで使用する
-    unsigned char buf[MBEDTLS_ECDSA_MAX_LEN];
-    unsigned char *p = buf + sizeof( buf );
-    size_t len = 0;
-
-    MBEDTLS_ASN1_CHK_ADD( len, mbedtls_asn1_write_mpi( &p, buf, s ) );
-    MBEDTLS_ASN1_CHK_ADD( len, mbedtls_asn1_write_mpi( &p, buf, r ) );
-
-    MBEDTLS_ASN1_CHK_ADD( len, mbedtls_asn1_write_len( &p, buf, len ) );
-    MBEDTLS_ASN1_CHK_ADD( len, mbedtls_asn1_write_tag( &p, buf,
-                                       MBEDTLS_ASN1_CONSTRUCTED | MBEDTLS_ASN1_SEQUENCE ) );
-
-    memcpy( sig, p, len );
-    *slen = len;
-
-    return( 0 );
-}
-
-
 /**
  * @param[out]  pPubKey
  * @param[out]  pRecId
@@ -1652,7 +1309,7 @@ static bool recover_pubkey(uint8_t *pPubKey, int *pRecId, const uint8_t *pRS, co
             assert(ret == 0);
 
             if (ret == 0) {
-                bret = btc_tx_verify_rs(pRS, pTxHash, pPubKey);
+                bret = btc_sig_verify_rs(pRS, pTxHash, pPubKey);
                 if (bret && pOrgPubKey) {
                     bret = (memcmp(pOrgPubKey, pPubKey, BTC_SZ_PUBKEY) == 0);
                 }

--- a/btc/btc_util.c
+++ b/btc/btc_util.c
@@ -200,7 +200,7 @@ bool btc_util_sign_p2wpkh(btc_tx_t *pTx, int Index, uint64_t Value, const btc_ke
 
     ret = btc_sw_sighash(txhash, pTx, Index, Value, &script_code);
     if (ret) {
-        ret = btc_tx_sign(&sigbuf, txhash, pKeys->priv);
+        ret = btc_sig_sign(&sigbuf, txhash, pKeys->priv);
     }
     if (ret) {
         //mNativeSegwitがfalseの場合はscriptSigへの追加も行う
@@ -235,13 +235,13 @@ bool btc_util_calc_sighash_p2wsh(uint8_t *pTxHash, const btc_tx_t *pTx, int Inde
 
 bool btc_util_sign_p2wsh(utl_buf_t *pSig, const uint8_t *pTxHash, const btc_keys_t *pKeys)
 {
-    return btc_tx_sign(pSig, pTxHash, pKeys->priv);
+    return btc_sig_sign(pSig, pTxHash, pKeys->priv);
 }
 
 
 bool btc_util_sign_p2wsh_rs(uint8_t *pRS, const uint8_t *pTxHash, const btc_keys_t *pKeys)
 {
-    return btc_tx_sign_rs(pRS, pTxHash, pKeys->priv);
+    return btc_sig_sign_rs(pRS, pTxHash, pKeys->priv);
 }
 
 

--- a/btc/examples/tx_verify.c
+++ b/btc/examples/tx_verify.c
@@ -35,7 +35,7 @@ int main(void)
     btc_init(BTC_TESTNET, true);
 
     const utl_buf_t sig = { (uint8_t *)SIG, sizeof(SIG) };
-    bool ret = btc_tx_verify(&sig, TXHASH, PUB);
+    bool ret = btc_sig_verify(&sig, TXHASH, PUB);
     printf("ret=%d\n", ret);
 
     btc_term();

--- a/btc/tests/test_main.cpp
+++ b/btc/tests/test_main.cpp
@@ -20,6 +20,7 @@ extern "C" {
 #include "btc_extkey.c"
 #include "btc_keys.c"
 #include "btc_sw.c"
+#include "btc_sig.c"
 #include "btc_tx.c"
 #include "btc_util.c"
 #include "segwit_addr.c"

--- a/btc/tests/testinc_keys.cpp
+++ b/btc/tests/testinc_keys.cpp
@@ -393,7 +393,7 @@ TEST_F(keys, multi_2of3)
     };
 
     utl_buf_t bufredeem;
-    bool ret = btc_keys_createmulti(&bufredeem, PUBS, 3, 2);
+    bool ret = btc_keys_create_multisig(&bufredeem, PUBS, 3, 2);
     //keys::DumpBin(bufredeem.buf, bufredeem.len);
     ASSERT_TRUE(ret);
     ASSERT_EQ(sizeof(REDEEM), bufredeem.len);

--- a/ln/ln_msg_anno.c
+++ b/ln/ln_msg_anno.c
@@ -258,19 +258,19 @@ bool HIDDEN ln_msg_cnl_announce_verify(const uint8_t *pData, uint16_t Len)
     // LOGD("hash=");
     // DUMPD(hash, BTC_SZ_HASH256);
 
-    ret = btc_tx_verify_rs(ptr.p_node_signature1, hash, ptr.p_node_id1);
+    ret = btc_sig_verify_rs(ptr.p_node_signature1, hash, ptr.p_node_id1);
     assert(ret);
 
     if (ret) {
-        ret = btc_tx_verify_rs(ptr.p_node_signature2, hash, ptr.p_node_id2);
+        ret = btc_sig_verify_rs(ptr.p_node_signature2, hash, ptr.p_node_id2);
         assert(ret);
     }
     if (ret) {
-        ret = btc_tx_verify_rs(ptr.p_btc_signature1, hash, ptr.p_btc_key1);
+        ret = btc_sig_verify_rs(ptr.p_btc_signature1, hash, ptr.p_btc_key1);
         assert(ret);
     }
     if (ret) {
-        ret = btc_tx_verify_rs(ptr.p_btc_signature2, hash, ptr.p_btc_key2);
+        ret = btc_sig_verify_rs(ptr.p_btc_signature2, hash, ptr.p_btc_key2);
         assert(ret);
     }
 
@@ -717,7 +717,7 @@ bool ln_msg_node_announce_read(ln_node_announce_t *pMsg, const uint8_t *pData, u
         //LOGD("hash=");
         //DUMPD(hash, BTC_SZ_HASH256);
 
-        ret = btc_tx_verify_rs(p_signature, hash, pMsg->p_node_id);
+        ret = btc_sig_verify_rs(p_signature, hash, pMsg->p_node_id);
         if (!ret) {
             LOGD("fail: verify\n");
         }
@@ -929,7 +929,7 @@ bool HIDDEN ln_msg_cnl_update_verify(const uint8_t *pPubkey, const uint8_t *pDat
     //LOGD("hash=");
     //DUMPD(hash, BTC_SZ_HASH256);
 
-    ret = btc_tx_verify_rs(pData + sizeof(uint16_t), hash, pPubkey);
+    ret = btc_sig_verify_rs(pData + sizeof(uint16_t), hash, pPubkey);
 
     return ret;
 }

--- a/ln/ln_node.c
+++ b/ln/ln_node.c
@@ -277,7 +277,7 @@ void HIDDEN ln_node_generate_shared_secret(uint8_t *pResult, const uint8_t *pPub
 
 bool HIDDEN ln_node_sign_nodekey(uint8_t *pRS, const uint8_t *pHash)
 {
-    return btc_tx_sign_rs(pRS, pHash, mNode.keys.priv);
+    return btc_sig_sign_rs(pRS, pHash, mNode.keys.priv);
 }
 
 

--- a/ln/ln_script.c
+++ b/ln/ln_script.c
@@ -595,14 +595,14 @@ bool HIDDEN ln_script_htlctx_verify(const btc_tx_t *pTx,
     //LOGD("sighash: ");
     //DUMPD(sighash, BTC_SZ_HASH256);
     if (ret && pLocalPubKey && pLocalSig) {
-        ret = btc_tx_verify(pLocalSig, sighash, pLocalPubKey);
-        //LOGD("btc_tx_verify(local)=%d\n", ret);
+        ret = btc_sig_verify(pLocalSig, sighash, pLocalPubKey);
+        //LOGD("btc_sig_verify(local)=%d\n", ret);
         //LOGD("localkey: ");
         //DUMPD(pLocalPubKey, BTC_SZ_PUBKEY);
     }
     if (ret) {
-        ret = btc_tx_verify(pRemoteSig, sighash, pRemotePubKey);
-        //LOGD("btc_tx_verify(remote)=%d\n", ret);
+        ret = btc_sig_verify(pRemoteSig, sighash, pRemotePubKey);
+        //LOGD("btc_sig_verify(remote)=%d\n", ret);
         //LOGD("remotekey: ");
         //DUMPD(pRemotePubKey, BTC_SZ_PUBKEY);
     }

--- a/ln/ln_signer.c
+++ b/ln/ln_signer.c
@@ -122,13 +122,13 @@ void HIDDEN ln_signer_get_revokesec(const ln_self_t *self, btc_keys_t *pKeys, co
 
 bool HIDDEN ln_signer_p2wsh(utl_buf_t *pSig, const uint8_t *pTxHash, const ln_self_priv_t *pPrivData, int PrivIndex)
 {
-    return btc_tx_sign(pSig, pTxHash, pPrivData->priv[PrivIndex]);
+    return btc_sig_sign(pSig, pTxHash, pPrivData->priv[PrivIndex]);
 }
 
 
 bool HIDDEN ln_signer_p2wsh_force(utl_buf_t *pSig, const uint8_t *pTxHash, const btc_keys_t *pKeys)
 {
-    return btc_tx_sign(pSig, pTxHash, pKeys->priv);
+    return btc_sig_sign(pSig, pTxHash, pKeys->priv);
 }
 
 
@@ -143,7 +143,7 @@ bool HIDDEN ln_signer_p2wpkh(btc_tx_t *pTx, int Index, uint64_t Value, const btc
 
     ret = btc_sw_sighash(txhash, pTx, Index, Value, &script_code);
     if (ret) {
-        ret = btc_tx_sign(&sigbuf, txhash, pKeys->priv);
+        ret = btc_sig_sign(&sigbuf, txhash, pKeys->priv);
     }
     if (ret) {
         //mNativeSegwitがfalseの場合はscriptSigへの追加も行う
@@ -159,7 +159,7 @@ bool HIDDEN ln_signer_p2wpkh(btc_tx_t *pTx, int Index, uint64_t Value, const btc
 
 bool HIDDEN ln_signer_sign_rs(uint8_t *pRS, const uint8_t *pTxHash, const ln_self_priv_t *pPrivData, int PrivIndex)
 {
-    return btc_tx_sign_rs(pRS, pTxHash, pPrivData->priv[PrivIndex]);
+    return btc_sig_sign_rs(pRS, pTxHash, pPrivData->priv[PrivIndex]);
 }
 
 
@@ -218,7 +218,7 @@ bool HIDDEN ln_signer_tolocal_tx(const ln_self_t *self, btc_tx_t *pTx,
     //vinは1つしかないので、Indexは0固定
     ret = btc_util_calc_sighash_p2wsh(sighash, pTx, 0, Value, pWitScript);
     if (ret) {
-        ret = btc_tx_sign(pSig, sighash, sigkey.priv);
+        ret = btc_sig_sign(pSig, sighash, sigkey.priv);
     }
 
     return ret;

--- a/ln/ln_signer.h
+++ b/ln/ln_signer.h
@@ -95,7 +95,7 @@ void HIDDEN ln_signer_get_revokesec(const ln_self_t *self, btc_keys_t *pKeys, co
  * @return      true:成功
  * @note
  *      - #btc_util_sign_p2wsh()
- *      - 中身は #btc_tx_sign()
+ *      - 中身は #btc_sig_sign()
  */
 bool HIDDEN ln_signer_p2wsh(utl_buf_t *pSig, const uint8_t *pTxHash, const ln_self_priv_t *pPrivData, int PrivIndex);
 
@@ -108,7 +108,7 @@ bool HIDDEN ln_signer_p2wsh(utl_buf_t *pSig, const uint8_t *pTxHash, const ln_se
  * @return      true:成功
  * @note
  *      - #btc_util_sign_p2wsh()
- *      - 中身は #btc_tx_sign()
+ *      - 中身は #btc_sig_sign()
  */
 bool HIDDEN ln_signer_p2wsh_force(utl_buf_t *pSig, const uint8_t *pTxHash, const btc_keys_t *pKeys);
 

--- a/ln/tests/test_main.cpp
+++ b/ln/tests/test_main.cpp
@@ -21,6 +21,7 @@ extern "C" {
 #include "../../btc/btc_extkey.c"
 #include "../../btc/btc_keys.c"
 #include "../../btc/btc_sw.c"
+#include "../../btc/btc_sig.c"
 #include "../../btc/btc_tx.c"
 #include "../../btc/btc_util.c"
 #include "../../btc/segwit_addr.c"

--- a/ptarmd/wallet.c
+++ b/ptarmd/wallet.c
@@ -115,7 +115,7 @@ bool wallet_from_ptarm(char **ppResult, const char *pAddr, uint32_t FeeratePerKb
             LOGD("fail: invalid type=%d\n", type);
         }
         if (ret) {
-            ret = btc_tx_sign(&sigbuf, txhash, p_secret);
+            ret = btc_sig_sign(&sigbuf, txhash, p_secret);
         } else {
             LOGD("fail: btc_util_calc_sighash_p2wsh()\n");
         }
@@ -124,7 +124,7 @@ bool wallet_from_ptarm(char **ppResult, const char *pAddr, uint32_t FeeratePerKb
             utl_buf_free(&p_vin->witness[0]);
             utl_buf_alloccopy(&p_vin->witness[0], sigbuf.buf, sigbuf.len);
         } else {
-            LOGD("fail: btc_tx_sign()\n");
+            LOGD("fail: btc_sig_sign()\n");
         }
         utl_buf_free(&sigbuf);
         utl_buf_free(&script_code);


### PR DESCRIPTION
and
rename `btc_keys_createmulti` -> `btc_keys_create_multisig`
rename `btc_tx_set_vin_p2sh_multi` -> `btc_tx_set_vin_p2sh_multisig`