### PR TITLE
ptarmcli : add `--noinitroutesync`

### DIFF
--- a/ptarmcli/ptarmcli.c
+++ b/ptarmcli/ptarmcli.c
@@ -60,6 +60,7 @@
 #define M_OPT_EMPTYWALLET           '\x05'
 #define M_OPT_INITROUTESYNC         '\x06'
 #define M_OPT_PAYTOWALLET           '\x07'
+#define M_OPT_NOINITROUTESYNC       '\x08'
 #define M_OPT_DEBUG                 '\x1f'
 
 #define BUFFER_SIZE     (256 * 1024)
@@ -130,6 +131,7 @@ static void optfunc_walletback(int *pOption, bool *pConn);
 static void optfunc_getbalance(int *pOption, bool *pConn);
 static void optfunc_emptywallet(int *pOption, bool *pConn);
 static void optfunc_initroutesync(int *pOption, bool *pConn);
+static void optfunc_noinitroutesync(int *pOption, bool *pConn);
 
 static void connect_rpc(void);
 static void stop_rpc(void);
@@ -169,6 +171,8 @@ static const struct {
     { M_OPT_EMPTYWALLET,        optfunc_emptywallet },
     { M_OPT_INITROUTESYNC,      optfunc_initroutesync },
     { M_OPT_PAYTOWALLET,        optfunc_walletback },
+    { M_OPT_NOINITROUTESYNC,    optfunc_noinitroutesync },
+    //
     { M_OPT_DEBUG,              optfunc_debug },
 };
 
@@ -888,6 +892,16 @@ static void optfunc_initroutesync(int *pOption, bool *pConn)
     M_CHK_CONN
 
     strcpy(mInitRouteSync, ",1");
+}
+
+
+static void optfunc_noinitroutesync(int *pOption, bool *pConn)
+{
+    (void)pConn;
+
+    M_CHK_CONN
+
+    strcpy(mInitRouteSync, ",0");
 }
 
 

--- a/ptarmcli/ptarmcli.c
+++ b/ptarmcli/ptarmcli.c
@@ -891,7 +891,7 @@ static void optfunc_initroutesync(int *pOption, bool *pConn)
 
     M_CHK_CONN
 
-    strcpy(mInitRouteSync, ",1");
+    snprintf(mInitRouteSync, sizeof(mInitRouteSync), ",%d", PTARMD_ROUTESYNC_INIT);
 }
 
 
@@ -901,7 +901,7 @@ static void optfunc_noinitroutesync(int *pOption, bool *pConn)
 
     M_CHK_CONN
 
-    strcpy(mInitRouteSync, ",0");
+    snprintf(mInitRouteSync, sizeof(mInitRouteSync), ",%d", PTARMD_ROUTESYNC_NONE);
 }
 
 

--- a/ptarmd/cmd_json.c
+++ b/ptarmd/cmd_json.c
@@ -1956,7 +1956,7 @@ static bool json_connect(cJSON *params, int *pIndex, peer_conn_t *pConn)
     if (params == NULL) {
         return false;
     }
-    pConn->routesync = 0;
+    pConn->routesync = PTARMD_ROUTESYNC_DEFAULT;
 
     //peer_nodeid, peer_addr, peer_port
     json = cJSON_GetArrayItem(params, (*pIndex)++);

--- a/ptarmd/lnapp.c
+++ b/ptarmd/lnapp.c
@@ -1302,6 +1302,7 @@ static bool exchange_init(lnapp_conf_t *p_conf)
 {
     utl_buf_t buf_bolt = UTL_BUF_INIT;
 
+    LOGD("$$$ initial_routing_sync=%s\n", ((p_conf->routesync == PTARMD_ROUTESYNC_INIT) ? "YES" : "no"));
     bool ret = ln_init_create(p_conf->p_self, &buf_bolt, p_conf->routesync == PTARMD_ROUTESYNC_INIT, true);     //channel announceあり
     if (!ret) {
         LOGD("fail: create\n");

--- a/ptarmd/lnapp.h
+++ b/ptarmd/lnapp.h
@@ -80,7 +80,7 @@ typedef struct lnapp_conf_t {
     //制御内容通知
     bool            initiator;                  ///< true:Noise Protocol handshakeのinitiator
     uint8_t         node_id[BTC_SZ_PUBKEY];     ///< 接続先(initiator==true時)
-    uint8_t         routesync;                  ///< initial_routing_sync
+    ptarmd_routesync_t  routesync;              ///< initial_routing_sync
 
     //lnappワーク
     volatile bool   loop;                   ///< true:channel動作中

--- a/ptarmd/ptarmd.h
+++ b/ptarmd/ptarmd.h
@@ -155,7 +155,9 @@ typedef enum {
     PTARMD_ROUTESYNC_NONE,
     PTARMD_ROUTESYNC_INIT,      ///< initial_routing_sync
     //
-    PTARMD_ROUTESYNC_MAX = PTARMD_ROUTESYNC_INIT
+    PTARMD_ROUTESYNC_MAX = PTARMD_ROUTESYNC_INIT,
+    //
+    PTARMD_ROUTESYNC_DEFAULT = PTARMD_ROUTESYNC_NONE,   //default
 } ptarmd_routesync_t;
 
 


### PR DESCRIPTION
add `ptarmcli -c XXX --noinitroutesync`.

現在のデフォルト動作は`--noinitroutesync`のままにするが、変更する可能性あり(`PTARMD_ROUTESYNC_DEFAULT`)。