### PR TITLE
invoice log: add date/time

### DIFF
--- a/ptarmd/cmd_json.c
+++ b/ptarmd/cmd_json.c
@@ -296,7 +296,8 @@ void cmd_json_pay_result(const uint8_t *pPaymentHash, const char *pResultStr)
     sprintf(fname, FNAME_INVOICE_LOG, str_payhash);
     fp = fopen(fname, "a");
     if (fp != NULL) {
-        fprintf(fp, "  result=%s\n", pResultStr);
+        char time[UTL_SZ_TIME_FMT_STR + 1];
+        fprintf(fp, "  result(%s)=%s\n", utl_time_str_time(time), pResultStr);
         fclose(fp);
     }
 }
@@ -1900,7 +1901,8 @@ static void cmd_routepay_save_route(
             }
         }
         fprintf(fp, "----------- end of route -----------\n");
-        fprintf(fp, "  result=%s\n", pResultStr);
+        char time[UTL_SZ_TIME_FMT_STR + 1];
+        fprintf(fp, "  result(%s)=%s\n", utl_time_str_time(time), pResultStr);
         fclose(fp);
     }
 }


### PR DESCRIPTION
add payment execution date/time in invoice.log

sample

```
----------- invoice -----------
payment_hash: 7f94b02aaabe6e9975ea178532d08dc06b16ebdbf608fa18067ee187692144a8
amount_msat: 800000
current blockcount: 1956
min_final_cltv_expiry: 9
timestamp: 2019-01-17T10:02:31Z

----------- route -----------
[0] 023cfc892387a8039d0aeee37b56b3f7a8630ff6a4c1d04adb4addb1cf04129ad3
  short_channel_id: 1955x2x0
       amount_msat: 800000
       cltv_expiry: 1965

[1] 02209a5537b10a5e72e85af9ea7fc3e61122f10dcce4fd71730dc3a6dd0bd3c874
----------- end of route -----------
  result(2019-01-17T10:02:37Z)=start payment
  result(2019-01-17T10:02:38Z)=success
```