### PR TITLE
fix close: close check on funding_tx is mined

### DIFF
--- a/ln/ln.c
+++ b/ln/ln.c
@@ -643,10 +643,15 @@ void ln_shutdown_update_fee(ln_channel_t *pChannel, uint64_t Fee)
 void ln_close_change_stat(ln_channel_t *pChannel, const btc_tx_t *pCloseTx, void *pDbParam)
 {
     LOGD("BEGIN: status=%d\n", (int)pChannel->status);
-    if ((pChannel->status == LN_STATUS_NORMAL) || (pChannel->status == LN_STATUS_CLOSE_WAIT)) {
-        pChannel->status = LN_STATUS_CLOSE_SPENT;
-        ln_db_channel_save_status(pChannel, pDbParam);
-    } else if (pChannel->status == LN_STATUS_CLOSE_SPENT) {
+    if (pCloseTx == NULL) {
+        //funding_tx isn't mining
+        if ( (pChannel->status == LN_STATUS_NORMAL) ||
+             (pChannel->status == LN_STATUS_CLOSE_WAIT) ) {
+            pChannel->status = LN_STATUS_CLOSE_SPENT;
+            ln_db_channel_save_status(pChannel, pDbParam);
+        }
+    } else {
+        //funding_tx is mined
         M_DBG_PRINT_TX(pCloseTx);
 
         uint8_t txid[BTC_SZ_TXID];

--- a/tests/4nodes_test/example_st5.sh
+++ b/tests/4nodes_test/example_st5.sh
@@ -13,3 +13,19 @@
 # mining
 sleep 3
 ./generate.sh 1
+
+loop=1
+while [ $loop -eq 1 ];
+do
+    loop=0
+    for i in 3333 4444 5555 6666
+    do
+        cnt=`./showdb -d node_$i -s | jq -e 'length'`
+        if [ $cnt -ne 0 ]; then
+            echo node_$i not closed
+            sleep 5
+            loop=1
+            continue
+        fi
+    done
+done


### PR DESCRIPTION
mutual closeでfundeeが閉じていなかった件の修正

以前は、funding_txがマイニングされているかどうかをチャネルオープンしたブロックから毎回行っていた。
が、raspberry piの場合にはその処理に時間がかかるため、前回チェックしたブロックは次回チェックしないようにした。
そして、ステータスの都合上、fundeeは2回チェックが走らないとクローズにならないようになっていたので、miningのチェックが1回しか動作しないとうまくいかなくなっていた。

まあ、クローズのステータスは見直した方が良いな。