### PR TITLE
fix close2: remove CLOSE_SPENT

### DIFF
--- a/ln/ln.h
+++ b/ln/ln.h
@@ -212,11 +212,10 @@ typedef enum {
     LN_STATUS_ESTABLISH = 1,        ///< establish
     LN_STATUS_NORMAL = 2,           ///< normal operation
     LN_STATUS_CLOSE_WAIT = 3,       ///< shutdown received or sent
-    LN_STATUS_CLOSE_SPENT = 4,      ///< funding_tx is spent but not in block
-    LN_STATUS_CLOSE_MUTUAL = 5,     ///< mutual close
-    LN_STATUS_CLOSE_UNI_LOCAL = 6,  ///< unilateral close(from local)
-    LN_STATUS_CLOSE_UNI_REMOTE = 7, ///< unilateral close(from remote)
-    LN_STATUS_CLOSE_REVOKED = 8     ///< revoked transaction close(from remote)
+    LN_STATUS_CLOSE_MUTUAL = 4,     ///< mutual close
+    LN_STATUS_CLOSE_UNI_LOCAL = 5,  ///< unilateral close(from local)
+    LN_STATUS_CLOSE_UNI_REMOTE = 6, ///< unilateral close(from remote)
+    LN_STATUS_CLOSE_REVOKED = 7     ///< revoked transaction close(from remote)
 } ln_status_t;
 
 
@@ -1088,6 +1087,14 @@ ln_status_t ln_status_get(const ln_channel_t *pChannel);
  * @retval  true    closing now
  */
 bool ln_status_is_closing(const ln_channel_t *pChannel);
+
+
+/** is closed ?
+ *
+ * @param[in]           pChannel        channel info
+ * @retval  true    funding_tx is spent
+ */
+bool ln_status_is_closed(const ln_channel_t *pChannel);
 
 
 /** get local_msat

--- a/ln/ln_close.c
+++ b/ln/ln_close.c
@@ -263,9 +263,7 @@ bool HIDDEN ln_closing_signed_recv(ln_channel_t *pChannel, const uint8_t *pData,
         }
         utl_buf_free(&txbuf);
 
-        //funding_txがspentになった
-        LOGD("$$$ close waiting\n");
-        pChannel->status = LN_STATUS_CLOSE_SPENT;
+        LOGD("$$$ send closing_tx\n");
 
         //clearはDB削除に任せる
         //channel_clear(pChannel);

--- a/ptarmd/lnapp.c
+++ b/ptarmd/lnapp.c
@@ -1734,7 +1734,7 @@ static void poll_normal_operating(lnapp_conf_t *p_conf)
     //DBGTRACE_BEGIN
 
     bool ret = ln_status_load(p_conf->p_channel);
-    if (ret && ln_status_is_closing(p_conf->p_channel)) {
+    if (ret && ln_status_is_closed(p_conf->p_channel)) {
         //ループ解除
         LOGD("funding_tx is spent: %016" PRIx64 "\n", ln_short_channel_id(p_conf->p_channel));
         stop_threads(p_conf);

--- a/ptarmd/monitoring.c
+++ b/ptarmd/monitoring.c
@@ -473,7 +473,7 @@ static bool funding_spent(ln_channel_t *pChannel, monparam_t *p_prm, void *p_db_
     utl_str_bin2str_rev(txid_str, ln_funding_txid(pChannel), BTC_SZ_TXID);
 
     LOGD("$$$ close: %s (confirm=%" PRIu32 ", status=%s)\n", txid_str, p_prm->confm, ln_status_string(pChannel));
-    if (stat <= LN_STATUS_CLOSE_SPENT) {
+    if (stat <= LN_STATUS_CLOSE_WAIT) {
         //update status
         monchanlist_t *p_list = NULL;
         ret = monchanlist_search(&p_list, ln_channel_id(pChannel), false);


### PR DESCRIPTION
#1144 の続き。
channelスレッドで、接続を切るかどうかのチェックに「close_wait」を使っていたが、あれは`shutdown`の交換以降のステータスのため、`closing_signed`が終わってないのに切断してしまうことがあった。

その修正をしていくと「close_spent」という、funding_txがSPENTされたようだ、という状態が中途半端だったので取り除き、funding_txをSPENTしたトランザクションがマイニングされたらクローズ種別を判定するようにした。