### PR TITLE
reply announcement_signatures

### DIFF
--- a/ln/ln.h
+++ b/ln/ln.h
@@ -1487,14 +1487,6 @@ bool ln_open_channel_create(ln_self_t *self, utl_buf_t *pOpen,
             const ln_fundin_t *pFundin, uint64_t FundingSat, uint64_t PushSat, uint32_t FeeRate);
 
 
-
-/** open_channelのchannel_flags.announce_channelのクリア
- *
- * @param[in,out]       self            channel info
- */
-void ln_open_channel_clr_announce(ln_self_t *self);
-
-
 /** announcement_signatures作成およびchannel_announcementの一部(peer署名無し)生成
  *
  * @param[in,out]       self            channel info

--- a/ln/ln_db_lmdb.c
+++ b/ln/ln_db_lmdb.c
@@ -2216,7 +2216,11 @@ bool ln_db_annoown_check(uint64_t ShortChannelId)
         key.mv_data = (uint8_t *)&ShortChannelId;
         retval = mdb_get(mTxnAnno, db.dbi, &key, &data);
     } else {
-        LOGD("ERR: %s\n", mdb_strerror(retval));
+        if (retval == MDB_NOTFOUND) {
+            LOGD("not have annoown: %016" PRIx64 "\n", ShortChannelId);
+        } else {
+            LOGD("ERR: %s\n", mdb_strerror(retval));
+        }
     }
 
     return retval == 0;

--- a/ptarmd/lnapp.h
+++ b/ptarmd/lnapp.h
@@ -111,6 +111,7 @@ typedef struct lnapp_conf_t {
     //send announcement
     uint64_t        last_anno_cnl;                      ///< [#send_channel_anno()]最後にannouncementしたchannel
     uint64_t        last_annocnl_sci;                   ///< [#send_channel_anno()]最後にcur_getしたchannel_announcementのshort_channel_id
+    bool            annosig_send_req;                   ///< true: open_channel.announce_channel=1 and announcement_signatures not send
     bool            annodb_updated;                     ///< true: flag to notify annodb update
     bool            annodb_cont;                        ///< true: announcement連続送信中
     time_t          annodb_stamp;                       ///< last annodb_updated change time


### PR DESCRIPTION
fix #971 

`announcement_signatures`を受信した場合、初回であれば再送する。
この場合の「初回」は、接続して初めて、と解釈している(BOLT07)。
