### PR TITLE
btc: btc_crypto: rename functions

### DIFF
--- a/btc/btc_crypto.c
+++ b/btc/btc_crypto.c
@@ -118,7 +118,7 @@ void btc_md_sha256cat(uint8_t *pSha256, const uint8_t *pData1, uint16_t Len1, co
 }
 
 
-int btc_util_ecp_point_read_binary2(void *pPoint, const uint8_t *pPubKey) //XXX: mbed
+int btc_ecc_ecp_point_read_binary2(void *pPoint, const uint8_t *pPubKey) //XXX: mbed
 {
     int ret;
     uint8_t parity;
@@ -227,7 +227,7 @@ LABEL_EXIT:
 }
 
 
-int btc_util_ecp_muladd(uint8_t *pResult, const uint8_t *pPubKeyIn, const void *pA) //XXX: mbed
+int btc_ecc_ecp_muladd(uint8_t *pResult, const uint8_t *pPubKeyIn, const void *pA) //XXX: mbed
 {
     int ret;
     mbedtls_ecp_point P1;
@@ -242,7 +242,7 @@ int btc_util_ecp_muladd(uint8_t *pResult, const uint8_t *pPubKeyIn, const void *
     mbedtls_ecp_group_load(&(keypair.grp), MBEDTLS_ECP_DP_SECP256K1);
 
     //P1: 前の公開鍵座標
-    ret = btc_util_ecp_point_read_binary2(&P1, pPubKeyIn);
+    ret = btc_ecc_ecp_point_read_binary2(&P1, pPubKeyIn);
     if (ret) {
         goto LABEL_EXIT;
     }
@@ -278,13 +278,13 @@ LABEL_EXIT:
 }
 
 
-bool btc_util_mul_pubkey(uint8_t *pResult, const uint8_t *pPubKey, const uint8_t *pMul, int MulLen) //XXX: mbed
+bool btc_ecc_mul_pubkey(uint8_t *pResult, const uint8_t *pPubKey, const uint8_t *pMul, int MulLen) //XXX: mbed
 {
     mbedtls_ecp_keypair keypair;
     mbedtls_ecp_keypair_init(&keypair);
     mbedtls_ecp_group_load(&(keypair.grp), MBEDTLS_ECP_DP_SECP256K1);
 
-    int ret = btcl_util_set_keypair(&keypair, pPubKey);
+    int ret = btc_ecc_set_keypair(&keypair, pPubKey);
     if (!ret) {
         // keypair.Qに公開鍵(x, y)が入っている
         mbedtls_ecp_point pnt;
@@ -306,17 +306,6 @@ bool btc_util_mul_pubkey(uint8_t *pResult, const uint8_t *pPubKey, const uint8_t
     mbedtls_ecp_keypair_free(&keypair);
 
     return ret == 0;
-}
-
-
-int btcl_util_set_keypair(void *pKeyPair, const uint8_t *pPubKey) //XXX: mbed
-{
-    int ret;
-
-    mbedtls_ecp_keypair *p_keypair = (mbedtls_ecp_keypair *)pKeyPair;
-    ret = btc_util_ecp_point_read_binary2(&(p_keypair->Q), pPubKey);
-
-    return ret;
 }
 
 
@@ -354,6 +343,21 @@ void btc_rng_free(void)
     mbedtls_entropy_free(&mEntropy);
     mbedtls_ctr_drbg_free(&mRng);
 #endif
+}
+
+
+/**************************************************************************
+ * package functions (btc_ecc)
+ **************************************************************************/
+
+int btc_ecc_set_keypair(void *pKeyPair, const uint8_t *pPubKey) //XXX: mbed
+{
+    int ret;
+
+    mbedtls_ecp_keypair *p_keypair = (mbedtls_ecp_keypair *)pKeyPair;
+    ret = btc_ecc_ecp_point_read_binary2(&(p_keypair->Q), pPubKey);
+
+    return ret;
 }
 
 

--- a/btc/btc_crypto.h
+++ b/btc/btc_crypto.h
@@ -31,6 +31,8 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+#include "utl_common.h"
+
 
 /**************************************************************************
  * typedefs
@@ -54,7 +56,7 @@
  **************************************************************************/
 
 /**************************************************************************
- * prototypes (btc_hash)
+ * prototypes (btc_md)
  **************************************************************************/
 
 /** RIPMED-160計算
@@ -105,7 +107,7 @@ void btc_md_sha256cat(uint8_t *pSha256, const uint8_t *pData1, uint16_t Len1, co
 
 
 /**************************************************************************
- * prototypes (???)
+ * prototypes (btc_ecc)
  **************************************************************************/
 
 /** 圧縮公開鍵を非圧縮公開鍵展開
@@ -117,32 +119,21 @@ void btc_md_sha256cat(uint8_t *pSha256, const uint8_t *pData1, uint16_t Len1, co
  * @note
  *      - https://gist.github.com/flying-fury/6bc42c8bb60e5ea26631
  */
-int btc_util_ecp_point_read_binary2(void *pPoint, const uint8_t *pPubKey);
+int btc_ecc_ecp_point_read_binary2(void *pPoint, const uint8_t *pPubKey);
 
 
 /**
  * pPubKeyOut = pPubKeyIn + pA * G
  *
  */
-int btc_util_ecp_muladd(uint8_t *pResult, const uint8_t *pPubKeyIn, const void *pA);
+int btc_ecc_ecp_muladd(uint8_t *pResult, const uint8_t *pPubKeyIn, const void *pA);
 
 
 /**
  * pResult = pPubKey * pMul
  *
  */
-bool btc_util_mul_pubkey(uint8_t *pResult, const uint8_t *pPubKey, const uint8_t *pMul, int MulLen);
-
-
-/** 圧縮された公開鍵をkeypairに展開する
- *
- * @param[in]       pPubKey     圧縮された公開鍵
- * @return      0   成功
- * @note
- *      - https://bitcointalk.org/index.php?topic=644919.0
- *      - https://gist.github.com/flying-fury/6bc42c8bb60e5ea26631
- */
-int btcl_util_set_keypair(void *pKeyPair, const uint8_t *pPubKey);
+bool btc_ecc_mul_pubkey(uint8_t *pResult, const uint8_t *pPubKey, const uint8_t *pMul, int MulLen);
 
 
 /**************************************************************************
@@ -169,6 +160,21 @@ bool btc_rng_rand(uint8_t *pData, uint16_t Len);
  *
  */
 void btc_rng_free(void);
+
+
+/**************************************************************************
+ * package functions (btc_ecc)
+ **************************************************************************/
+
+/** 圧縮された公開鍵をkeypairに展開する
+ *
+ * @param[in]       pPubKey     圧縮された公開鍵
+ * @return      0   成功
+ * @note
+ *      - https://bitcointalk.org/index.php?topic=644919.0
+ *      - https://gist.github.com/flying-fury/6bc42c8bb60e5ea26631
+ */
+int HIDDEN btc_ecc_set_keypair(void *pKeyPair, const uint8_t *pPubKey);
 
 
 #endif /* BTC_CRYPTO_H__ */

--- a/btc/btc_extkey.c
+++ b/btc/btc_extkey.c
@@ -264,7 +264,7 @@ bool btc_extkey_generate(btc_extkey_t *pExtKey, uint8_t Type, uint8_t Depth, uin
         assert(ret);
     } else if (pExtKey->type == BTC_EXTKEY_PUB) {
         //parent public key --> child public key
-        ret = (btc_util_ecp_muladd(pExtKey->key, pKey, &l_L) == 0);
+        ret = (btc_ecc_ecp_muladd(pExtKey->key, pKey, &l_L) == 0);
     } else {
         assert(ret);
     }

--- a/btc/btc_keys.c
+++ b/btc/btc_keys.c
@@ -257,7 +257,7 @@ bool btc_keys_uncomp_pub(uint8_t *pUncomp, const uint8_t *pPubKey) //XXX: mbed
     mbedtls_ecp_keypair_init(&keypair);
     mbedtls_ecp_group_load(&(keypair.grp), MBEDTLS_ECP_DP_SECP256K1);
 
-    int ret = btcl_util_set_keypair(&keypair, pPubKey);
+    int ret = btc_ecc_set_keypair(&keypair, pPubKey);
     if (!ret) {
         mbedtls_mpi_write_binary(&(keypair.Q.X), pUncomp, BTC_SZ_PUBKEY - 1);
         mbedtls_mpi_write_binary(&(keypair.Q.Y), pUncomp + BTC_SZ_PUBKEY - 1, BTC_SZ_PUBKEY - 1);
@@ -301,7 +301,7 @@ bool btc_keys_check_pub(const uint8_t *pPubKey) //XXX: mbed
     mbedtls_ecp_keypair_init(&keypair);
     mbedtls_ecp_group_load(&(keypair.grp), MBEDTLS_ECP_DP_SECP256K1);
 
-    int ret = btcl_util_set_keypair(&keypair, pPubKey);
+    int ret = btc_ecc_set_keypair(&keypair, pPubKey);
     mbedtls_ecp_keypair_free(&keypair);
 
     return ret == 0;

--- a/btc/btc_sig.c
+++ b/btc/btc_sig.c
@@ -156,7 +156,7 @@ bool btc_sig_verify_2(const uint8_t *pSig, uint32_t Len, const uint8_t *pTxHash,
         goto LABEL_EXIT;
     }
 
-    ret = btcl_util_set_keypair(&keypair, pPubKey);
+    ret = btc_ecc_set_keypair(&keypair, pPubKey);
     if (ret) {
         LOGD("fail keypair\n");
         goto LABEL_EXIT;
@@ -210,7 +210,7 @@ bool btc_sig_verify_rs(const uint8_t *pRS, const uint8_t *pTxHash, const uint8_t
         goto LABEL_EXIT;
     }
 
-    ret = btcl_util_set_keypair(&keypair, pPubKey);
+    ret = btc_ecc_set_keypair(&keypair, pPubKey);
     if (ret) {
         LOGD("fail keypair\n");
         goto LABEL_EXIT;
@@ -556,7 +556,7 @@ static bool recover_pubkey(uint8_t *pPubKey, int *pRecId, const uint8_t *pRS, co
         pubx[0] = 0x02;
         ret = mbedtls_mpi_write_binary(&x, pubx + 1, BTC_SZ_FIELD);
         assert(ret == 0);
-        ret = btc_util_ecp_point_read_binary2(&R, pubx);
+        ret = btc_ecc_ecp_point_read_binary2(&R, pubx);
         assert(ret == 0);
 
         // 1.4.

--- a/btc/tests/testinc_keys.cpp
+++ b/btc/tests/testinc_keys.cpp
@@ -442,7 +442,7 @@ TEST_F(keys, uncomp1)
     uint8_t uncomp[BTC_SZ_PUBKEY_UNCOMP - 1];
 
     mbedtls_ecp_point_init(&unpnt);
-    int ret = btc_util_ecp_point_read_binary2(&unpnt, COMP);
+    int ret = btc_ecc_ecp_point_read_binary2(&unpnt, COMP);
     ASSERT_EQ(0, ret);
     mbedtls_mpi_write_binary(&unpnt.X, uncomp, 32);
     mbedtls_mpi_write_binary(&unpnt.Y, uncomp + 32, 32);
@@ -463,7 +463,7 @@ TEST_F(keys, uncomp2)
     uint8_t uncomp[BTC_SZ_PUBKEY_UNCOMP - 1];
 
     mbedtls_ecp_point_init(&unpnt);
-    int ret = btc_util_ecp_point_read_binary2(&unpnt, COMP);
+    int ret = btc_ecc_ecp_point_read_binary2(&unpnt, COMP);
     ASSERT_EQ(0, ret);
     mbedtls_mpi_write_binary(&unpnt.X, uncomp, 32);
     mbedtls_mpi_write_binary(&unpnt.Y, uncomp + 32, 32);
@@ -484,7 +484,7 @@ TEST_F(keys, uncomp3)
     uint8_t uncomp[BTC_SZ_PUBKEY_UNCOMP - 1];
 
     mbedtls_ecp_point_init(&unpnt);
-    int ret = btc_util_ecp_point_read_binary2(&unpnt, COMP);
+    int ret = btc_ecc_ecp_point_read_binary2(&unpnt, COMP);
     ASSERT_EQ(0, ret);
     mbedtls_mpi_write_binary(&unpnt.X, uncomp, 32);
     mbedtls_mpi_write_binary(&unpnt.Y, uncomp + 32, 32);
@@ -505,7 +505,7 @@ TEST_F(keys, uncomp4)
     uint8_t uncomp[BTC_SZ_PUBKEY_UNCOMP - 1];
 
     mbedtls_ecp_point_init(&unpnt);
-    int ret = btc_util_ecp_point_read_binary2(&unpnt, COMP);
+    int ret = btc_ecc_ecp_point_read_binary2(&unpnt, COMP);
     ASSERT_EQ(0, ret);
     mbedtls_mpi_write_binary(&unpnt.X, uncomp, 32);
     mbedtls_mpi_write_binary(&unpnt.Y, uncomp + 32, 32);

--- a/ln/ln_derkey.c
+++ b/ln/ln_derkey.c
@@ -63,7 +63,7 @@ bool HIDDEN ln_derkey_pubkey(uint8_t *pPubKey,
 
     mbedtls_mpi_init(&bp);
     mbedtls_mpi_read_binary(&bp, base, sizeof(base));
-    ret = btc_util_ecp_muladd(pPubKey, pBasePoint, &bp);
+    ret = btc_ecc_ecp_muladd(pPubKey, pBasePoint, &bp);
     mbedtls_mpi_free(&bp);
 
 #ifdef M_DBG_PRINT
@@ -179,12 +179,12 @@ bool HIDDEN ln_derkey_revocationkey(uint8_t *pRevPubKey,
     mbedtls_ecp_keypair_init(&keypair);
 
     mbedtls_mpi_read_binary(&bp1, base1, sizeof(base1));
-    ret = btc_util_ecp_point_read_binary2(&S1, pBasePoint);
+    ret = btc_ecc_ecp_point_read_binary2(&S1, pBasePoint);
     if (ret) {
         goto LABEL_EXIT;
     }
     mbedtls_mpi_read_binary(&bp2, base2, sizeof(base2));
-    ret = btc_util_ecp_point_read_binary2(&S2, pPerCommitPoint);
+    ret = btc_ecc_ecp_point_read_binary2(&S2, pPerCommitPoint);
     if (ret) {
         goto LABEL_EXIT;
     }

--- a/ln/ln_misc.c
+++ b/ln/ln_misc.c
@@ -392,6 +392,6 @@ void HIDDEN ln_misc_get_short_channel_id_param(uint32_t *pHeight, uint32_t *pBIn
 void HIDDEN ln_misc_generate_shared_secret(uint8_t *pResult, const uint8_t *pPubKey, const uint8_t *pPrivKey)
 {
     uint8_t pub[BTC_SZ_PUBKEY];
-    btc_util_mul_pubkey(pub, pPubKey, pPrivKey, BTC_SZ_PRIVKEY);
+    btc_ecc_mul_pubkey(pub, pPubKey, pPrivKey, BTC_SZ_PRIVKEY);
     btc_md_sha256(pResult, pub, sizeof(pub));
 }

--- a/ln/ln_node.c
+++ b/ln/ln_node.c
@@ -275,7 +275,7 @@ void HIDDEN ln_node_create_key(char *pWif, uint8_t *pPubKey)
 void HIDDEN ln_node_generate_shared_secret(uint8_t *pResult, const uint8_t *pPubKey)
 {
     uint8_t pub[BTC_SZ_PUBKEY];
-    btc_util_mul_pubkey(pub, pPubKey, mNode.keys.priv, BTC_SZ_PRIVKEY);
+    btc_ecc_mul_pubkey(pub, pPubKey, mNode.keys.priv, BTC_SZ_PRIVKEY);
     btc_md_sha256(pResult, pub, sizeof(pub));
 }
 

--- a/ln/ln_onion.c
+++ b/ln/ln_onion.c
@@ -637,7 +637,7 @@ static void multi_scalar_mul(uint8_t *pResult, const uint8_t *pPubKey, const uin
  */
 static bool blind_group_element(uint8_t *pResult, const uint8_t *pPubKey, const uint8_t *pBlindingFactor)
 {
-    bool ret = btc_util_mul_pubkey(pResult, pPubKey, pBlindingFactor, M_SZ_BLINDING_FACT);
+    bool ret = btc_ecc_mul_pubkey(pResult, pPubKey, pBlindingFactor, M_SZ_BLINDING_FACT);
     return ret;
 }
 


### PR DESCRIPTION
`btc_util_ecp_point_read_binary2` -> `btc_ecc_ecp_point_read_binary2`
`btc_util_ecp_muladd` -> `btc_ecc_ecp_muladd`
`btc_util_mul_pubkey` -> `btc_ecc_mul_pubkey`
`btcl_util_set_keypair` -> `btc_ecc_set_keypair`