### PR TITLE
ln_msg_normalope: refactor

### DIFF
--- a/ln/ln_msg_normalope.c
+++ b/ln/ln_msg_normalope.c
@@ -56,7 +56,7 @@
 static void update_add_htlc_print(const ln_msg_update_add_htlc_t *pMsg);
 static void update_fulfill_htlc_print(const ln_msg_update_fulfill_htlc_t *pMsg);
 static void update_fail_htlc_print(const ln_msg_update_fail_htlc_t *pMsg);
-static void update_fail_malformed_htlc_print(const ln_update_fail_malformed_htlc_t *pMsg);
+static void update_fail_malformed_htlc_print(const ln_msg_update_fail_malformed_htlc_t *pMsg);
 static void commit_signed_print(const ln_commit_signed_t *pMsg);
 static void revoke_and_ack_print(const ln_revoke_and_ack_t *pMsg);
 static void update_fee_print(const ln_update_fee_t *pMsg);
@@ -276,98 +276,65 @@ static void update_fail_htlc_print(const ln_msg_update_fail_htlc_t *pMsg)
  * update_fail_malformed_htlc
  ********************************************************************/
 
-bool HIDDEN ln_msg_update_fail_malformed_htlc_write(utl_buf_t *pBuf, const ln_update_fail_malformed_htlc_t *pMsg)
+bool HIDDEN ln_msg_update_fail_malformed_htlc_write(utl_buf_t *pBuf, const ln_msg_update_fail_malformed_htlc_t *pMsg)
 {
-    //    type: 135 (update_fail_malformed_htlc)
-    //    data:
-    //        [32:channel-id]
-    //        [8:id]
-    //        [32:sha256-of-onion]
-    //        [2:failure-code]
-
-    utl_push_t    proto;
-
 #ifdef DBG_PRINT_WRITE
     LOGD("@@@@@ %s @@@@@\n", __func__);
     update_fail_malformed_htlc_print(pMsg);
 #endif  //DBG_PRINT_WRITE
 
-    utl_push_init(&proto, pBuf, sizeof(uint16_t) + 74);
-
-    //    type: 135 (update_fail_malformed_htlc)
-    ln_misc_push16be(&proto, MSGTYPE_UPDATE_FAIL_MALFORMED_HTLC);
-
-    //        [32:channel-id]
-    utl_push_data(&proto, pMsg->p_channel_id, LN_SZ_CHANNEL_ID);
-
-    //        [8:id]
-    ln_misc_push64be(&proto, pMsg->id);
-
-    //        [32:sha256-of-onion]
-    utl_push_data(&proto, pMsg->p_sha256_onion, BTC_SZ_HASH256);
-
-    //        [2:failure-code]
-    ln_misc_push16be(&proto, pMsg->failure_code);
-
-    assert(sizeof(uint16_t) + 74 == pBuf->len);
-
-    utl_push_trim(&proto);
-
+    btc_buf_w_t buf_w;
+    btc_buf_w_init(&buf_w, 0);
+    if (!btc_buf_w_write_u16be(&buf_w, MSGTYPE_UPDATE_FAIL_MALFORMED_HTLC)) goto LABEL_ERROR;
+    if (!btc_buf_w_write_data(&buf_w, pMsg->p_channel_id, LN_SZ_CHANNEL_ID)) goto LABEL_ERROR;
+    if (!btc_buf_w_write_u64be(&buf_w, pMsg->id)) goto LABEL_ERROR;
+    if (!btc_buf_w_write_data(&buf_w, pMsg->p_sha256_of_onion, BTC_SZ_HASH256)) goto LABEL_ERROR;
+    if (!btc_buf_w_write_u16be(&buf_w, pMsg->failure_code)) goto LABEL_ERROR;
+    btc_buf_w_move(&buf_w, pBuf);
     return true;
+
+LABEL_ERROR:
+    btc_buf_w_free(&buf_w);
+    return false;
 }
 
 
-bool HIDDEN ln_msg_update_fail_malformed_htlc_read(ln_update_fail_malformed_htlc_t *pMsg, const uint8_t *pData, uint16_t Len)
+bool HIDDEN ln_msg_update_fail_malformed_htlc_read(ln_msg_update_fail_malformed_htlc_t *pMsg, const uint8_t *pData, uint16_t Len)
 {
-    if (Len < sizeof(uint16_t) + 74) {
-        LOGD("fail: invalid length: %d\n", Len);
-        return false;
-    }
-
-    uint16_t type = utl_int_pack_u16be(pData);
+    btc_buf_r_t buf_r;
+    btc_buf_r_init(&buf_r, pData, Len);
+    uint16_t type;
+    if (!btc_buf_r_read_u16be(&buf_r, &type)) goto LABEL_ERROR_SYNTAX;
     if (type != MSGTYPE_UPDATE_FAIL_MALFORMED_HTLC) {
         LOGD("fail: type not match: %04x\n", type);
         return false;
     }
-
-    int pos = sizeof(uint16_t);
-
-    //        [32:channel-id]
-    memcpy(pMsg->p_channel_id, pData + pos, LN_SZ_CHANNEL_ID);
-    pos += LN_SZ_CHANNEL_ID;
-
-    //        [8:id]
-    pMsg->id = utl_int_pack_u64be(pData + pos);
-    pos += sizeof(uint64_t);
-
-    //        [32:sha256-of-onion]
-    memcpy(pMsg->p_sha256_onion, pData + pos, BTC_SZ_HASH256);
-    pos += BTC_SZ_HASH256;
-
-    //        [2:failure-code]
-    pMsg->failure_code = utl_int_pack_u16be(pData + pos);
-    pos += sizeof(uint16_t);
-
-    assert(Len >= pos);
+    if (!btc_buf_r_get_pos_and_seek(&buf_r, &pMsg->p_channel_id, (int32_t)LN_SZ_CHANNEL_ID)) goto LABEL_ERROR_SYNTAX;
+    if (!btc_buf_r_read_u64be(&buf_r, &pMsg->id)) goto LABEL_ERROR_SYNTAX;
+    if (!btc_buf_r_get_pos_and_seek(&buf_r, &pMsg->p_sha256_of_onion, BTC_SZ_HASH256)) goto LABEL_ERROR_SYNTAX;
+    if (!btc_buf_r_read_u16be(&buf_r, &pMsg->failure_code)) goto LABEL_ERROR_SYNTAX;
 
 #ifdef DBG_PRINT_READ
     LOGD("@@@@@ %s @@@@@\n", __func__);
     update_fail_malformed_htlc_print(pMsg);
 #endif  //DBG_PRINT_READ
-
     return true;
+
+LABEL_ERROR_SYNTAX:
+    LOGD("fail: invalid syntax\n");
+    return false;
 }
 
 
-static void update_fail_malformed_htlc_print(const ln_update_fail_malformed_htlc_t *pMsg)
+static void update_fail_malformed_htlc_print(const ln_msg_update_fail_malformed_htlc_t *pMsg)
 {
 #ifdef PTARM_DEBUG
     LOGD("-[update_fail_malformed_htlc]-------------------------------\n");
-    LOGD("channel-id: ");
+    LOGD("channel_id: ");
     DUMPD(pMsg->p_channel_id, LN_SZ_CHANNEL_ID);
     LOGD("id: %" PRIu64 "\n", pMsg->id);
-    LOGD("sha256_onion: ");
-    DUMPD(pMsg->p_sha256_onion, BTC_SZ_HASH256);
+    LOGD("sha256_of_onion: ");
+    DUMPD(pMsg->p_sha256_of_onion, BTC_SZ_HASH256);
     LOGD("failure_code: %04x\n", pMsg->failure_code);
     LOGD("--------------------------------\n");
 #endif  //PTARM_DEBUG

--- a/ln/ln_msg_normalope.c
+++ b/ln/ln_msg_normalope.c
@@ -57,7 +57,7 @@ static void update_add_htlc_print(const ln_msg_update_add_htlc_t *pMsg);
 static void update_fulfill_htlc_print(const ln_msg_update_fulfill_htlc_t *pMsg);
 static void update_fail_htlc_print(const ln_msg_update_fail_htlc_t *pMsg);
 static void update_fail_malformed_htlc_print(const ln_msg_update_fail_malformed_htlc_t *pMsg);
-static void commit_signed_print(const ln_commit_signed_t *pMsg);
+static void commitment_signed_print(const ln_msg_commitment_signed_t *pMsg);
 static void revoke_and_ack_print(const ln_revoke_and_ack_t *pMsg);
 static void update_fee_print(const ln_update_fee_t *pMsg);
 
@@ -345,102 +345,67 @@ static void update_fail_malformed_htlc_print(const ln_msg_update_fail_malformed_
  * commitment_signed
  ********************************************************************/
 
-bool HIDDEN ln_msg_commit_signed_write(utl_buf_t *pBuf, const ln_commit_signed_t *pMsg)
+bool HIDDEN ln_msg_commitment_signed_write(utl_buf_t *pBuf, const ln_msg_commitment_signed_t *pMsg)
 {
-    //    type: 132 (commitment_signed)
-    //    data:
-    //        [32:channel-id]
-    //        [64:signature]
-    //        [2:num-htlcs]
-    //        [num-htlcs*64:htlc-signature]
-
-    utl_push_t    proto;
-
 #ifdef DBG_PRINT_WRITE
     LOGD("@@@@@ %s @@@@@\n", __func__);
-    commit_signed_print(pMsg);
+    commitment_signed_print(pMsg);
 #endif  //DBG_PRINT_WRITE
 
-    utl_push_init(&proto, pBuf, sizeof(uint16_t) + 98 + pMsg->num_htlcs * LN_SZ_SIGNATURE);
-
-    //    type: 132 (commitment_signed)
-    ln_misc_push16be(&proto, MSGTYPE_COMMITMENT_SIGNED);
-
-    //        [32:channel-id]
-    utl_push_data(&proto, pMsg->p_channel_id, LN_SZ_CHANNEL_ID);
-
-    //        [64:signature]
-    utl_push_data(&proto, pMsg->p_signature, LN_SZ_SIGNATURE);
-
-    //        [2:num-htlcs]
-    ln_misc_push16be(&proto, pMsg->num_htlcs);
-
-    //        [num-htlcs*64:htlc-signature]
-    utl_push_data(&proto, pMsg->p_htlc_signature, pMsg->num_htlcs * LN_SZ_SIGNATURE);
-
-    assert(sizeof(uint16_t) + 98 + pMsg->num_htlcs * LN_SZ_SIGNATURE == pBuf->len);
-
-    utl_push_trim(&proto);
-
+    btc_buf_w_t buf_w;
+    btc_buf_w_init(&buf_w, 0);
+    if (!btc_buf_w_write_u16be(&buf_w, MSGTYPE_COMMITMENT_SIGNED)) goto LABEL_ERROR;
+    if (!btc_buf_w_write_data(&buf_w, pMsg->p_channel_id, LN_SZ_CHANNEL_ID)) goto LABEL_ERROR;
+    if (!btc_buf_w_write_data(&buf_w, pMsg->p_signature, LN_SZ_SIGNATURE)) goto LABEL_ERROR;
+    if (!btc_buf_w_write_u16be(&buf_w, pMsg->num_htlcs)) goto LABEL_ERROR;
+    if (!btc_buf_w_write_data(&buf_w, pMsg->p_htlc_signature, pMsg->num_htlcs * LN_SZ_SIGNATURE)) goto LABEL_ERROR;
+    btc_buf_w_move(&buf_w, pBuf);
     return true;
+
+LABEL_ERROR:
+    btc_buf_w_free(&buf_w);
+    return false;
 }
 
 
-bool HIDDEN ln_msg_commit_signed_read(ln_commit_signed_t *pMsg, const uint8_t *pData, uint16_t Len)
+bool HIDDEN ln_msg_commitment_signed_read(ln_msg_commitment_signed_t *pMsg, const uint8_t *pData, uint16_t Len)
 {
-    if (Len < sizeof(uint16_t) + 98) {
-        LOGD("fail: invalid length: %d\n", Len);
-        return false;
-    }
-
-    uint16_t type = utl_int_pack_u16be(pData);
+    btc_buf_r_t buf_r;
+    btc_buf_r_init(&buf_r, pData, Len);
+    uint16_t type;
+    if (!btc_buf_r_read_u16be(&buf_r, &type)) goto LABEL_ERROR_SYNTAX;
     if (type != MSGTYPE_COMMITMENT_SIGNED) {
         LOGD("fail: type not match: %04x\n", type);
         return false;
     }
-
-    int pos = sizeof(uint16_t);
-
-    //        [32:channel-id]
-    memcpy(pMsg->p_channel_id, pData + pos, LN_SZ_CHANNEL_ID);
-    pos += LN_SZ_CHANNEL_ID;
-
-    //        [64:signature]
-    memcpy(pMsg->p_signature, pData + pos, LN_SZ_SIGNATURE);
-    pos += LN_SZ_SIGNATURE;
-
-    //        [2:num-htlcs]
-    pMsg->num_htlcs = utl_int_pack_u16be(pData + pos);
-    pos += sizeof(uint16_t);
-
-
-    //        [num-htlcs*64:htlc-signature]
-    pMsg->p_htlc_signature = (uint8_t *)UTL_DBG_MALLOC(pMsg->num_htlcs * LN_SZ_SIGNATURE);
-    memcpy(pMsg->p_htlc_signature, pData + pos, pMsg->num_htlcs * LN_SZ_SIGNATURE);
-    pos += pMsg->num_htlcs * LN_SZ_SIGNATURE;
-
-    assert(Len >= pos);
+    if (!btc_buf_r_get_pos_and_seek(&buf_r, &pMsg->p_channel_id, (int32_t)LN_SZ_CHANNEL_ID)) goto LABEL_ERROR_SYNTAX;
+    if (!btc_buf_r_get_pos_and_seek(&buf_r, &pMsg->p_signature, LN_SZ_SIGNATURE)) goto LABEL_ERROR_SYNTAX;
+    if (!btc_buf_r_read_u16be(&buf_r, &pMsg->num_htlcs)) goto LABEL_ERROR_SYNTAX;
+    if (!btc_buf_r_get_pos_and_seek(&buf_r, &pMsg->p_htlc_signature, pMsg->num_htlcs * LN_SZ_SIGNATURE)) goto LABEL_ERROR_SYNTAX;
 
 #ifdef DBG_PRINT_READ
     LOGD("@@@@@ %s @@@@@\n", __func__);
-    commit_signed_print(pMsg);
+    commitment_signed_print(pMsg);
 #endif  //DBG_PRINT_READ
-
     return true;
+
+LABEL_ERROR_SYNTAX:
+    LOGD("fail: invalid syntax\n");
+    return false;
 }
 
 
-static void commit_signed_print(const ln_commit_signed_t *pMsg)
+static void commitment_signed_print(const ln_msg_commitment_signed_t *pMsg)
 {
 #ifdef PTARM_DEBUG
     LOGD("-[commitment_signed]-------------------------------\n");
-    LOGD("channel-id: ");
+    LOGD("channel_id: ");
     DUMPD(pMsg->p_channel_id, LN_SZ_CHANNEL_ID);
     LOGD("signature: ");
     DUMPD(pMsg->p_signature, LN_SZ_SIGNATURE);
-    LOGD("num_htlcs= %lu\n", (unsigned long)pMsg->num_htlcs);
+    LOGD("num_htlc: %lu\n", pMsg->num_htlcs);
     for (int lp = 0; lp < pMsg->num_htlcs; lp++) {
-        LOGD("htlc-signature[%d]: ", lp);
+        LOGD("htlc_signature[%d]: ", lp);
         DUMPD(pMsg->p_htlc_signature + lp * LN_SZ_SIGNATURE, LN_SZ_SIGNATURE);
     }
     LOGD("--------------------------------\n");

--- a/ln/ln_msg_normalope.h
+++ b/ln/ln_msg_normalope.h
@@ -110,15 +110,22 @@ typedef struct {
 } ln_msg_update_fail_malformed_htlc_t;
 
 
-/** @struct     ln_commit_signed_t
+/** @struct     ln_msg_commitment_signed_t
  *  @brief      commitment_signed
  */
 typedef struct {
-    uint8_t     *p_channel_id;                      ///< 32: channel-id
-    uint8_t     *p_signature;                       ///< 64: signature
-    uint16_t    num_htlcs;                          ///< 2:  num-htlcs
-    uint8_t     *p_htlc_signature;                  ///< num-htlcs*64: htlc-signature
-} ln_commit_signed_t;
+    //type: 132 (commitment_signed)
+    //data:
+    //  [32:channel_id]
+    //  [64:signature]
+    //  [2:num_htlcs]
+    //  [num_htlcs*64:htlc_signature]
+
+    const uint8_t   *p_channel_id;
+    const uint8_t   *p_signature;
+    uint16_t        num_htlcs;
+    const uint8_t   *p_htlc_signature;
+} ln_msg_commitment_signed_t;
 
 
 /** @struct     ln_revoke_and_ack_t
@@ -226,7 +233,7 @@ bool HIDDEN ln_msg_update_fail_malformed_htlc_read(ln_msg_update_fail_malformed_
  * @param[in]       pMsg    元データ
  * retval   true    成功
  */
-bool HIDDEN ln_msg_commit_signed_write(utl_buf_t *pBuf, const ln_commit_signed_t *pMsg);
+bool HIDDEN ln_msg_commitment_signed_write(utl_buf_t *pBuf, const ln_msg_commitment_signed_t *pMsg);
 
 
 /** commit_signed読込み
@@ -236,7 +243,7 @@ bool HIDDEN ln_msg_commit_signed_write(utl_buf_t *pBuf, const ln_commit_signed_t
  * @param[in]       Len     pData長
  * retval   true    成功
  */
-bool HIDDEN ln_msg_commit_signed_read(ln_commit_signed_t *pMsg, const uint8_t *pData, uint16_t Len);
+bool HIDDEN ln_msg_commitment_signed_read(ln_msg_commitment_signed_t *pMsg, const uint8_t *pData, uint16_t Len);
 
 
 /** revoke_and_ack生成

--- a/ln/ln_msg_normalope.h
+++ b/ln/ln_msg_normalope.h
@@ -92,15 +92,22 @@ typedef struct {
 } ln_msg_update_fail_htlc_t;
 
 
-/** @struct     ln_update_fail_malformed_htlc_t
+/** @struct     ln_msg_update_fail_malformed_htlc_t
  *  @brief      update_fail_malformed_htlc
  */
 typedef struct {
-    uint8_t     *p_channel_id;                      ///< 32: channel-id
-    uint64_t    id;                                 ///< 8:  id
-    uint8_t     *p_sha256_onion;                    ///< 32: sha256-of-onion
-    uint16_t    failure_code;                       ///< 2:  failure-code
-} ln_update_fail_malformed_htlc_t;
+    //type: 135 (update_fail_malformed_htlc)
+    //data:
+    //  [32:channel_id]
+    //  [8:id]
+    //  [32:sha256_of_onion]
+    //  [2:failure_code]
+
+    const uint8_t   *p_channel_id;
+    uint64_t        id;
+    const uint8_t   *p_sha256_of_onion;
+    uint16_t        failure_code;
+} ln_msg_update_fail_malformed_htlc_t;
 
 
 /** @struct     ln_commit_signed_t
@@ -200,7 +207,7 @@ bool HIDDEN ln_msg_update_fail_htlc_read(ln_msg_update_fail_htlc_t *pMsg, const 
  * @param[in]       pMsg    元データ
  * retval   true    成功
  */
-bool HIDDEN ln_msg_update_fail_malformed_htlc_write(utl_buf_t *pBuf, const ln_update_fail_malformed_htlc_t *pMsg);
+bool HIDDEN ln_msg_update_fail_malformed_htlc_write(utl_buf_t *pBuf, const ln_msg_update_fail_malformed_htlc_t *pMsg);
 
 
 /** update_fail_malformed_htlc読込み
@@ -210,7 +217,7 @@ bool HIDDEN ln_msg_update_fail_malformed_htlc_write(utl_buf_t *pBuf, const ln_up
  * @param[in]       Len     pData長
  * retval   true    成功
  */
-bool HIDDEN ln_msg_update_fail_malformed_htlc_read(ln_update_fail_malformed_htlc_t *pMsg, const uint8_t *pData, uint16_t Len);
+bool HIDDEN ln_msg_update_fail_malformed_htlc_read(ln_msg_update_fail_malformed_htlc_t *pMsg, const uint8_t *pData, uint16_t Len);
 
 
 /** commit_signed生成


### PR DESCRIPTION
ln_msg_normalope: refactor `ln_msg_update_fail_malformed_htlc_*`

rename `ln_update_fail_malformed_htlc_t` -> `ln_msg_update_fail_malformed_htlc_t`
refactor
`ln_msg_update_fail_malformed_htlc_write`
`ln_msg_update_fail_malformed_htlc_read`

AND

ln_msg_normalope: refactor `ln_msg_update_commitment_signed_*`

rename `ln_update_commitment_signed_t` -> `ln_msg_update_commitment_signed_t`
refactor
`ln_msg_update_commitment_signed_write`
`ln_msg_update_commitment_signed_read`