### PR TITLE
apt build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,13 @@ lib:
 	$(MAKE) -C btc
 	$(MAKE) -C ln
 
+apt: lib_apt default
+lib_apt:
+	$(MAKE) -C libs apt
+	$(MAKE) -C utl
+	$(MAKE) -C btc
+	$(MAKE) -C ln
+
 lib_clean:
 	$(MAKE) -C libs clean
 	$(MAKE) -C utl clean

--- a/libs/Makefile
+++ b/libs/Makefile
@@ -19,10 +19,19 @@ endif
 
 all: lib
 
-lib: mk_install mk_jsonrpc_c mk_inih mk_base58 mk_lmdb mk_mbedtls mk_boost mk_jansson mk_zlib mk_curl
+lib: mk_install mk_libev mk_jsonrpc_c mk_inih mk_base58 mk_lmdb mk_mbedtls mk_boost mk_jansson mk_zlib mk_curl
 
 apt: git_update mk_install mk_jsonrpc_c mk_inih mk_base58 mk_mbedtls
-	sudo apt install libboost-dev libjansson-dev libz-dev libcurl4-openssl-dev libev-dev liblmdb-dev
+	sudo apt install -y \
+			libboost-dev=1.65.1.0ubuntu1 \
+			libjansson-dev=2.11-1 \
+			zlib1g-dev=1:1.2.11.dfsg-0ubuntu2 \
+			libcurl4-openssl-dev=7.58.0-2ubuntu3.5 \
+			libev-dev=1:4.22-1 \
+			liblmdb-dev=0.9.21-1
+
+apt_remove:
+	sudo apt remove libboost-dev libjansson-dev zlib1g-dev libcurl4-openssl-dev libev-dev liblmdb-dev
 
 git_update:
 	git submodule update --init inih
@@ -36,13 +45,15 @@ mk_install:
 	@mkdir -p $(INSTALL_DIR)/lib
 	@mkdir -p $(INSTALL_DIR)/boost
 
-mk_jsonrpc_c:
+mk_libev:
 	cd libev; \
 	autoreconf -i ;\
 	./configure --prefix=$(INSTALL_DIR) --host=$(HOST) CC=$(GNU_PREFIX)gcc CFLAGS="$(ADD_CFLAGS)" --disable-shared ; \
 	$(MAKE) ; \
 	$(MAKE) install ; \
 	cd ..
+
+mk_jsonrpc_c:
 	cd jsonrpc-c; \
 	autoreconf -i ; \
 	./configure --prefix=$(INSTALL_DIR) --host=$(HOST) CC=$(GNU_PREFIX)gcc --with-libev=$(INSTALL_DIR) --disable-shared ; \

--- a/libs/Makefile
+++ b/libs/Makefile
@@ -21,6 +21,17 @@ all: lib
 
 lib: mk_install mk_jsonrpc_c mk_inih mk_base58 mk_lmdb mk_mbedtls mk_boost mk_jansson mk_zlib mk_curl
 
+apt: git_update mk_install mk_jsonrpc_c mk_inih mk_base58 mk_lmdb mk_mbedtls
+	sudo apt install libboost-dev libjansson-dev libz-dev libcurl4-openssl-dev
+
+git_update:
+	git submodule update --init inih
+	git submodule update --init jsonrpc-c
+	git submodule update --init libbase58
+	git submodule update --init libev
+	git submodule update --init lmdb
+	git submodule update --init mbedtls
+
 mk_install:
 	@mkdir -p $(INSTALL_DIR)
 	@mkdir -p $(INSTALL_DIR)/include

--- a/libs/Makefile
+++ b/libs/Makefile
@@ -21,15 +21,13 @@ all: lib
 
 lib: mk_install mk_jsonrpc_c mk_inih mk_base58 mk_lmdb mk_mbedtls mk_boost mk_jansson mk_zlib mk_curl
 
-apt: git_update mk_install mk_jsonrpc_c mk_inih mk_base58 mk_lmdb mk_mbedtls
-	sudo apt install libboost-dev libjansson-dev libz-dev libcurl4-openssl-dev
+apt: git_update mk_install mk_jsonrpc_c mk_inih mk_base58 mk_mbedtls
+	sudo apt install libboost-dev libjansson-dev libz-dev libcurl4-openssl-dev libev-dev liblmdb-dev
 
 git_update:
 	git submodule update --init inih
 	git submodule update --init jsonrpc-c
 	git submodule update --init libbase58
-	git submodule update --init libev
-	git submodule update --init lmdb
 	git submodule update --init mbedtls
 
 mk_install:

--- a/libs/Makefile
+++ b/libs/Makefile
@@ -21,7 +21,9 @@ all: lib
 
 lib: mk_install mk_libev mk_jsonrpc_c mk_inih mk_base58 mk_lmdb mk_mbedtls mk_boost mk_jansson mk_zlib mk_curl
 
-apt: git_update mk_install mk_jsonrpc_c mk_inih mk_base58 mk_mbedtls
+apt: git_update mk_install apt_install mk_jsonrpc_c mk_inih mk_base58 mk_mbedtls
+
+apt_install:
 	sudo apt install -y \
 			libboost-dev=1.65.1.0ubuntu1 \
 			libjansson-dev=2.11-1 \

--- a/update_libs.sh
+++ b/update_libs.sh
@@ -1,15 +1,5 @@
 #!/bin/sh
-
-func_upd() {
-	if [ -d $1 ]; then
-		cd $1
-		git checkout $3
-		git pull
-		cd ..
-	else
-		echo "$1" not found
-	fi
-}
+set -eu
 
 func_tag() {
 	if [ -d $1 ]; then
@@ -27,31 +17,12 @@ func_tag() {
 
 cd libs
 
-# change URL
-cd inih
-CNT=`git remote -v | grep -c nayutaco`
-if [ $CNT -ne 0 ]; then
-	git checkout master
-	git remote set-url origin https://github.com/benhoyt/inih.git
-	git fetch
-fi
-cd ..
-
-cd lmdb
-CNT=`git remote -v | grep -c nayutaco`
-if [ $CNT -ne 0 ]; then
-	git checkout mdb.master
-	git remote set-url origin https://github.com/LMDB/lmdb.git
-	git fetch
-fi
-cd ..
-
 git submodule sync
 git submodule update --init
 
-func_upd jsonrpc-c https://github.com/nayutaco/jsonrpc-c.git localonly
-func_upd libbase58 https://github.com/luke-jr/libbase58.git master
-func_upd libev https://github.com/enki/libev.git master
+func_tag jsonrpc-c https://github.com/nayutaco/jsonrpc-c.git localonly 38d15468b26b447907fbabdc061b2e08a48c3e0d
+func_tag libbase58 https://github.com/luke-jr/libbase58.git master 1cb26b5bfff6b52995a2d88a4b7e1041df589d35
+func_tag libev https://github.com/enki/libev.git master 93823e6ca699df195a6c7b8bfa6006ec40ee0003
 
 func_tag inih https://github.com/benhoyt/inih.git master refs/tags/r42
 func_tag lmdb https://github.com/LMDB/lmdb.git mdb.master refs/tags/LMDB_0.9.23


### PR DESCRIPTION
add `make apt`.

ライブラリの大半をgitから取得するようにしているが、その理由はRaspberry Piなどの遅い端末でビルドするのがつらいため、クロスコンパイルすることを考えていたからだった。
しかし、当面の使い方からすると、クロスコンパイルすることはないんじゃなかろうかと考えるようになってきた。
フルノードが動いている状況だとまた違ったかもしれないが、SPVで運用するとなるとセルフビルドするくらいの余力はある(ものすごく遅いが)。

というわけで、仮で`apt install`するmake optionを追加した。
格好は悪いが、中で`sudo`させている。
READMEに書いている内容には影響しないので、こっそり試そうと思う。
MbedTLSはgitから取得しているが、これはChaCha20が使える後のLTS版がaptになさそうだったからだ。