### PR TITLE
fix: remove unuse argument

### DIFF
--- a/tests/4nodes_test/example_st4fail4c.sh
+++ b/tests/4nodes_test/example_st4fail4c.sh
@@ -14,7 +14,7 @@ echo "--------------------------------------------"
 # create invalid realm onion
 ./ptarmcli --debug 16 $PAYER_PORT
 
-./example_st4pay_r.sh $PAY_BEGIN $PAY_END $AMOUNT $1
+./example_st4pay_r.sh $PAY_BEGIN $PAY_END $AMOUNT
 
 read -p "Hit ENTER Key!" key
 


### PR DESCRIPTION
引数無しでよいテストなので、引数を削除