### PR TITLE
get feerate_per_kw before `open_channel`

### DIFF
--- a/ln/ln.c
+++ b/ln/ln.c
@@ -1067,6 +1067,11 @@ bool ln_open_channel_create(ln_self_t *self, utl_buf_t *pOpen,
         M_SET_ERR(self, LNERR_ALREADY_FUNDING, "already funding");
         return false;
     }
+    if (FeeRate < LN_FEERATE_PER_KW_MIN) {
+        //feerate_per_kw too low
+        M_SET_ERR(self, LNERR_INV_VALUE, "feerate_per_kw too low");
+        return false;
+    }
 
     //仮チャネルID
     btc_rng_rand(self->channel_id, LN_SZ_CHANNEL_ID);

--- a/ptarmd/lnapp.c
+++ b/ptarmd/lnapp.c
@@ -1432,7 +1432,7 @@ static bool send_open_channel(lnapp_conf_t *p_conf, const funding_conf_t *pFundi
     if (ret && unspent) {
         uint32_t feerate_kw;
         if (pFunding->feerate_per_kw == 0) {
-            feerate_kw = p_conf->feerate_per_kw;
+            feerate_kw = ptarmd_get_latest_feerate_kw();
         } else {
             feerate_kw = pFunding->feerate_per_kw;
         }


### PR DESCRIPTION
fix PR #977

チャネル接続時のfeerate_per_kw初期値を前回のfeerate_per_kwと同じ値になるように変更(#977)したが、チャネル未開設の場合には0が入っていて、そのまま`open_channel`で使っていた。