### PR TITLE
return skip_none if skip DB not exist

### DIFF
--- a/ln/ln_db_lmdb.c
+++ b/ln/ln_db_lmdb.c
@@ -2458,7 +2458,7 @@ LABEL_EXIT:
  */
 ln_db_routeskip_t ln_db_routeskip_search(uint64_t ShortChannelId)
 {
-    ln_db_routeskip_t result = LN_DB_ROUTESKIP_ERROR;
+    ln_db_routeskip_t result = LN_DB_ROUTESKIP_NONE;
     int         retval;
     MDB_txn     *txn;
     MDB_dbi     dbi;


### PR DESCRIPTION
skip DBが見つからない場合に、検索結果を「skipしない」にする