### PR TITLE
ptarmd: starting node connect list

### DIFF
--- a/ln/ln_node.h
+++ b/ln/ln_node.h
@@ -53,8 +53,18 @@ typedef struct {
     btc_keys_t          keys;                           ///< node鍵
     uint8_t             features;                       ///< localfeatures
     char                alias[LN_SZ_ALIAS_STR + 1];     ///< ノード名(\0 terminate)
-    ln_node_addr_t       addr;                           ///< ノードアドレス
+    ln_node_addr_t      addr;                           ///< ノードアドレス
 } ln_node_t;
+
+
+/** @struct ln_node_conn_t
+ *  @brief  node connection info
+ */
+typedef struct {
+    uint8_t             node_id[BTC_SZ_PUBKEY];
+    char                addr[LN_ADDR_DESC_ADDR_LEN_MAX];
+    uint16_t            port;
+} ln_node_conn_t;
 
 
 /********************************************************************
@@ -88,5 +98,14 @@ bool HIDDEN ln_node_sign_nodekey(uint8_t *pRS, const uint8_t *pHash);
  * @retval  true    検索成功 
  */
 bool HIDDEN ln_node_search_node_id(uint8_t *pNodeId, uint64_t ShortChannelId);
+
+
+/** decode node connection string
+ * 
+ * @param[out]  pNodeConn       decoded info
+ * @param[in]   pConnStr        connection string(<NODE_ID>@<IPADDR>:<PORT>)
+ * @retval  true    success
+ */
+bool ln_node_addr_dec(ln_node_conn_t *pNodeConn, const char *pConnStr);
 
 #endif /* LN_NODE_H__ */

--- a/ln/tests/Makefile
+++ b/ln/tests/Makefile
@@ -13,6 +13,7 @@ TEST_TARGET_SRC += \
 	test_ln_bolt.cpp \
 	test_ln_htlcflag.cpp \
 	test_ln.cpp \
+	test_ln_node.cpp \
 	test_ln_proto_init.cpp \
 	test_ln_proto_openchannel.cpp \
 	test_ln_proto_acceptchannel.cpp \

--- a/ln/tests/test_ln_node.cpp
+++ b/ln/tests/test_ln_node.cpp
@@ -1,0 +1,244 @@
+#include "gtest/gtest.h"
+#include <string.h>
+#include "tests/fff.h"
+DEFINE_FFF_GLOBALS;
+
+
+extern "C" {
+// #undef LOG_TAG
+// #include "../../utl/utl_thread.c"
+#undef LOG_TAG
+#include "../../utl/utl_log.c"
+#undef LOG_TAG
+#include "../../utl/utl_dbg.c"
+#include "../../utl/utl_buf.c"
+// #include "../../utl/utl_push.c"
+#include "../../utl/utl_time.c"
+// #include "../../utl/utl_int.c"
+#include "../../utl/utl_str.c"
+#include "../../utl/utl_addr.c"
+#include "../../utl/utl_net.c"
+#undef LOG_TAG
+#include "../../btc/btc.c"
+#include "../../btc/btc_buf.c"
+// #include "../../btc/btc_extkey.c"
+#include "../../btc/btc_keys.c"
+// #include "../../btc/btc_sw.c"
+// #include "../../btc/btc_sig.c"
+// #include "../../btc/btc_script.c"
+// #include "../../btc/btc_tx.c"
+// #include "../../btc/btc_tx_buf.c"
+#include "../../btc/btc_crypto.c"
+// #include "../../btc/segwit_addr.c"
+// #include "../../btc/btc_segwit_addr.c"
+// #include "../../btc/btc_test_util.c"
+
+#undef LOG_TAG
+#include "ln_node.c"
+}
+
+////////////////////////////////////////////////////////////////////////
+//FAKE関数
+
+
+////////////////////////////////////////////////////////////////////////
+
+class ln: public testing::Test {
+protected:
+    virtual void SetUp() {
+        //utl_log_init_stderr();
+        utl_dbg_malloc_cnt_reset();
+        btc_init(BTC_TESTNET, true);
+    }
+
+    virtual void TearDown() {
+        ln_node_term();
+        btc_term();
+        ASSERT_EQ(0, utl_dbg_malloc_cnt());
+    }
+
+public:
+    static void DumpBin(const uint8_t *pData, uint16_t Len)
+    {
+        for (uint16_t lp = 0; lp < Len; lp++) {
+            printf("%02x", pData[lp]);
+        }
+        printf("\n");
+    }
+    static bool DumpCheck(const void *pData, uint32_t Len, uint8_t Fill)
+    {
+        bool ret = true;
+        const uint8_t *p = (const uint8_t *)pData;
+        for (uint32_t lp = 0; lp < Len; lp++) {
+            if (p[lp] != Fill) {
+                ret = false;
+                break;
+            }
+        }
+        return ret;
+    }
+};
+
+
+////////////////////////////////////////////////////////////////////////
+
+TEST_F(ln, ln_node_addr_dec_ok1)
+{
+    const char CONN_STR[] = "03694d1090cbaef885bcdf56ce47e78b62e130b929107d32f501b1628c4e01bd53@1.1.1.1:1";
+    const uint8_t CONN_NODE[] = {
+        0x03, 0x69, 0x4d, 0x10, 0x90, 0xcb, 0xae, 0xf8, 0x85, 0xbc, 0xdf, 0x56, 0xce, 0x47, 0xe7, 0x8b,
+        0x62, 0xe1, 0x30, 0xb9, 0x29, 0x10, 0x7d, 0x32, 0xf5, 0x01, 0xb1, 0x62, 0x8c, 0x4e, 0x01, 0xbd,
+        0x53,
+    };
+
+    ln_node_conn_t conn;
+
+    memset(&conn, 0, sizeof(conn));
+    bool ret = ln_node_addr_dec(&conn, CONN_STR);
+    ASSERT_TRUE(ret);
+    ASSERT_EQ(0, memcmp(CONN_NODE, conn.node_id, BTC_SZ_PUBKEY));
+    ASSERT_STREQ("1.1.1.1", conn.addr);
+    ASSERT_EQ(1, conn.port);
+}
+
+
+TEST_F(ln, ln_node_addr_dec_ok2)
+{
+    const char CONN_STR[] = "03694d1090cbaef885bcdf56ce47e78b62e130b929107d32f501b1628c4e01bd53@223.254.254.254:65535";
+    const uint8_t CONN_NODE[] = {
+        0x03, 0x69, 0x4d, 0x10, 0x90, 0xcb, 0xae, 0xf8, 0x85, 0xbc, 0xdf, 0x56, 0xce, 0x47, 0xe7, 0x8b,
+        0x62, 0xe1, 0x30, 0xb9, 0x29, 0x10, 0x7d, 0x32, 0xf5, 0x01, 0xb1, 0x62, 0x8c, 0x4e, 0x01, 0xbd,
+        0x53,
+    };
+
+    ln_node_conn_t conn;
+
+    memset(&conn, 0, sizeof(conn));
+    bool ret = ln_node_addr_dec(&conn, CONN_STR);
+    ASSERT_TRUE(ret);
+    ASSERT_EQ(0, memcmp(CONN_NODE, conn.node_id, BTC_SZ_PUBKEY));
+    ASSERT_STREQ("223.254.254.254", conn.addr);
+    ASSERT_EQ(65535, conn.port);
+}
+
+
+TEST_F(ln, ln_node_addr_dec_ng_key)
+{
+    // "0369..." --> "0469..."
+    const char CONN_STR[] = "04694d1090cbaef885bcdf56ce47e78b62e130b929107d32f501b1628c4e01bd53@223.254.254.254:65535";
+
+    ln_node_conn_t conn;
+
+    memset(&conn, 0, sizeof(conn));
+    bool ret = ln_node_addr_dec(&conn, CONN_STR);
+    ASSERT_FALSE(ret);
+}
+
+
+TEST_F(ln, ln_node_addr_dec_ng_addr1)
+{
+    const char CONN_STR[] = "03694d1090cbaef885bcdf56ce47e78b62e130b929107d32f501b1628c4e01bd53"
+                            "@0.0.0.0:65535";
+
+    ln_node_conn_t conn;
+
+    memset(&conn, 0, sizeof(conn));
+    bool ret = ln_node_addr_dec(&conn, CONN_STR);
+    ASSERT_FALSE(ret);
+}
+
+
+TEST_F(ln, ln_node_addr_dec_ng_addr2)
+{
+    const char CONN_STR[] = "03694d1090cbaef885bcdf56ce47e78b62e130b929107d32f501b1628c4e01bd53"
+                            "@255.255.255.255:65535";
+
+    ln_node_conn_t conn;
+
+    memset(&conn, 0, sizeof(conn));
+    bool ret = ln_node_addr_dec(&conn, CONN_STR);
+    ASSERT_FALSE(ret);
+}
+
+
+TEST_F(ln, ln_node_addr_dec_ng_addr_len1)
+{
+    const char CONN_STR[] = "03694d1090cbaef885bcdf56ce47e78b62e130b929107d32f501b1628c4e01bd53"
+                            "@223.254.254:12345";
+
+    ln_node_conn_t conn;
+
+    memset(&conn, 0, sizeof(conn));
+    bool ret = ln_node_addr_dec(&conn, CONN_STR);
+    ASSERT_FALSE(ret);
+}
+
+
+TEST_F(ln, ln_node_addr_dec_ng_addr_len2)
+{
+    const char CONN_STR[] = "03694d1090cbaef885bcdf56ce47e78b62e130b929107d32f501b1628c4e01bd53"
+                            "@223.254.254.254.254:12345";
+
+    ln_node_conn_t conn;
+
+    memset(&conn, 0, sizeof(conn));
+    bool ret = ln_node_addr_dec(&conn, CONN_STR);
+    ASSERT_FALSE(ret);
+}
+
+
+TEST_F(ln, ln_node_addr_dec_ng_port1)
+{
+    const char CONN_STR[] = "03694d1090cbaef885bcdf56ce47e78b62e130b929107d32f501b1628c4e01bd53"
+                            "@223.254.254.254:0";
+
+    ln_node_conn_t conn;
+
+    memset(&conn, 0, sizeof(conn));
+    bool ret = ln_node_addr_dec(&conn, CONN_STR);
+    ASSERT_FALSE(ret);
+}
+
+
+TEST_F(ln, ln_node_addr_dec_ng_port2)
+{
+    const char CONN_STR[] = "03694d1090cbaef885bcdf56ce47e78b62e130b929107d32f501b1628c4e01bd53"
+                            "@223.254.254.254:65536";
+
+    ln_node_conn_t conn;
+
+    memset(&conn, 0, sizeof(conn));
+    bool ret = ln_node_addr_dec(&conn, CONN_STR);
+    ASSERT_FALSE(ret);
+}
+
+
+TEST_F(ln, ln_node_addr_dec_ng_len1)
+{
+    //node_id: odd length
+    const char CONN_STR[] = "03694d1090cbaef885bcdf56ce47e78b62e130b929107d32f501b1628c4e01bd5"
+                            "@223.254.254.254:12345";
+
+    ln_node_conn_t conn;
+
+    memset(&conn, 0, sizeof(conn));
+    bool ret = ln_node_addr_dec(&conn, CONN_STR);
+    ASSERT_FALSE(ret);
+}
+
+
+TEST_F(ln, ln_node_addr_dec_ng_len2)
+{
+    //node_id: 67 length
+    const char CONN_STR[] = "03694d1090cbaef885bcdf56ce47e78b62e130b929107d32f501b1628c4e01bd5344"
+                            "@223.254.254.254:12345";
+
+    ln_node_conn_t conn;
+
+    memset(&conn, 0, sizeof(conn));
+    bool ret = ln_node_addr_dec(&conn, CONN_STR);
+    ASSERT_FALSE(ret);
+}
+
+
+////////////////////////////////////////////////////////////////////////

--- a/ptarmcli/ptarmcli.c
+++ b/ptarmcli/ptarmcli.c
@@ -344,16 +344,12 @@ static void optfunc_conn_param(int *pOption, bool *pConn)
         utl_str_bin2str(mPeerNodeId, peer.node_id, BTC_SZ_PUBKEY);
         *pOption = M_OPTIONS_CONN;
     } else if (optlen >= (BTC_SZ_PUBKEY * 2 + 1 + 7 + 1 + 1)) {
-        // <pubkey>@<ipaddr>:<port>
-        // (33 * 2)@x.x.x.x:x
-        int results = sscanf(optarg, "%66s@%" SZ_IPV4_LEN_STR "[^:]:%" SCNu16,
-            mPeerNodeId,
-            mPeerAddr,
-            &mPeerPort);
-        // printf("id: %s\n", mPeerNodeId);
-        // printf("addr: %s\n", mPeerAddr);
-        // printf("port: %" PRIu16 "\n", mPeerPort);
-        if (results == 3) {
+        ln_node_conn_t node_conn;
+        bool dec_ret = ln_node_addr_dec(&node_conn, optarg);
+        if (dec_ret) {
+            utl_str_bin2str(mPeerNodeId, node_conn.node_id, BTC_SZ_PUBKEY);
+            strcpy(mPeerAddr, node_conn.addr);
+            mPeerPort = node_conn.port;
             *pConn = true;
             *pOption = M_OPTIONS_CONN;
         } else {
@@ -361,7 +357,7 @@ static void optfunc_conn_param(int *pOption, bool *pConn)
             *pOption = M_OPTIONS_HELP;
         }
     } else if (optlen == BTC_SZ_PUBKEY * 2) {
-        //node_idを直で指定した可能性あり(connectとしては使用できない)
+        //node_idだけ指定した可能性あり(connectとしては使用できない)
         strcpy(mPeerAddr, "0.0.0.0");
         mPeerPort = 0;
         strcpy(mPeerNodeId, optarg);

--- a/ptarmd/cmd_json.c
+++ b/ptarmd/cmd_json.c
@@ -179,7 +179,9 @@ void cmd_json_start(uint16_t Port)
 {
     int ret = jrpc_server_init(&mJrpc, Port);
     if (ret != 0) {
-        fprintf(stderr, "ERR: cannot start JSON-RPC event loop\n");
+        const char *p_err = "ERR: cannot start JSON-RPC event loop\n";
+        fprintf(stderr, "%s", p_err);
+        LOGE("%s", p_err);
         ptarmd_stop();
         return;
     }
@@ -239,6 +241,7 @@ int cmd_json_connect(const uint8_t *pNodeId, const char *pIpAddr, uint16_t Port)
 
     bool ret = p2p_cli_connect_test(pIpAddr, Port);
     if (!ret) {
+        LOGE("fail: connect test\n");
         return -1;
     }
 

--- a/ptarmd/conf.c
+++ b/ptarmd/conf.c
@@ -66,6 +66,7 @@
 static int handler_btcrpc_conf(void* user, const char* section, const char* name, const char* value);
 static int handler_anno_conf(void* user, const char* section, const char* name, const char* value);
 static int handler_channel_conf(void* user, const char* section, const char* name, const char* value);
+static int handler_connect_conf(void* user, const char* section, const char* name, const char* value);
 
 
 /**************************************************************************
@@ -165,6 +166,22 @@ bool conf_channel_load(const char *pConfFile, channel_conf_t *pChannConf)
 {
     if (ini_parse(pConfFile, handler_channel_conf, pChannConf) != 0) {
         //LOGE("fail channel parse[%s]", pConfFile);
+        return false;
+    }
+
+    return true;
+}
+
+
+void conf_connect_init(connect_conf_t *pConnConf)
+{
+    memset(pConnConf, 0, sizeof(connect_conf_t));
+}
+
+
+bool conf_connect_load(const char *pConfFile, connect_conf_t *pConnConf)
+{
+    if (ini_parse(pConfFile, handler_connect_conf, pConnConf) != 0) {
         return false;
     }
 
@@ -295,3 +312,24 @@ static int handler_channel_conf(void* user, const char* section, const char* nam
     return 1;
 }
 
+
+static int handler_connect_conf(void* user, const char* section, const char* name, const char* value)
+{
+    (void)section;
+
+    connect_conf_t* pconfig = (connect_conf_t *)user;
+
+    if (strncmp(name, "node", 4) == 0) {
+        int num = 0;
+        num = (int)strtol(name + 4, NULL, 10);
+        if ((0 <= num) && (num < PTARMD_CONNLIST_MAX)) {
+            strncpy(pconfig->conn_str[num], value, SZ_NODECONN_STR);
+            pconfig->conn_str[num][SZ_NODECONN_STR] = '\0';
+        } else {
+            //through
+        }
+    } else {
+        return 0;  /* unknown section/name, error */
+    }
+    return 1;
+}

--- a/ptarmd/conf.h
+++ b/ptarmd/conf.h
@@ -40,6 +40,9 @@ bool conf_anno_load(const char *pConfFile, anno_conf_t *pAnnoConf);
 void conf_channel_init(channel_conf_t *pEstConf);
 bool conf_channel_load(const char *pConfFile, channel_conf_t *pEstConf);
 
+void conf_connect_init(connect_conf_t *pConnConf);
+bool conf_connect_load(const char *pConfFile, connect_conf_t *pConnConf);
+
 #ifdef __cplusplus
 }
 #endif  //__cplusplus

--- a/ptarmd/lnapp.c
+++ b/ptarmd/lnapp.c
@@ -3218,7 +3218,7 @@ static void load_announce_settings(void)
 {
     anno_conf_t aconf;
     conf_anno_init(&aconf);
-    (void)conf_anno_load("anno.conf", &aconf);
+    (void)conf_anno_load(FNAME_CONF_ANNO, &aconf);
     mAnnoPrm.cltv_expiry_delta = aconf.cltv_expiry_delta;
     mAnnoPrm.htlc_minimum_msat = aconf.htlc_minimum_msat;
     mAnnoPrm.fee_base_msat = aconf.fee_base_msat;

--- a/ptarmd/p2p_svr.c
+++ b/ptarmd/p2p_svr.c
@@ -175,7 +175,6 @@ LABEL_EXIT:
     if (sock > 0) {
         close(sock);
     }
-    ptarmd_stop();
     LOGD("[exit]p2p_svr thread: sock=%d\n", sock);
     ptarmd_stop();
 

--- a/ptarmd/ptarmd.c
+++ b/ptarmd/ptarmd.c
@@ -534,7 +534,7 @@ static void load_channel_settings(void)
     channel_conf_t econf;
 
     conf_channel_init(&econf);
-    (void)conf_channel_load("channel.conf", &econf);
+    (void)conf_channel_load(FNAME_CONF_CHANNEL, &econf);
     mEstablishPrm.dust_limit_sat = econf.dust_limit_sat;
     mEstablishPrm.max_htlc_value_in_flight_msat = econf.max_htlc_value_in_flight_msat;
     mEstablishPrm.channel_reserve_sat = econf.channel_reserve_sat;

--- a/ptarmd/ptarmd.h
+++ b/ptarmd/ptarmd.h
@@ -50,15 +50,22 @@ extern "C" {
  * macros
  ********************************************************************/
 
+#define PTARMD_CONNLIST_MAX         (5)         ///< connect_conf_t list max nodes
+
 #define SZ_RPC_USER                 (64)        ///< RPCUSER
 #define SZ_RPC_PASSWD               (64)        ///< RPCPASSWORD
 #define SZ_RPC_URL                  (256)       ///< URL
 
 #define SZ_IPV4_LEN                 INET_ADDRSTRLEN     ///< IPv4長
 #define SZ_IPV4_LEN_STR             "15"                ///< IPv4長(sprintf用)
-#define SZ_CONN_STR                 (INET6_ADDRSTRLEN + 1 + 5)   ///< <IP len>:<port>
+#define SZ_CONN_STR                 (INET6_ADDRSTRLEN + 1 + 5)   ///< <IP addr>:<port>
+#define SZ_NODECONN_STR             (BTC_SZ_HASH256 * 2 + 1 + SZ_CONN_STR)  ///< <node_id>@<IP addr>:<port>
 
 #define TM_WAIT_CONNECT             (10)        ///< client socket接続待ち[sec]
+
+#define FNAME_CONF_ANNO             "anno.conf"
+#define FNAME_CONF_CHANNEL          "channel.conf"
+#define FNAME_CONF_CONNLIST         "connlist.conf"
 
 #define FNAME_LOGDIR                "logs"
 #define FNAME_CONN_LOG              FNAME_LOGDIR "/connect.log"
@@ -250,6 +257,14 @@ typedef struct {
 
     uint8_t     localfeatures;                      ///< init.localfeatures
 } channel_conf_t;
+
+
+/** @struct     connect_conf_t
+ *  @brief      connect node list
+ */
+typedef struct {
+    char        conn_str[PTARMD_CONNLIST_MAX][SZ_NODECONN_STR + 1];
+} connect_conf_t;
 
 
 /** @struct bwd_proc_fulfill_t

--- a/ptarmd/ptarmd_main.c
+++ b/ptarmd/ptarmd_main.c
@@ -51,7 +51,7 @@
  * prototypes
  ********************************************************************/
 
-static void reset_getopt();
+static void reset_getopt(void);
 static void sig_set_catch_sigs(sigset_t *pSigSet);
 static void *sig_handler_start(void *pArg);
 
@@ -260,7 +260,7 @@ LABEL_EXIT:
  * private functions
  ********************************************************************/
 
-static void reset_getopt()
+static void reset_getopt(void)
 {
     //optreset = 1;
     //optind = 1;

--- a/utl/utl_net.c
+++ b/utl/utl_net.c
@@ -51,9 +51,9 @@ static inline bool ipv4_addr_is_subset(const uint8_t addr[4], uint8_t mask_bit_n
 
 bool utl_net_ipv4_addr_is_routable(const uint8_t* addr)
 {
-    struct addrblock {
-        uint8_t addr[4];
-        uint8_t mask_bit_num;
+    const struct addrblock {
+        const uint8_t addr[4];
+        const uint8_t mask_bit_num;
     } reserved[] = {
         {{0, 0, 0, 0}, 8},
         {{10, 0, 0, 0}, 8},


### PR DESCRIPTION
カレントディレクトリにconnlist.confファイルがある場合、`ptarmd`の起動時にノード接続しにいく。
チャネルオープンなどは行わない。
現在はnode0～4まで使用する。

```
node0=028df7753f0802ec2b781ffd44da838b7b57baebe2930132411fded4399e33bf58@40.115.138.202:9735
node1=0390e7b01cefe69a76c7084acaebf13be2d95d536897f93f00faf31bcc1a41ec21@13.78.12.166:9735
node2=03a6265d05735a3092839ec48a0519a42d3e294239c154ece9b88cc1577c8f6b62@13.78.35.128:9735
```