### PR TITLE
lnapp: add pong list for delay pong reply

### DIFF
--- a/ln/ln.c
+++ b/ln/ln.c
@@ -139,8 +139,6 @@
 #define M_HTLCFLAG_BITS_MALFORMEDHTLC   (LN_HTLCFLAG_SFT_ADDHTLC(LN_ADDHTLC_RECV) | LN_HTLCFLAG_SFT_DELHTLC(LN_DELHTLC_MALFORMED) | LN_HTLCFLAG_SFT_UPDSEND | LN_HTLCFLAG_SFT_COMSEND)
 
 
-#define M_PONG_MISSING                      (3)             ///< pongが返ってこないエラー上限
-
 #define M_FUNDING_INDEX                     (0)             ///< funding_txのvout
 
 #define M_HYSTE_CLTV_EXPIRY_MIN             (7)             ///< BOLT4 check:cltv_expiryのhysteresis
@@ -1090,6 +1088,8 @@ bool ln_open_channel_create(ln_self_t *self, utl_buf_t *pOpen,
     //funding_tx作成用に保持
     self->p_establish->p_fundin = (ln_fundin_t *)UTL_DBG_MALLOC(sizeof(ln_fundin_t));     //free: free_establish()
     memcpy(self->p_establish->p_fundin, pFundin, sizeof(ln_fundin_t));
+#else
+    (void)pFundin;
 #endif
 
     //open_channel
@@ -1712,41 +1712,16 @@ bool ln_update_fee_create(ln_self_t *self, utl_buf_t *pUpdFee, uint32_t FeerateP
  * ping/pong
  ********************************************************************/
 
-bool ln_ping_create(ln_self_t *self, utl_buf_t *pPing)
+bool ln_ping_create(ln_self_t *self, utl_buf_t *pPing, uint16_t PingLen, uint16_t PongLen)
 {
+    (void)self;
+
     ln_msg_ping_t msg;
 
-    // if (self->last_num_pong_bytes != 0) {
-    //     LOGD("not receive pong(last_num_pong_bytes=%d)\n", self->last_num_pong_bytes);
-    //     return false;
-    // }
-
-#if 1
-    // https://github.com/lightningnetwork/lightning-rfc/issues/373
-    //  num_pong_bytesが大きすぎると無視される？
-    uint8_t r;
-    btc_rng_rand(&r, 1);
-    self->last_num_pong_bytes = r;
-    btc_rng_rand(&r, 1);
-    msg.byteslen = r;
-#else
-    btc_rng_rand((uint8_t *)&self->last_num_pong_bytes, 2);
-    btc_rng_rand((uint8_t *)&msg.byteslen, 2);
-#endif
-    msg.num_pong_bytes = self->last_num_pong_bytes;
+    msg.byteslen = PingLen;
+    msg.num_pong_bytes = PongLen;
     msg.p_ignored = NULL;
     bool ret = ln_msg_ping_write(pPing, &msg);
-    if (ret) {
-        self->missing_pong_cnt++;
-        if (self->missing_pong_cnt > 1) {
-            LOGD("missing pong: %d\n", self->missing_pong_cnt);
-            if (self->missing_pong_cnt > M_PONG_MISSING) {
-                M_SET_ERR(self, LNERR_PINGPONG, "many pong missing...(%d)\n", self->missing_pong_cnt);
-                ret = false;
-            }
-        }
-    }
-
     return ret;
 }
 
@@ -2690,18 +2665,14 @@ static bool recv_pong(ln_self_t *self, const uint8_t *pData, uint16_t Len)
         return false;
     }
 
-    //pongのbyteslenはpingのnum_pong_bytesであること
-    ret = (msg.byteslen == self->last_num_pong_bytes);
-    if (ret) {
-        self->missing_pong_cnt--;
-        //LOGD("missing_pong_cnt: %d / last_num_pong_bytes: %d\n", self->missing_pong_cnt, self->last_num_pong_bytes);
-        self->last_num_pong_bytes = 0;
-    } else {
-        LOGD("fail: msg.byteslen(%" PRIu16 ") != self->last_num_pong_bytes(%" PRIu16 ")\n", msg.byteslen, self->last_num_pong_bytes);
-    }
+    ln_cb_pong_recv_t pongrecv;
+    pongrecv.result = false;
+    pongrecv.byteslen = msg.byteslen;
+    pongrecv.p_ignored = msg.p_ignored;
+    callback(self, LN_CB_PONG_RECV, &pongrecv);
 
     //LOGD("END\n");
-    return true;
+    return pongrecv.result;
 }
 
 

--- a/ln/ln.h
+++ b/ln/ln.h
@@ -289,6 +289,7 @@ typedef enum {
     LN_CB_SEND_QUEUE,           ///< 送信キュー保存(廃止予定)
     LN_CB_GET_LATEST_FEERATE,   ///< feerate_per_kw取得要求
     LN_CB_GETBLOCKCOUNT,        ///< getblockcount
+    LN_CB_PONG_RECV,            ///< pong received
     LN_CB_MAX,
 } ln_cb_t;
 
@@ -866,6 +867,16 @@ typedef struct {
 } ln_cb_update_annodb_t;
 
 
+/** @struct ln_cb_pong_recv_t
+ *  @brief  pong received(#LN_CB_PONG_RECV)
+ */
+typedef struct {
+    bool                            result;         //true: lnapp check OK
+    uint16_t                        byteslen;       //pong.byteslen
+    const uint8_t                   *p_ignored;     //pong.ignored
+} ln_cb_pong_recv_t;
+
+
 /**************************************************************************
  * typedefs : 管理データ
  **************************************************************************/
@@ -978,8 +989,6 @@ struct ln_self_t {
     uint8_t                     peer_node_id[BTC_SZ_PUBKEY];    ///< [CONN_01]接続先ノード
     ln_nodeaddr_t               last_connected_addr;            ///< [CONN_02]最後に接続したIP address
     ln_status_t                 status;                         ///< [CONN_03]状態
-    uint16_t                    missing_pong_cnt;               ///< [CONN_04]ping送信に対してpongを受信しなかった回数
-    uint16_t                    last_num_pong_bytes;            ///< [CONN_05]最後にping送信したlast_num_pong_bytes
 
     //key storage
     ln_derkey_storage_t         peer_storage;                   ///< [KEYS_01]key storage(peer)
@@ -1556,9 +1565,11 @@ bool ln_update_fee_create(ln_self_t *self, utl_buf_t *pUpdFee, uint32_t FeerateP
  *
  * @param[in]           self            channel info
  * @param[out]          pPing           生成したpingメッセージ
+ * @param[in]           PingLen         ping byteslen
+ * @param[in]           PongLen         num_pong_bytes
  * @retval      true    成功
  */
-bool ln_ping_create(ln_self_t *self, utl_buf_t *pPing);
+bool ln_ping_create(ln_self_t *self, utl_buf_t *pPing, uint16_t PingLen, uint16_t PongLen);
 
 
 /** pong作成

--- a/ln/ln_db_lmdb.c
+++ b/ln/ln_db_lmdb.c
@@ -322,8 +322,6 @@ static const backup_param_t DBSELF_VALUES[] = {
     M_ITEM(ln_self_t, peer_node_id),    //[CONN01]
     M_ITEM(ln_self_t, last_connected_addr),     //[CONN02]
     M_ITEM(ln_self_t, status),      //[CONN03]
-    //[CONN04]missing_pong_cnt
-    //[CONN05]last_num_pong_bytes
 
     //
     //keys

--- a/ptarmd/lnapp.h
+++ b/ptarmd/lnapp.h
@@ -67,6 +67,17 @@ typedef struct routelist_t {
 LIST_HEAD(routelisthead_t, routelist_t);
 
 
+/** @struct     pinglist_t
+ *  @brief      ping.num_pong_bytes list
+ */
+typedef struct ponglist_t {
+    LIST_ENTRY(ponglist_t) list;
+    uint16_t                num_pong_bytes;
+} ponglist_t;
+
+LIST_HEAD(ponglisthead_t, ponglist_t);
+
+
 /** @struct lnapp_conf_t
  *  @brief  アプリ側のチャネル管理情報
  */
@@ -87,7 +98,8 @@ typedef struct lnapp_conf_t {
     ln_self_t       *p_self;                ///< channelのコンテキスト
 
     bool            initial_routing_sync;   ///< init.localfeaturesのinitial_routing_sync
-    uint8_t         ping_counter;           ///< 無送受信時にping送信するカウンタ(カウントアップ)
+    int             ping_counter;           ///< 無送受信時にping送信するカウンタ(カウントアップ)
+
     bool            funding_waiting;        ///< true:funding_txの安定待ち
     uint32_t        funding_confirm;        ///< funding_txのconfirmation数
 
@@ -107,6 +119,7 @@ typedef struct lnapp_conf_t {
 
     struct rcvidlelisthead_t    rcvidle_head;   //受信アイドル時キュー
     struct routelisthead_t      payroute_head;  //payment
+    struct ponglisthead_t       pong_head;      //pong.num_pong_bytes
 
     //send announcement
     uint64_t        last_anno_cnl;                      ///< [#send_channel_anno()]最後にannouncementしたchannel


### PR DESCRIPTION
In initial_routing_sync, nodes(c-lightning, eclair, lnd) don't send `pong` against our `ping`.
But their send `pong` after initial_routing_sync at all once.

initial_routing_syncでannouncementを送信している間、彼らは`ping`受信に対して`pong`送信を行わない。
しかし、`ping`を無視しているわけではなく、全部が終わった後にまとめて送信してくる。
そのため、`ping`で送信した"`pong`に載せてくるignoredのサイズ"を保持しておき、`pong`を受信した順に比較する。

こちらとしてはinitial_routing_sync中かどうかにかかわらず`ping`を送信する必要があるが(そうしないと相手から切断される)、`ping`に対して`pong`が返ってこない場合に切断するのは難しい。
当面は60回までであれば`ping`に対する`pong`がなくても切断しない。