### PR TITLE
btc: btc_sw: fix bad ScriptPk len(varint) handling

### DIFF
--- a/btc/btc_buf.c
+++ b/btc/btc_buf.c
@@ -31,6 +31,7 @@
 #include "utl_int.h"
 #include "utl_dbg.h"
 
+#include "btc_util.h"
 #include "btc_buf.h"
 
 
@@ -159,6 +160,39 @@ bool btc_buf_w_write_data(btc_buf_w_t *pBufW, const void *pData, uint32_t Len)
     memcpy(&pBufW->_buf[pBufW->_pos], pData, Len);
     pBufW->_pos += Len;
     return true;
+}
+
+
+bool btc_buf_w_write_u16le(btc_buf_w_t *pBufW, uint16_t U16)
+{
+    uint8_t buf[2];
+    utl_int_unpack_u16le(buf, U16);
+    return btc_buf_w_write_data(pBufW, buf, 2);
+}
+
+
+bool btc_buf_w_write_u32le(btc_buf_w_t *pBufW, uint32_t U32)
+{
+    uint8_t buf[4];
+    utl_int_unpack_u32le(buf, U32);
+    return btc_buf_w_write_data(pBufW, buf, 4);
+}
+
+
+bool btc_buf_w_write_u64le(btc_buf_w_t *pBufW, uint64_t U64)
+{
+    uint8_t buf[8];
+    utl_int_unpack_u64le(buf, U64);
+    return btc_buf_w_write_data(pBufW, buf, 8);
+}
+
+
+bool btc_buf_w_write_hash256(btc_buf_w_t *pBufW, const void *pData, uint32_t Len)
+{
+    uint8_t buf[BTC_SZ_HASH256];
+
+    btc_util_hash256(buf, (uint8_t *)pData, Len);
+    return btc_buf_w_write_data(pBufW, buf, BTC_SZ_HASH256);
 }
 
 

--- a/btc/btc_buf.h
+++ b/btc/btc_buf.h
@@ -68,12 +68,16 @@ bool btc_buf_r_seek(btc_buf_r_t *pBufR, int32_t offset);
 uint32_t btc_buf_r_remains(btc_buf_r_t *pBufR);
 
 
-//XXX: comment
+//XXX: test & comment
 bool btc_buf_w_init(btc_buf_w_t *pBufW, uint32_t Size);
 void btc_buf_w_free(btc_buf_w_t *pBufW);
 uint8_t *btc_buf_w_get_data(btc_buf_w_t *pBufW);
 uint32_t btc_buf_w_get_len(btc_buf_w_t *pBufW);
 bool btc_buf_w_write_data(btc_buf_w_t *pBufW, const void *pData, uint32_t Len);
+bool btc_buf_w_write_u16le(btc_buf_w_t *pBufW, uint16_t U16);
+bool btc_buf_w_write_u32le(btc_buf_w_t *pBufW, uint32_t U32);
+bool btc_buf_w_write_u64le(btc_buf_w_t *pBufW, uint64_t U64);
+bool btc_buf_w_write_hash256(btc_buf_w_t *pBufW, const void *pData, uint32_t Len);
 void btc_buf_w_truncate(btc_buf_w_t *pBufW);
 
 


### PR DESCRIPTION
in `btc_sw_sighash`
use `btc_tx_buf_w_write_varint_len` to write `varint`
and refactor...

ScriptPk長の長さが1バイト固定になってた（varint）
書き込みバッファのユーティリティ作ったから全面的に置き換えた