### PR TITLE
ln_msg_normalope: refacotr `ln_msg_update_fail_htlc_*`

### DIFF
--- a/ln/ln_msg_normalope.h
+++ b/ln/ln_msg_normalope.h
@@ -74,14 +74,22 @@ typedef struct {
 } ln_msg_update_fulfill_htlc_t;
 
 
-/** @struct     ln_update_fail_htlc_t
+/** @struct     ln_msg_update_fail_htlc_t
  *  @brief      update_fail_htlc
  */
 typedef struct {
-    uint8_t     *p_channel_id;                      ///< 32: channel-id
-    uint64_t    id;                                 ///< 8:  id
-    utl_buf_t   *p_reason;                          ///< onion failure packet
-} ln_update_fail_htlc_t;
+    //type: 131 (update_fail_htlc)
+    //data:
+    //  [32:channel_id]
+    //  [8:id]
+    //  [2:len]
+    //  [len:reason]
+
+    const uint8_t   *p_channel_id;
+    uint64_t        id;
+    uint16_t        len;
+    const uint8_t   *p_reason;
+} ln_msg_update_fail_htlc_t;
 
 
 /** @struct     ln_update_fail_malformed_htlc_t
@@ -173,7 +181,7 @@ bool HIDDEN ln_msg_update_fulfill_htlc_read(ln_msg_update_fulfill_htlc_t *pMsg, 
  * @param[in]       pMsg    元データ
  * retval   true    成功
  */
-bool HIDDEN ln_msg_update_fail_htlc_write(utl_buf_t *pBuf, const ln_update_fail_htlc_t *pMsg);
+bool HIDDEN ln_msg_update_fail_htlc_write(utl_buf_t *pBuf, const ln_msg_update_fail_htlc_t *pMsg);
 
 
 /** update_fail_htlc読込み
@@ -183,7 +191,7 @@ bool HIDDEN ln_msg_update_fail_htlc_write(utl_buf_t *pBuf, const ln_update_fail_
  * @param[in]       Len     pData長
  * retval   true    成功
  */
-bool HIDDEN ln_msg_update_fail_htlc_read(ln_update_fail_htlc_t *pMsg, const uint8_t *pData, uint16_t Len);
+bool HIDDEN ln_msg_update_fail_htlc_read(ln_msg_update_fail_htlc_t *pMsg, const uint8_t *pData, uint16_t Len);
 
 
 /** update_fail_malformed_htlc生成


### PR DESCRIPTION
rename `ln_update_fail_htlc_t` -> `ln_msg_update_fail_htlc_t`
refactor
`ln_msg_update_fail_htlc_write`
`ln_msg_update_fail_htlc_read`