### PR TITLE
ptarmcli -l : short list `-l1`

### DIFF
--- a/ptarmcli/ptarmcli.c
+++ b/ptarmcli/ptarmcli.c
@@ -201,7 +201,7 @@ int main(int argc, char *argv[])
     mTcpSend = true;
     mInitRouteSync[0] = '\0';
     int opt;
-    while ((opt = getopt_long(argc, argv, "c:hta:lq::f:i:e:mp:r:R:x::wg::s:X:", OPTIONS, NULL)) != -1) {
+    while ((opt = getopt_long(argc, argv, "c:hta:l::q::f:i:e:mp:r:R:x::wg::s:X:", OPTIONS, NULL)) != -1) {
         for (size_t lp = 0; lp < ARRAY_SIZE(OPTION_FUNCS); lp++) {
             if (opt == OPTION_FUNCS[lp].opt) {
                 (*OPTION_FUNCS[lp].func)(&option, &conn);
@@ -375,11 +375,16 @@ static void optfunc_getinfo(int *pOption, bool *pConn)
 
     M_CHK_INIT
 
-    snprintf(mBuf, BUFFER_SIZE,
-        "{"
-            M_STR("method", "getinfo") M_NEXT
-            M_QQ("params") ":[]"
-        "}");
+    strncpy(mBuf,
+        "{" M_STR("method", "getinfo") M_NEXT M_QQ("params") ":[",
+        BUFFER_SIZE);
+    if ((optarg != NULL) && (strlen(optarg) > 0)) {
+        int level = atoi(optarg);
+        if (level != 0) {
+            strncat(mBuf, optarg, BUFFER_SIZE);
+        }
+    }
+    strncat(mBuf, "]}", BUFFER_SIZE);
 
     *pOption = M_OPTIONS_EXEC;
 }

--- a/ptarmd/cmd_json.c
+++ b/ptarmd/cmd_json.c
@@ -391,8 +391,15 @@ static cJSON *cmd_getinfo(jrpc_context *ctx, cJSON *params, cJSON *id)
 {
     (void)ctx; (void)params; (void)id;
 
+    cJSON *json;
+    int level = 0;
     cJSON *result = cJSON_CreateObject();
     cJSON *result_peer = cJSON_CreateArray();
+
+    json = cJSON_GetArrayItem(params, 0);
+    if ((json != NULL) && (json->type == cJSON_Number)) {
+        level = json->valueint;
+    }
 
     uint64_t total_amount = ln_node_total_msat();
 
@@ -404,6 +411,10 @@ static cJSON *cmd_getinfo(jrpc_context *ctx, cJSON *params, cJSON *id)
     cJSON_AddItemToObject(result, "node_id", cJSON_CreateString(node_id));
     cJSON_AddItemToObject(result, "node_port", cJSON_CreateNumber(ln_node_addr()->port));
     cJSON_AddNumber64ToObject(result, "total_local_msat", total_amount);
+
+    if (level == 1) {
+        return result;
+    }
 
 #ifdef DEVELOPER_MODE
     //blockcount


### PR DESCRIPTION
`ptarmcli -l1`で短い情報を出力する。
1以外は、今まで通り(文字列でも同じ)。

```
{
 "result": {
  "node_id": "034dc970b108e793e3217e83467e63f6cd08f44540280ca8081c90b4fbcdeaf2f0",
  "node_port": 3333,
  "total_local_msat": 0
 }
}
```