### PR TITLE
Pr/fail after irrevocably

### DIFF
--- a/ln/ln.h
+++ b/ln/ln.h
@@ -711,6 +711,8 @@ typedef struct {
 
 
 typedef struct {
+    uint64_t                    short_channel_id;
+    uint16_t                    idx;
     uint8_t                     fin_delhtlc;
 } ln_cb_bwd_del_htlc_t;
 
@@ -1466,6 +1468,16 @@ bool ln_fulfill_htlc_set(ln_self_t *self, uint16_t Idx, const uint8_t *pPreImage
  *      - onion_routing_packetと共用のため、onion_routingは消える
  */
 bool ln_fail_htlc_set(ln_self_t *self, uint16_t Idx, const utl_buf_t *pReason);
+
+
+bool ln_fail_htlc_set_bwd(ln_self_t *self, uint16_t Idx, const utl_buf_t *pReason);
+
+
+/** update_fail_htlc転送
+ *
+ *
+ */
+void ln_del_htlc_start_bwd(ln_self_t *self, uint16_t Idx);
 
 
 /** update_feeメッセージ作成

--- a/ln/ln_local.h
+++ b/ln/ln_local.h
@@ -147,7 +147,7 @@
 
 
 /** @def    LN_HTLC_ENABLE_LOCAL_DELHTLC_OFFER(htlc)
- *  @brief  
+ *  @brief
  *    - commitment_signed受信時、local commit_tx作成に含む
  */
 #define LN_HTLC_ENABLE_LOCAL_DELHTLC_OFFER(htlc)    \
@@ -225,27 +225,6 @@
             ((htlc)->stat.flag.delhtlc != LN_DELHTLC_NONE) && \
             ((htlc)->stat.flag.updsend == 0) && \
             ((htlc)->stat.flag.updwait == 0))
-
-
-/** @def    LN_HTLC_IS_FULFILL(htlc)
- *  @brief  update_fulfill_htlc送信予定
- *  @note   #LN_HTLC_WILL_DELHTLC()がtrueの場合に有効
- */
-#define LN_HTLC_IS_FULFILL(htlc)    ((htlc)->stat.flag.delhtlc == LN_DELHTLC_FULFILL)
-
-
-/** @def    LN_HTLC_IS_FAIL(htlc)
- *  @brief  update_fail_htlc送信予定
- *  @note   #LN_HTLC_WILL_DELHTLC()がtrueの場合に有効
- */
-#define LN_HTLC_IS_FAIL(htlc)    ((htlc)->stat.flag.delhtlc == LN_DELHTLC_FAIL)
-
-
-/** @def    LN_HTLC_IS_MALFORMED(htlc)
- *  @brief  update_fail_malformed_htlc送信予定
- *  @note   #LN_HTLC_WILL_DELHTLC()がtrueの場合に有効
- */
-#define LN_HTLC_IS_MALFORMED(htlc)  ((htlc)->stat.flag.delhtlc == LN_DELHTLC_MALFORMED)
 
 
 /** @def    LN_HTLC_ENABLE_LOCAL_ADDHTLC_RECV(htlc)


### PR DESCRIPTION
fix #855 

`update_fail_htlc / update_fail_malformed_htlc`の転送については`revoke_and_ack`後に行う。
`update_fulfill_htlc`は、受信したらそのまま転送する。