### PR TITLE
log: fix PTARM_UTL_LOG_MACRO_DISABLED

### DIFF
--- a/btc/btc_tx.c
+++ b/btc/btc_tx.c
@@ -819,6 +819,16 @@ void btc_tx_print_raw(const uint8_t *pData, uint32_t Len)
 
     btc_tx_free(&tx);
 }
+#else
+void btc_tx_print(const btc_tx_t *pTx)
+{
+    (void)pTx;
+}
+
+void btc_tx_print_raw(const uint8_t *pData, uint32_t Len)
+{
+    (void)pData; (void)Len;
+}
 #endif  //PTARM_USE_PRINTFUNC
 
 

--- a/utl/utl_log.h
+++ b/utl/utl_log.h
@@ -37,14 +37,22 @@ void utl_log_dump_rev(int Pri, const char* pFname, int Line, int Flag, const cha
 
 
 #ifdef PTARM_UTL_LOG_MACRO_DISABLED
-#define LOGV(...)       //none
-#define DUMPV(...)      //none
-#define TXIDV(...)      //none
+#define LOGE(...)       //none
+#define DUMPE(...)      //none
+#define TXIDE(...)      //none
+
+#define LOGI(...)       //none
+#define DUMPI(...)      //none
+#define TXIDI(...)      //none
 
 #define LOGD(...)       //none
 #define LOGD2(...)      //none
 #define DUMPD(...)      //none
 #define TXIDD(...)      //none
+
+#define LOGV(...)       //none
+#define DUMPV(...)      //none
+#define TXIDV(...)      //none
 
 #elif defined(ANDROID) //PTARM_UTL_LOG_MACRO_DISABLED
 #include <android/log.h>


### PR DESCRIPTION
`PTARM_UTL_LOG_MACRO_DISABLED`を定義した際にコンパイルエラーとなったため、マクロ追加。