### PR TITLE
gossip_query: create message

### DIFF
--- a/ln/ln.c
+++ b/ln/ln.c
@@ -154,7 +154,12 @@ static const struct {
     { MSGTYPE_CHANNEL_ANNOUNCEMENT,         ln_channel_announcement_recv },
     { MSGTYPE_NODE_ANNOUNCEMENT,            ln_node_announcement_recv },
     { MSGTYPE_CHANNEL_UPDATE,               ln_channel_update_recv },
-    { MSGTYPE_ANNOUNCEMENT_SIGNATURES,      ln_announcement_signatures_recv }
+    { MSGTYPE_ANNOUNCEMENT_SIGNATURES,      ln_announcement_signatures_recv },
+    { MSGTYPE_QUERY_SHORT_CHANNEL_IDS,      ln_query_short_channel_ids_recv },
+    { MSGTYPE_REPLY_SHORT_CHANNEL_IDS_END,  ln_reply_short_channel_ids_end_recv },
+    { MSGTYPE_QUERY_CHANNEL_RANGE,          ln_query_channel_range_recv },
+    { MSGTYPE_REPLY_CHANNEL_RANGE,          ln_reply_channel_range_recv },
+    { MSGTYPE_GOSSIP_TIMESTAMP_FILTER,      ln_gossip_timestamp_filter_recv }
 };
 
 

--- a/ln/ln_anno.c
+++ b/ln/ln_anno.c
@@ -383,6 +383,109 @@ bool ln_channel_update_disable(ln_self_t *self)
 }
 
 
+bool ln_query_short_channel_ids_send(ln_self_t *self)
+{
+    (void)self;
+    return false;
+}
+
+
+bool HIDDEN ln_query_short_channel_ids_recv(ln_self_t *self, const uint8_t *pData, uint16_t Len)
+{
+    (void)self;
+    ln_msg_query_short_channel_ids_t msg;
+    ln_msg_query_short_channel_ids_read(&msg, pData, Len);
+    return true;
+}
+
+
+bool ln_reply_short_channel_ids_recv_send(ln_self_t *self)
+{
+    (void)self;
+    return false;
+}
+
+
+bool HIDDEN ln_reply_short_channel_ids_end_recv(ln_self_t *self, const uint8_t *pData, uint16_t Len)
+{
+    (void)self;
+    ln_msg_reply_short_channel_ids_end_t msg;
+    ln_msg_reply_short_channel_ids_end_read(&msg, pData, Len);
+    return true;
+}
+
+
+bool ln_query_channel_range_send(ln_self_t *self)
+{
+    ln_msg_query_channel_range_t msg;
+    msg.p_chain_hash = ln_genesishash_get();
+    msg.first_blocknum = 0;
+    msg.number_of_blocks = 0xffffffff;
+    utl_buf_t buf = UTL_BUF_INIT;
+    if(!ln_msg_query_channel_range_write(&buf, &msg)) {
+        LOGE("fail: create query_channel_range\n");
+        return false;
+    }
+    ln_callback(self, LN_CB_SEND_REQ, &buf);
+    utl_buf_free(&buf);
+    return true;
+}
+
+
+bool HIDDEN ln_query_channel_range_recv(ln_self_t *self, const uint8_t *pData, uint16_t Len)
+{
+    (void)self;
+    ln_msg_query_channel_range_t msg;
+    ln_msg_query_channel_range_read(&msg, pData, Len);
+    return true;
+}
+
+
+bool ln_reply_channel_range_send(ln_self_t *self)
+{
+    (void)self;
+    return false;
+}
+
+
+bool HIDDEN ln_reply_channel_range_recv(ln_self_t *self, const uint8_t *pData, uint16_t Len)
+{
+    (void)self;
+    ln_msg_reply_channel_range_t msg;
+    bool ret = ln_msg_reply_channel_range_read(&msg, pData, Len);
+    if (ret) {
+        uint64_t *p_short_ids = NULL;
+        size_t ids = 0;
+        char str_sci[LN_SZ_SHORTCHANNELID_STR + 1];
+        ret = ln_msg_gossip_ids_decode(&p_short_ids, &ids, msg.p_encoded_short_ids, msg.len);
+        if (ret) {
+            for (size_t lp = 0; lp < ids; lp++) {
+                ln_short_channel_id_string(str_sci, p_short_ids[lp]);
+                LOGD("[%ld]%s\n", lp, str_sci);
+            }
+            UTL_DBG_FREE(p_short_ids);
+        }
+    }
+    return true;
+}
+
+
+bool ln_gossip_timestamp_filter_send(ln_self_t *self)
+{
+    (void)self;
+    return false;
+}
+
+
+bool HIDDEN ln_gossip_timestamp_filter_recv(ln_self_t *self, const uint8_t *pData, uint16_t Len)
+{
+    (void)self;
+    ln_msg_gossip_timestamp_filter_t msg;
+    ln_msg_gossip_timestamp_filter_read(&msg, pData, Len);
+    return true;
+}
+
+
 /********************************************************************
  * private functions
  ********************************************************************/

--- a/ln/ln_anno.h
+++ b/ln/ln_anno.h
@@ -46,5 +46,15 @@ bool /*HIDDEN*/ ln_channel_update_send(ln_self_t *self);
 bool HIDDEN ln_channel_update_recv(ln_self_t *self, const uint8_t *pData, uint16_t Len);
 bool ln_channel_update_disable(ln_self_t *self);
 
+bool ln_query_short_channel_ids_send(ln_self_t *self);
+bool HIDDEN ln_query_short_channel_ids_recv(ln_self_t *self, const uint8_t *pData, uint16_t Len);
+bool ln_reply_short_channel_ids_recv_send(ln_self_t *self);
+bool HIDDEN ln_reply_short_channel_ids_end_recv(ln_self_t *self, const uint8_t *pData, uint16_t Len);
+bool ln_query_channel_range_send(ln_self_t *self);
+bool HIDDEN ln_query_channel_range_recv(ln_self_t *self, const uint8_t *pData, uint16_t Len);
+bool ln_reply_channel_range_send(ln_self_t *self);
+bool HIDDEN ln_reply_channel_range_recv(ln_self_t *self, const uint8_t *pData, uint16_t Len);
+bool ln_gossip_timestamp_filter_send(ln_self_t *self);
+bool HIDDEN ln_gossip_timestamp_filter_recv(ln_self_t *self, const uint8_t *pData, uint16_t Len);
 
 #endif /* LN_ANNO_H__ */

--- a/ln/ln_msg.c
+++ b/ln/ln_msg.c
@@ -65,6 +65,11 @@ const char *ln_msg_name(uint16_t Type)
         { 0x0101, "node_announcement" },
         { 0x0102, "channel_update" },
         { 0x0103, "announcement_signatures" },
+        { 0x0105, "query_short_channel_ids" },
+        { 0x0106, "reply_short_channel_ids_end" },
+        { 0x0107, "query_channel_range" },
+        { 0x0108, "reply_channel_range" },
+        { 0x0109, "gossip_timestamp_filter" },
     };
     for (size_t lp = 0; lp < ARRAY_SIZE(MESSAGE); lp++) {
         if (Type == MESSAGE[lp].type) {

--- a/ln/ln_msg.h
+++ b/ln/ln_msg.h
@@ -62,6 +62,11 @@
 #define MSGTYPE_NODE_ANNOUNCEMENT           ((uint16_t)0x0101)
 #define MSGTYPE_CHANNEL_UPDATE              ((uint16_t)0x0102)
 #define MSGTYPE_ANNOUNCEMENT_SIGNATURES     ((uint16_t)0x0103)
+#define MSGTYPE_QUERY_SHORT_CHANNEL_IDS     ((uint16_t)0x0105)
+#define MSGTYPE_REPLY_SHORT_CHANNEL_IDS_END ((uint16_t)0x0106)
+#define MSGTYPE_QUERY_CHANNEL_RANGE         ((uint16_t)0x0107)
+#define MSGTYPE_REPLY_CHANNEL_RANGE         ((uint16_t)0x0108)
+#define MSGTYPE_GOSSIP_TIMESTAMP_FILTER     ((uint16_t)0x0109)
 
 
 /**************************************************************************

--- a/ln/ln_msg_anno.h
+++ b/ln/ln_msg_anno.h
@@ -200,6 +200,90 @@ typedef struct {
 } ln_msg_channel_update_t;
 
 
+/** @struct     ln_msg_query_short_channel_ids_t
+ *  @brief      query_short_channel_ids
+ */
+typedef struct ln_msg_query_short_channel_ids_t {
+    //1. type: 261 (`query_short_channel_ids`) (`gossip_queries`)
+    //2. data:
+    //    * [`32`:`chain_hash`]
+    //    * [`2`:`len`]
+    //    * [`len`:`encoded_short_ids`]
+
+    const uint8_t *p_chain_hash;
+    uint16_t len;
+    const uint8_t *p_encoded_short_ids;
+} ln_msg_query_short_channel_ids_t;
+
+
+/** @struct     ln_msg_reply_short_channel_ids_end_t
+ *  @brief      reply_short_channel_ids_end
+ */
+typedef struct ln_msg_reply_short_channel_ids_end_t {
+    //1. type: 262 (`reply_short_channel_ids_end`) (`gossip_queries`)
+    //2. data:
+    //    * [`32`:`chain_hash`]
+    //    * [`1`:`complete`]
+
+    const uint8_t *p_chain_hash;
+    uint8_t complete;
+} ln_msg_reply_short_channel_ids_end_t;
+
+
+/** @struct     ln_msg_query_channel_range_t
+ *  @brief      query_channel_range
+ */
+typedef struct ln_msg_query_channel_range_t {
+    //1. type: 263 (`query_channel_range`) (`gossip_queries`)
+    //2. data:
+    //    * [`32`:`chain_hash`]
+    //    * [`4`:`first_blocknum`]
+    //    * [`4`:`number_of_blocks`]
+
+    const uint8_t *p_chain_hash;
+    uint32_t first_blocknum;
+    uint32_t number_of_blocks;
+} ln_msg_query_channel_range_t;
+
+
+/** @struct     ln_msg_reply_channel_range_t
+ *  @brief      reply_channel_range
+ */
+typedef struct ln_msg_reply_channel_range_t {
+    //1. type: 264 (`reply_channel_range`) (`gossip_queries`)
+    //2. data:
+    //    * [`32`:`chain_hash`]
+    //    * [`4`:`first_blocknum`]
+    //    * [`4`:`number_of_blocks`]
+    //    * [`1`:`complete`]
+    //    * [`2`:`len`]
+    //    * [`len`:`encoded_short_ids`]
+
+    const uint8_t *p_chain_hash;
+    uint32_t first_blocknum;
+    uint32_t number_of_blocks;
+    uint8_t complete;
+    uint16_t len;
+    const uint8_t *p_encoded_short_ids;
+} ln_msg_reply_channel_range_t;
+
+
+/** @struct     ln_msg_gossip_timestamp_filter_t
+ *  @brief      gossip_timestamp_filter
+ */
+typedef struct ln_msg_gossip_timestamp_filter_t {
+    //1. type: 265 (`gossip_timestamp_filter`) (`gossip_queries`)
+    //2. data:
+    //    * [`32`:`chain_hash`]
+    //    * [`4`:`first_timestamp`]
+    //    * [`4`:`timestamp_range`]
+
+    const uint8_t *p_chain_hash;
+    uint32_t first_timestamp;
+    uint32_t timestamp_range;
+} ln_msg_gossip_timestamp_filter_t;
+
+
 /**************************************************************************
  * const variables
  **************************************************************************/
@@ -314,11 +398,11 @@ bool HIDDEN ln_msg_node_announcement_print_2(const uint8_t *pData, uint16_t Len)
 
 
 //XXX:
-bool HIDDEN ln_msg_node_announcement_addresses_write(utl_buf_t *pBuf, const ln_msg_node_announcement_addresses_t *pAddrs); 
+bool HIDDEN ln_msg_node_announcement_addresses_write(utl_buf_t *pBuf, const ln_msg_node_announcement_addresses_t *pAddrs);
 
 
 //XXX:
-bool /*HIDDEN*/ ln_msg_node_announcement_addresses_read(ln_msg_node_announcement_addresses_t *pAddrs, const uint8_t *pData, uint16_t Len); 
+bool /*HIDDEN*/ ln_msg_node_announcement_addresses_read(ln_msg_node_announcement_addresses_t *pAddrs, const uint8_t *pData, uint16_t Len);
 
 
 /** sign node_announcement
@@ -327,7 +411,7 @@ bool /*HIDDEN*/ ln_msg_node_announcement_addresses_read(ln_msg_node_announcement
 bool HIDDEN ln_msg_node_announcement_sign(uint8_t *pData, uint16_t Len);
 
 
-/** vefiry node_announcement
+/** verify node_announcement
  *
  */
 bool HIDDEN ln_msg_node_announcement_verify(const ln_msg_node_announcement_t *pMsg, const uint8_t *pData, uint16_t Len);
@@ -373,5 +457,77 @@ bool HIDDEN ln_msg_channel_update_verify(const uint8_t *pNodePubKey, const uint8
  */
 bool HIDDEN ln_msg_channel_update_print(const uint8_t *pData, uint16_t Len);
 
+
+/** write query_short_channel_ids
+ *
+ */
+bool HIDDEN ln_msg_query_short_channel_ids_write(utl_buf_t *pBuf, const ln_msg_query_short_channel_ids_t *pMsg);
+
+
+/** read query_short_channel_ids
+ *
+ */
+bool HIDDEN ln_msg_query_short_channel_ids_read(ln_msg_query_short_channel_ids_t *pMsg, const uint8_t *pData, uint16_t Len);
+
+
+/** write reply_short_channel_ids_end
+ *
+ */
+bool HIDDEN ln_msg_reply_short_channel_ids_end_write(utl_buf_t *pBuf, const ln_msg_reply_short_channel_ids_end_t *pMsg);
+
+
+/** write reply_short_channel_ids_end
+ *
+ */
+bool HIDDEN ln_msg_reply_short_channel_ids_end_read(ln_msg_reply_short_channel_ids_end_t *pMsg, const uint8_t *pData, uint16_t Len);
+
+
+/** write query_channel_range
+ *
+ */
+bool HIDDEN ln_msg_query_channel_range_write(utl_buf_t *pBuf, const ln_msg_query_channel_range_t *pMsg);
+
+
+/** write query_channel_range
+ *
+ */
+bool HIDDEN ln_msg_query_channel_range_read(ln_msg_query_channel_range_t *pMsg, const uint8_t *pData, uint16_t Len);
+
+
+/** write reply_channel_range
+ *
+ */
+bool HIDDEN ln_msg_reply_channel_range_write(utl_buf_t *pBuf, const ln_msg_reply_channel_range_t *pMsg);
+
+
+/** write reply_channel_range
+ *
+ */
+bool HIDDEN ln_msg_reply_channel_range_read(ln_msg_reply_channel_range_t *pMsg, const uint8_t *pData, uint16_t Len);
+
+
+/** write gossip_timestamp_filter
+ *
+ */
+bool HIDDEN ln_msg_gossip_timestamp_filter_write(utl_buf_t *pBuf, const ln_msg_gossip_timestamp_filter_t *pMsg);
+
+
+/** write gossip_timestamp_filter
+ *
+ */
+bool HIDDEN ln_msg_gossip_timestamp_filter_read(ln_msg_gossip_timestamp_filter_t *pMsg, const uint8_t *pData, uint16_t Len);
+
+
+/** decode encoded_short_ids
+ *
+ * @param[out]     ppShortChannelIds       decoded short_channel_id (free() after used)
+ * @param[out]     pSz                     num of ppShortChannelIds
+ * @param[in]      pData                   encoded_short_ids
+ * @param[in]      Len                     pData length
+ * @retval      true    success
+ * @attention
+ *      - ppShortChannelIds is allocated by this function.
+ */
+bool HIDDEN ln_msg_gossip_ids_decode(uint64_t **ppShortChannelIds, size_t *pSz, const uint8_t *pData, size_t Len);
 
 #endif /* LN_MSG_ANNO_H__ */

--- a/ln/tests/test_ln_msg_anno_gossip.cpp
+++ b/ln/tests/test_ln_msg_anno_gossip.cpp
@@ -1,0 +1,228 @@
+#include "gtest/gtest.h"
+#include <string.h>
+#include "tests/fff.h"
+DEFINE_FFF_GLOBALS;
+
+
+extern "C" {
+#include "../../utl/utl_log.c"
+#undef LOG_TAG
+#include "../../utl/utl_dbg.c"
+#include "../../utl/utl_buf.c"
+#include "../../utl/utl_push.c"
+#include "../../utl/utl_time.c"
+#include "../../utl/utl_int.c"
+#include "../../utl/utl_str.c"
+
+#undef LOG_TAG
+#include "../../btc/btc.c"
+#include "../../btc/btc_buf.c"
+// #include "../../btc/btc_extkey.c"
+// #include "../../btc/btc_keys.c"
+// #include "../../btc/btc_sw.c"
+//#include "../../btc/btc_sig.c"
+// #include "../../btc/btc_script.c"
+// #include "../../btc/btc_tx.c"
+// #include "../../btc/btc_tx_buf.c"
+#include "../../btc/btc_crypto.c"
+// #include "../../btc/segwit_addr.c"
+// #include "../../btc/btc_segwit_addr.c"
+// #include "../../btc/btc_test_util.c"
+
+#undef LOG_TAG
+#include "ln_msg_anno.c"
+#include "ln_misc.c"
+//#include "ln_node.c"
+#include "ln.c"
+}
+
+////////////////////////////////////////////////////////////////////////
+//FAKE関数
+
+////////////////////////////////////////////////////////////////////////
+
+namespace LN_DUMMY {
+}
+
+
+////////////////////////////////////////////////////////////////////////
+
+class ln: public testing::Test {
+protected:
+    virtual void SetUp() {
+        //utl_log_init_stderr();
+        utl_dbg_malloc_cnt_reset();
+    }
+
+    virtual void TearDown() {
+        ASSERT_EQ(0, utl_dbg_malloc_cnt());
+    }
+
+public:
+    static void DumpBin(const uint8_t *pData, uint16_t Len)
+    {
+        for (uint16_t lp = 0; lp < Len; lp++) {
+            printf("%02x", pData[lp]);
+        }
+        printf("\n");
+    }
+    static bool DumpCheck(const void *pData, uint32_t Len, uint8_t Fill)
+    {
+        bool ret = true;
+        const uint8_t *p = (const uint8_t *)pData;
+        for (uint32_t lp = 0; lp < Len; lp++) {
+            if (p[lp] != Fill) {
+                ret = false;
+                break;
+            }
+        }
+        return ret;
+    }
+};
+
+////////////////////////////////////////////////////////////////////////
+TEST_F(ln, query_short_channel_ids_write_ok)
+{
+    ln_msg_query_short_channel_ids_t msg;
+    utl_buf_t buf = UTL_BUF_INIT;
+
+    const uint8_t ENCODED_SHORT_IDS[16] = {
+        20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35
+    };
+    const uint8_t CHAIN_HASH[32] = {
+        0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
+        255, 254, 253, 252, 251, 250, 249, 248, 247, 246, 245, 244, 243, 242, 241, 240,
+    };
+
+    const uint8_t MSG[] = {
+        0x01, 0x05,
+        //
+        0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
+        255, 254, 253, 252, 251, 250, 249, 248, 247, 246, 245, 244, 243, 242, 241, 240,
+        //
+        0x00, 0x10,
+        20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35
+    };
+
+    msg.p_chain_hash = CHAIN_HASH;
+    msg.len = 16;
+    msg.p_encoded_short_ids = ENCODED_SHORT_IDS;
+    bool ret = ln_msg_query_short_channel_ids_write(&buf, &msg);
+    ASSERT_TRUE(ret);
+    ASSERT_EQ(sizeof(MSG), buf.len);
+    ASSERT_EQ(0, memcmp(MSG, buf.buf, sizeof(MSG)));
+    utl_buf_free(&buf);
+}
+
+
+TEST_F(ln, query_short_channel_ids_read_ok1)
+{
+    ln_msg_query_short_channel_ids_t msg;
+    utl_buf_t buf = UTL_BUF_INIT;
+
+    const uint8_t ENCODED_SHORT_IDS[16] = {
+        20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35
+    };
+    const uint8_t CHAIN_HASH[32] = {
+        0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
+        255, 254, 253, 252, 251, 250, 249, 248, 247, 246, 245, 244, 243, 242, 241, 240,
+    };
+
+    const uint8_t MSG[] = {
+        0x01, 0x05,
+        //
+        0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
+        255, 254, 253, 252, 251, 250, 249, 248, 247, 246, 245, 244, 243, 242, 241, 240,
+        //
+        0x00, 0x10,
+        20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35
+    };
+
+    memset(&msg, 0xcc, sizeof(msg));
+    bool ret = ln_msg_query_short_channel_ids_read(&msg, MSG, sizeof(MSG));
+    ASSERT_TRUE(ret);
+    ASSERT_EQ(0, memcmp(CHAIN_HASH, msg.p_chain_hash, sizeof(CHAIN_HASH)));
+    ASSERT_EQ(MSG + 2, msg.p_chain_hash);
+    ASSERT_EQ(MSG + 2 + 32 + 2, msg.p_encoded_short_ids);
+    ASSERT_EQ(16, msg.len);
+    ASSERT_EQ(0, memcmp(ENCODED_SHORT_IDS, msg.p_encoded_short_ids, sizeof(ENCODED_SHORT_IDS)));
+    utl_buf_free(&buf);
+}
+
+
+TEST_F(ln, query_short_channel_ids_read_ok2)
+{
+    ln_msg_query_short_channel_ids_t msg;
+    utl_buf_t buf = UTL_BUF_INIT;
+
+    const uint8_t ENCODED_SHORT_IDS[16] = {
+        20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35
+    };
+    const uint8_t CHAIN_HASH[32] = {
+        0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
+        255, 254, 253, 252, 251, 250, 249, 248, 247, 246, 245, 244, 243, 242, 241, 240,
+    };
+
+    const uint8_t MSG[] = {
+        0x01, 0x05,
+        //
+        0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
+        255, 254, 253, 252, 251, 250, 249, 248, 247, 246, 245, 244, 243, 242, 241, 240,
+        //
+        0x00, 0x10,
+        20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35,
+        //dust
+        1, 2, 3, 4, 5       //後ろに長くても大丈夫
+    };
+
+    memset(&msg, 0xcc, sizeof(msg));
+    bool ret = ln_msg_query_short_channel_ids_read(&msg, MSG, sizeof(MSG));
+    ASSERT_TRUE(ret);
+    ASSERT_EQ(0, memcmp(CHAIN_HASH, msg.p_chain_hash, sizeof(CHAIN_HASH)));
+    ASSERT_EQ(0, memcmp(ENCODED_SHORT_IDS, msg.p_encoded_short_ids, sizeof(ENCODED_SHORT_IDS)));
+    utl_buf_free(&buf);
+}
+
+
+TEST_F(ln, query_short_channel_ids_read_len)
+{
+    ln_msg_query_short_channel_ids_t msg;
+    utl_buf_t buf = UTL_BUF_INIT;
+
+    const uint8_t MSG[] = {
+        0x01, 0x05,
+        //
+        0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
+        255, 254, 253, 252, 251, 250, 249, 248, 247, 246, 245, 244, 243, 242, 241, 240,
+        //
+        0x00, 0x10,
+        20, 21, 22, 23, 24, 25, 26, 27, 28, 29, //30, 31, 32, 33, 34, 35,   //★短い
+    };
+
+    memset(&msg, 0xcc, sizeof(msg));
+    bool ret = ln_msg_query_short_channel_ids_read(&msg, MSG, sizeof(MSG));
+    ASSERT_FALSE(ret);
+    utl_buf_free(&buf);
+}
+
+
+TEST_F(ln, query_short_channel_ids_read_type)
+{
+    ln_msg_query_short_channel_ids_t msg;
+    utl_buf_t buf = UTL_BUF_INIT;
+
+    const uint8_t MSG[] = {
+        0x01, 0x05 + 1,     //★type違う
+        //
+        0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
+        255, 254, 253, 252, 251, 250, 249, 248, 247, 246, 245, 244, 243, 242, 241, 240,
+        //
+        0x00, 0x10,
+        20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35,
+    };
+
+    memset(&msg, 0xcc, sizeof(msg));
+    bool ret = ln_msg_query_short_channel_ids_read(&msg, MSG, sizeof(MSG));
+    ASSERT_FALSE(ret);
+    utl_buf_free(&buf);
+}

--- a/ptarmd/Makefile
+++ b/ptarmd/Makefile
@@ -108,13 +108,13 @@ LDFLAGS += -pthread
 
 #Link Library
 LIBS += -L$(COMMON_PATH)/libs/install/lib
+LIBS += -L$(COMMON_PATH)/ln -lln
+LIBS += -L$(COMMON_PATH)/btc -lbtc
+LIBS += -L$(COMMON_PATH)/utl -lutl
 LIBS += -ljansson
 LIBS += -lcurl -lrt -lz
 LIBS += -ljsonrpcc -lev -lm
 LIBS += -linih
-LIBS += -L$(COMMON_PATH)/ln -lln
-LIBS += -L$(COMMON_PATH)/btc -lbtc
-LIBS += -L$(COMMON_PATH)/utl -lutl
 LIBS += -llmdb -lbase58 -lmbedcrypto
 LIBS += -lstdc++
 

--- a/routing/Makefile
+++ b/routing/Makefile
@@ -7,7 +7,7 @@ CC              := "$(GNU_PREFIX)gcc"
 
 CFLAGS  += --std=c99 -I../utl -I../btc -I../ln -I../ptarmd -I../libs/install/include
 LDFLAGS += -L../libs/install/lib -L../ln -L../btc -L../utl
-LDFLAGS += -pthread -lln -lbtc -lutl -llmdb -lbase58 -lmbedcrypto -lstdc++
+LDFLAGS += -pthread -lln -lbtc -lutl -llmdb -lbase58 -lmbedcrypto -lz -lstdc++
 
 all: routing
 

--- a/showdb/Makefile
+++ b/showdb/Makefile
@@ -7,7 +7,7 @@ CC              := "$(GNU_PREFIX)gcc"
 
 CFLAGS  += --std=c99 -I../utl -I../btc -I../ln -I../ptarmd -I../libs/install/include
 LDFLAGS += -L../libs/install/lib -L../ln -L../btc -L../utl
-LDFLAGS += -pthread -lln -lbtc -lutl -llmdb -lbase58 -lmbedcrypto -lstdc++
+LDFLAGS += -pthread -lln -lbtc -lutl -llmdb -lbase58 -lmbedcrypto -lz -lstdc++
 
 all: showdb
 


### PR DESCRIPTION
gossip_queryのencode/decodeのみ追加。
`init.localfeatures`のgossip_queryフラグは立てていないし、送信もしていない。