### PR TITLE
fix: crash if disconnect before noise handshake

### DIFF
--- a/ln/ln.c
+++ b/ln/ln.c
@@ -1636,8 +1636,6 @@ static void channel_clear(ln_self_t *self)
     self->anno_flag = 0;
     self->shutdown_flag = 0;
 
-    ln_handshake_free(self);
-
     ln_establish_free(self);
 }
 


### PR DESCRIPTION
socket接続後、noise protocol handshakeの手前でエラーになった場合、`ln_term()`呼び出しによって未設定のnoise handshake用メモリを解放しようとしてしまう。

メモリの確保は`ln_handshake_start()`で行われ、handshakeの直前に呼び出され、`malloc()`は無条件で行われている。
そしてhandshakeの終了時にエラーであっても`ln_handshake_free()`で解放されるため、ここは削除しても大丈夫なはず。