### PR TITLE
gquery: check gossip_queries negotiation

### DIFF
--- a/ln/ln.c
+++ b/ln/ln.c
@@ -1203,6 +1203,12 @@ void ln_last_conf_set(ln_channel_t *pChannel, uint32_t Conf)
 }
 
 
+bool ln_announcement_is_gossip_query(const ln_channel_t *pChannel)
+{
+    return pChannel->init_flag & M_INIT_GOSSIP_QUERY;
+}
+
+
 bool ln_need_init_routing_sync(const ln_channel_t *pChannel)
 {
     return pChannel->lfeature_remote & LN_INIT_LF_ROUTE_SYNC;

--- a/ln/ln.h
+++ b/ln/ln.h
@@ -115,7 +115,7 @@ extern "C" {
 // revoked transaction closeされたときの pChannel->p_revoked_vout, p_revoked_witのインデックス値
 #define LN_RCLOSE_IDX_TO_LOCAL           (0)         ///< to_local
 #define LN_RCLOSE_IDX_TO_REMOTE          (1)         ///< to_remote
-#define LN_RCLOSE_IDX_HTLC              (2)         ///< HTLC
+#define LN_RCLOSE_IDX_HTLC               (2)         ///< HTLC
 
 #define LN_UGLY_NORMAL                              ///< payment_hashを保存するタイプ
                                                     ///< コメントアウトするとDB保存しなくなるが、revoked transaction closeから取り戻すために
@@ -128,7 +128,7 @@ extern "C" {
 #define LN_INIT_LF_OPT_UPF_SHDN         (1 << 5)    ///< option_upfront_shutdown_script
 #define LN_INIT_LF_OPT_GSP_QUERY_REQ    (1 << 6)    ///< gossip_queries
 #define LN_INIT_LF_OPT_GSP_QUERY        (1 << 7)    ///< gossip_queries
-
+#define LN_INIT_LF_OPT_GSP_QUERIES      (LN_INIT_LF_OPT_GSP_QUERY_REQ | LN_INIT_LF_OPT_GSP_QUERY)
 
 //XXX:
 #define LN_MAX_ACCEPTED_HTLCS_MAX       (483)
@@ -384,7 +384,9 @@ typedef struct {
 /// @{
 
 /** @struct     ln_anno_prm_t
- *  @brief      announce関連のパラメータ
+ *  @brief      announcement parameter
+ *  @note
+ *      - lnapp has default parameter(initialize on node startup)
  */
 typedef struct {
     //channel_update
@@ -1195,6 +1197,9 @@ uint32_t ln_last_conf_get(const ln_channel_t *pChannel);
 
 
 void ln_last_conf_set(ln_channel_t *pChannel, uint32_t Conf);
+
+
+bool ln_announcement_is_gossip_query(const ln_channel_t *pChannel);
 
 
 /** initial_routing_sync動作が必要かどうか

--- a/ln/ln_db_lmdb.c
+++ b/ln/ln_db_lmdb.c
@@ -972,7 +972,7 @@ bool ln_db_channel_save(const ln_channel_t *pChannel)
         }
     }
     if (retval != 0) {
-        LOGE("fail through: channel_id is 0\n");
+        LOGD("through: channel_id is 0\n");
         return true;
     }
 
@@ -2456,7 +2456,7 @@ bool ln_db_routeskip_work(bool bWork)
                 retval_put = mdb_put(db.txn, db.dbi, &key, &data, 0);
             }
             if (retval_put != 0) {
-                LOGD("fail through: mdb_put(%s)\n", mdb_strerror(retval_put));
+                LOGD("through: mdb_put(%s)\n", mdb_strerror(retval_put));
             }
         }
     }
@@ -4400,6 +4400,9 @@ static int annocnl_cur_load(MDB_cursor *cur, uint64_t *pShortChannelId, char *pT
                 data.mv_size -= sizeof(uint32_t);
             } else {
                 //channel_announcementにtimestampは無い
+                if (pTimeStamp != NULL) {
+                    *pTimeStamp = 0;
+                }
             }
             utl_buf_alloccopy(pBuf, pData, data.mv_size);
         } else {

--- a/ln/ln_msg_anno.c
+++ b/ln/ln_msg_anno.c
@@ -1008,7 +1008,9 @@ static void gossip_timestamp_filter_print(const ln_msg_gossip_timestamp_filter_t
     LOGD("-[gossip_timestamp_filter]-------------------------------\n");
     LOGD("chain_hash: ");
     DUMPD(pMsg->p_chain_hash, BTC_SZ_HASH256);
-    LOGD("first_timestamp: %" PRIu32 "\n", pMsg->first_timestamp);
+    char str_time[UTL_SZ_TIME_FMT_STR + 1];
+    (void)utl_time_fmt(str_time, pMsg->first_timestamp);
+    LOGD("first_timestamp: %" PRIu32 "(%s)\n", pMsg->first_timestamp, str_time);
     LOGD("timestamp_range: %" PRIu32 "\n", pMsg->timestamp_range);
     LOGD("--------------------------------\n");
 #endif  //PTARM_DEBUG

--- a/ln/ln_msg_setupctl.c
+++ b/ln/ln_msg_setupctl.c
@@ -125,6 +125,10 @@ static void init_print(const ln_msg_init_t *pMsg)
     DUMPD(pMsg->p_globalfeatures, pMsg->gflen);
     LOGD("localfeatures: ");
     DUMPD(pMsg->p_localfeatures, pMsg->lflen);
+    LOGD("  option_data_loss_protect:       %d\n", (pMsg->p_localfeatures[0] & 0x03));
+    LOGD("  initial_routing_sync:           %d\n", (pMsg->p_localfeatures[0] & 0x0c) >> 2);
+    LOGD("  option_upfront_shutdown_script: %d\n", (pMsg->p_localfeatures[0] & 0x30) >> 4);
+    LOGD("  gossip_queries:                 %d\n", (pMsg->p_localfeatures[0] & 0xc0) >> 6);
     LOGD("--------------------------------\n");
 #endif  //PTARM_DEBUG
 }

--- a/ln/ln_setupctl.h
+++ b/ln/ln_setupctl.h
@@ -48,6 +48,7 @@
 #define M_INIT_FLAG_ALL                     (M_INIT_FLAG_EXCG | M_INIT_FLAG_REEST_EXCG)
 #define M_INIT_CH_EXCHANGED(flag)           (((flag) & M_INIT_FLAG_ALL) == M_INIT_FLAG_ALL)
 #define M_INIT_ANNOSIG_SENT                 (0x10)          ///< announcement_signatures送信/再送済み
+#define M_INIT_GOSSIP_QUERY                 (0x20)          ///< gossip_queries
 
 
 #define M_SET_ERR(pChannel, err, fmt,...) { \

--- a/ln/tests/Makefile
+++ b/ln/tests/Makefile
@@ -5,7 +5,7 @@ CXX=g++
 MK := mkdir
 RM := rm -rf
 
- TEST_TARGET_SRC += \
+TEST_TARGET_SRC += \
 	test_ln_proto_updatechannel.cpp \
 	test_ln_msg_close.cpp \
 	test_ln_msg_normalope.cpp \
@@ -22,7 +22,8 @@ RM := rm -rf
 	test_ln_bech32.cpp
 
 # TEST_TARGET_SRC += \
-# 	test_ln_msg_anno_gossip.cpp
+# 	test_ln_msg_anno_gossip.cpp \
+# 	test_ln_anno.cpp
 
 # #remove -lz
 # TEST_TARGET_SRC += \

--- a/ln/tests/test_ln_anno.cpp
+++ b/ln/tests/test_ln_anno.cpp
@@ -1,0 +1,135 @@
+#include "gtest/gtest.h"
+#include <string.h>
+#include "tests/fff.h"
+DEFINE_FFF_GLOBALS;
+
+
+extern "C" {
+#include "../../utl/utl_log.c"
+#undef LOG_TAG
+#include "../../utl/utl_dbg.c"
+#include "../../utl/utl_buf.c"
+#include "../../utl/utl_push.c"
+#include "../../utl/utl_time.c"
+#include "../../utl/utl_int.c"
+#include "../../utl/utl_str.c"
+
+#undef LOG_TAG
+#include "../../btc/btc.c"
+#include "../../btc/btc_buf.c"
+// #include "../../btc/btc_extkey.c"
+// #include "../../btc/btc_keys.c"
+// #include "../../btc/btc_sw.c"
+//#include "../../btc/btc_sig.c"
+// #include "../../btc/btc_script.c"
+// #include "../../btc/btc_tx.c"
+// #include "../../btc/btc_tx_buf.c"
+#include "../../btc/btc_crypto.c"
+// #include "../../btc/segwit_addr.c"
+// #include "../../btc/btc_segwit_addr.c"
+// #include "../../btc/btc_test_util.c"
+
+#undef LOG_TAG
+#include "ln_anno.c"
+#include "ln.c"
+}
+
+////////////////////////////////////////////////////////////////////////
+//FAKE関数
+
+FAKE_VALUE_FUNC(bool, ln_msg_query_short_channel_ids_write, utl_buf_t *, const ln_msg_query_short_channel_ids_t *);
+FAKE_VALUE_FUNC(bool, ln_msg_reply_short_channel_ids_end_write, utl_buf_t *, const ln_msg_reply_short_channel_ids_end_t *);
+FAKE_VALUE_FUNC(bool, ln_msg_query_channel_range_write, utl_buf_t *, const ln_msg_query_channel_range_t *);
+FAKE_VALUE_FUNC(bool, ln_msg_reply_channel_range_write, utl_buf_t *, const ln_msg_reply_channel_range_t *);
+FAKE_VALUE_FUNC(bool, ln_msg_gossip_timestamp_filter_write, utl_buf_t *, const ln_msg_gossip_timestamp_filter_t *);
+
+FAKE_VALUE_FUNC(bool, ln_msg_query_short_channel_ids_read, ln_msg_query_short_channel_ids_t *, const uint8_t *, uint16_t );
+FAKE_VALUE_FUNC(bool, ln_msg_reply_short_channel_ids_end_read, ln_msg_reply_short_channel_ids_end_t *, const uint8_t *, uint16_t );
+FAKE_VALUE_FUNC(bool, ln_msg_query_channel_range_read, ln_msg_query_channel_range_t *, const uint8_t *, uint16_t );
+FAKE_VALUE_FUNC(bool, ln_msg_reply_channel_range_read, ln_msg_reply_channel_range_t *, const uint8_t *, uint16_t );
+FAKE_VALUE_FUNC(bool, ln_msg_gossip_timestamp_filter_read, ln_msg_gossip_timestamp_filter_t *, const uint8_t *, uint16_t );
+
+FAKE_VALUE_FUNC(bool, ln_msg_gossip_ids_encode, utl_buf_t *, const uint64_t *, size_t );
+FAKE_VALUE_FUNC(bool, ln_msg_gossip_ids_decode, uint64_t **, size_t *, const uint8_t *, size_t );
+
+
+////////////////////////////////////////////////////////////////////////
+
+namespace LN_DUMMY {
+
+}
+
+
+////////////////////////////////////////////////////////////////////////
+
+class ln: public testing::Test {
+protected:
+    virtual void SetUp() {
+        //utl_log_init_stderr();
+        RESET_FAKE(ln_msg_query_short_channel_ids_write)
+        RESET_FAKE(ln_msg_reply_short_channel_ids_end_write)
+        RESET_FAKE(ln_msg_query_channel_range_write)
+        RESET_FAKE(ln_msg_reply_channel_range_write)
+        RESET_FAKE(ln_msg_gossip_timestamp_filter_write)
+        RESET_FAKE(ln_msg_query_short_channel_ids_read)
+        RESET_FAKE(ln_msg_reply_short_channel_ids_end_read)
+        RESET_FAKE(ln_msg_query_channel_range_read)
+        RESET_FAKE(ln_msg_reply_channel_range_read)
+        RESET_FAKE(ln_msg_gossip_timestamp_filter_read)
+
+        utl_dbg_malloc_cnt_reset();
+    }
+
+    virtual void TearDown() {
+        ASSERT_EQ(0, utl_dbg_malloc_cnt());
+    }
+
+public:
+    static void DumpBin(const uint8_t *pData, uint16_t Len)
+    {
+        for (uint16_t lp = 0; lp < Len; lp++) {
+            printf("%02x", pData[lp]);
+        }
+        printf("\n");
+    }
+    static bool DumpCheck(const void *pData, uint32_t Len, uint8_t Fill)
+    {
+        bool ret = true;
+        const uint8_t *p = (const uint8_t *)pData;
+        for (uint32_t lp = 0; lp < Len; lp++) {
+            if (p[lp] != Fill) {
+                ret = false;
+                break;
+            }
+        }
+        return ret;
+    }
+};
+
+////////////////////////////////////////////////////////////////////////
+
+
+
+TEST_F(ln, no_gossip_queries)
+{
+    ln_channel_t channel;
+    memset(&channel, 0xcc, sizeof(channel));
+
+    channel.init_flag = 0;
+
+    ln_msg_query_short_channel_ids_t qsci;
+    ln_msg_query_channel_range_t qcr;
+    memset(&qsci, 0, sizeof(qsci));
+    memset(&qcr, 0, sizeof(qcr));
+
+    ASSERT_FALSE(ln_query_short_channel_ids_send(&channel));
+    ASSERT_TRUE(ln_query_short_channel_ids_recv(&channel, NULL, 0));
+    ASSERT_FALSE(ln_reply_short_channel_ids_end_send(&channel, &qsci));
+    ASSERT_FALSE(ln_reply_short_channel_ids_end_recv(&channel, NULL, 0));
+    ASSERT_FALSE(ln_query_channel_range_send(&channel, 0, 0));
+    ASSERT_TRUE(ln_query_channel_range_recv(&channel, NULL, 0));
+    ASSERT_FALSE(ln_reply_channel_range_send(&channel, &qcr));
+    ASSERT_FALSE(ln_reply_channel_range_recv(&channel, NULL, 0));
+    ASSERT_FALSE(ln_gossip_timestamp_filter_send(&channel));
+    ASSERT_TRUE(ln_gossip_timestamp_filter_recv(&channel, NULL, 0));
+}

--- a/ln/tests/test_ln_proto_init.cpp
+++ b/ln/tests/test_ln_proto_init.cpp
@@ -164,7 +164,6 @@ TEST_F(ln, init_recv_ok)
     LnInit(&channel);
 
     static bool b_called;
-    static bool b_initial_routing_sync;
     class dummy {
     public:
         static bool ln_msg_init_read(ln_msg_init_t *pMsg, const uint8_t *pData, uint16_t Len) {
@@ -176,7 +175,6 @@ TEST_F(ln, init_recv_ok)
             (void)pChannel;
             if (type == LN_CB_INIT_RECV) {
                 b_called = true;
-                b_initial_routing_sync = *(bool *)p_param;
             }
         }
     };
@@ -188,7 +186,6 @@ TEST_F(ln, init_recv_ok)
     ASSERT_EQ(0x00, channel.lfeature_remote);
     ASSERT_EQ(M_INIT_FLAG_RECV, channel.init_flag);
     ASSERT_TRUE(b_called);
-    ASSERT_FALSE(b_initial_routing_sync);
 }
 
 
@@ -198,7 +195,6 @@ TEST_F(ln, init_recv_fail)
     LnInit(&channel);
 
     static bool b_called;
-    static bool b_initial_routing_sync;
     class dummy {
     public:
         // static bool ln_msg_init_read(ln_msg_init_t *pMsg, const uint8_t *pData, uint16_t Len) {
@@ -208,7 +204,6 @@ TEST_F(ln, init_recv_fail)
             (void)pChannel;
             if (type == LN_CB_INIT_RECV) {
                 b_called = true;
-                b_initial_routing_sync = *(bool *)p_param;
             }
         }
     };
@@ -227,7 +222,6 @@ TEST_F(ln, init_recv_gf1)
     LnInit(&channel);
 
     static bool b_called;
-    static bool b_initial_routing_sync;
     static uint8_t gf;
     class dummy {
     public:
@@ -241,7 +235,6 @@ TEST_F(ln, init_recv_gf1)
             (void)pChannel;
             if (type == LN_CB_INIT_RECV) {
                 b_called = true;
-                b_initial_routing_sync = *(bool *)p_param;
             }
         }
     };
@@ -254,7 +247,6 @@ TEST_F(ln, init_recv_gf1)
         channel.init_flag = 0;
         channel.lfeature_remote = 0;
         b_called = false;
-        b_initial_routing_sync = false;
 
         //odd bits(7, 5, 3, 1)
         //          abcd
@@ -265,7 +257,6 @@ TEST_F(ln, init_recv_gf1)
         ASSERT_EQ(0x00, channel.lfeature_remote);
         ASSERT_EQ(M_INIT_FLAG_RECV, channel.init_flag);
         ASSERT_TRUE(b_called);
-        ASSERT_FALSE(b_initial_routing_sync);
     }
 }
 
@@ -276,7 +267,6 @@ TEST_F(ln, init_recv_gf2)
     LnInit(&channel);
 
     static bool b_called;
-    static bool b_initial_routing_sync;
     static uint8_t gf;
     class dummy {
     public:
@@ -289,7 +279,6 @@ TEST_F(ln, init_recv_gf2)
             (void)pChannel;
             if (type == LN_CB_INIT_RECV) {
                 b_called = true;
-                b_initial_routing_sync = *(bool *)p_param;
             }
         }
     };
@@ -302,7 +291,6 @@ TEST_F(ln, init_recv_gf2)
         channel.init_flag = 0;
         channel.lfeature_remote = 0;
         b_called = false;
-        b_initial_routing_sync = false;
 
         //even bits(6, 4, 2, 0)
         //          abcd
@@ -313,7 +301,6 @@ TEST_F(ln, init_recv_gf2)
         ASSERT_EQ(0x00, channel.lfeature_remote);
         ASSERT_EQ(0, channel.init_flag);
         ASSERT_FALSE(b_called);
-        ASSERT_FALSE(b_initial_routing_sync);
     }
 }
 
@@ -324,7 +311,6 @@ TEST_F(ln, init_recv_lf1)
     LnInit(&channel);
 
     static bool b_called;
-    static bool b_initial_routing_sync;
     static uint8_t lf;
     class dummy {
     public:
@@ -338,7 +324,6 @@ TEST_F(ln, init_recv_lf1)
             (void)pChannel;
             if (type == LN_CB_INIT_RECV) {
                 b_called = true;
-                b_initial_routing_sync = *(bool *)p_param;
             }
         }
     };
@@ -351,7 +336,6 @@ TEST_F(ln, init_recv_lf1)
         channel.init_flag = 0;
         channel.lfeature_remote = 0;
         b_called = false;
-        b_initial_routing_sync = false;
 
         //odd bits(7, 5, 3, 1)
         //          abcd
@@ -362,65 +346,5 @@ TEST_F(ln, init_recv_lf1)
         ASSERT_EQ(lf, channel.lfeature_remote);
         ASSERT_EQ(M_INIT_FLAG_RECV, channel.init_flag);
         ASSERT_TRUE(b_called);
-        bool initsync = ((lp & 0x02) << 2) != 0;
-        ASSERT_EQ(initsync, b_initial_routing_sync);
-    }
-}
-
-
-TEST_F(ln, init_recv_lf2)
-{
-    ln_channel_t channel;
-    LnInit(&channel);
-
-    static bool b_called;
-    static bool b_initial_routing_sync;
-    static uint8_t lf;
-    class dummy {
-    public:
-        static bool ln_msg_init_read(ln_msg_init_t *pMsg, const uint8_t *pData, uint16_t Len) {
-            pMsg->gflen = 0;
-            pMsg->lflen = 1;
-            pMsg->p_localfeatures = &lf;
-            return true;
-        }
-        static void callback(ln_channel_t *pChannel, ln_cb_t type, void *p_param) {
-            (void)pChannel;
-            if (type == LN_CB_INIT_RECV) {
-                b_called = true;
-                b_initial_routing_sync = *(bool *)p_param;
-            }
-        }
-    };
-    channel.p_callback = dummy::callback;
-    ln_msg_init_read_fake.custom_fake = dummy::ln_msg_init_read;
-
-    bool ret;
-    
-    for (int lp = 1; lp <= 0x0f; lp++) {
-        channel.init_flag = 0;
-        channel.lfeature_remote = 0;
-        b_called = false;
-        b_initial_routing_sync = false;
-
-        //even bits(6, 4, 2, 0)
-        //          abcd
-        //      0a0b0c0d
-        lf = (lp & 0x08) << 3 | (lp & 0x04) << 2 | (lp & 0x02) << 1 | (lp & 0x01);
-        ret = ln_init_recv(&channel, NULL, 0);
-        if (lf == 0x01) {
-            //option_data_loss_protect
-            ASSERT_TRUE(ret);
-            ASSERT_EQ(lf, channel.lfeature_remote);
-            ASSERT_EQ(M_INIT_FLAG_RECV, channel.init_flag);
-            ASSERT_TRUE(b_called);
-            ASSERT_FALSE(b_initial_routing_sync);
-        } else {
-            ASSERT_FALSE(ret);
-            ASSERT_EQ(0x00, channel.lfeature_remote);
-            ASSERT_EQ(0, channel.init_flag);
-            ASSERT_FALSE(b_called);
-            ASSERT_FALSE(b_initial_routing_sync);
-        }
     }
 }

--- a/ptarmd/lnapp.h
+++ b/ptarmd/lnapp.h
@@ -91,13 +91,18 @@ typedef struct lnapp_conf_t {
     //制御内容通知
     bool            initiator;                  ///< true:Noise Protocol handshakeのinitiator
     uint8_t         node_id[BTC_SZ_PUBKEY];     ///< 接続先(initiator==true時)
-    ptarmd_routesync_t  routesync;              ///< initial_routing_sync
+    
+    //routing_sync
+    ptarmd_routesync_t  routesync;              ///< local routing_sync
+    uint32_t            firstblock;             ///< [query/reply_channel_range]
+    uint32_t            lastblock;              ///< [query/reply_channel_range]
+    uint32_t            firsttimestamp;         ///< [gossip_timestamp_filter]
+    uint32_t            lasttimestamp;          ///< [gossip_timestamp_filter]
 
     //lnappワーク
     volatile bool   loop;                   ///< true:channel動作中
     ln_channel_t    *p_channel;             ///< channelのコンテキスト
 
-    bool            initial_routing_sync;   ///< init.localfeaturesのinitial_routing_sync
     int             ping_counter;           ///< 無送受信時にping送信するカウンタ(カウントアップ)
 
     bool            funding_waiting;        ///< true:funding_txの安定待ち
@@ -140,6 +145,9 @@ typedef struct lnapp_conf_t {
 /********************************************************************
  * prototypes
  ********************************************************************/
+
+void lnapp_init(void);
+
 
 /** [lnapp]開始
  *

--- a/ptarmd/ptarmd.c
+++ b/ptarmd/ptarmd.c
@@ -193,6 +193,7 @@ int ptarmd_start(uint16_t RpcPort, const ln_node_t *pNode)
     load_channel_settings();
     btcrpc_set_creationhash(ln_creationhash_get());
     set_channels();
+    lnapp_init();
 
     //接続待ち受け用
     pthread_t th_svr;


### PR DESCRIPTION
* gossip_queries negotiationしていない場合の対応追加
  * gossip_queries系メッセージ(奇数)で何も返さない
  * gossip_queries系メッセージ(偶数)はsocket切断
* `init.localfeatures`受信で、gossip_queriesの偶数bitを許容する