### PR TITLE
ptarmd: exit at  invalid option

### DIFF
--- a/ptarmd/ptarmd_main.c
+++ b/ptarmd/ptarmd_main.c
@@ -91,6 +91,9 @@ int main(int argc, char *argv[])
                 return -1;
             }
             break;
+        case '?':
+            //invalid option
+            return -1;
         default:
             break;
         }


### PR DESCRIPTION
`ptarmd`が未知のoptionを付けても起動していたため、終了させる。