### PR TITLE
ln_db: add channel load with no key

### DIFF
--- a/ln/ln_db.h
+++ b/ln/ln_db.h
@@ -222,7 +222,8 @@ bool ln_db_channel_del_prm(const ln_channel_t *pChannel, void *p_db_param);
 
 
 /** channel情報検索
- *      比較関数を使用してchannel情報を検索する
+ *      比較関数を使用してchannel情報を検索する。
+ *      最後はcommitされる。
  *
  * @param[in]       pFunc       検索関数
  * @param[in,out]   pFuncParam  検索関数に渡す引数
@@ -232,7 +233,35 @@ bool ln_db_channel_del_prm(const ln_channel_t *pChannel, void *p_db_param);
  *      - 戻り値がtrueの場合、検索関数のpChannelは解放しない。必要があれば#ln_term()を実行すること。
  */
 bool ln_db_channel_search(ln_db_func_cmp_t pFunc, void *pFuncParam);
+
+
+/** channel情報検索(read only)
+ *      比較関数を使用してchannel情報を検索する。
+ *      最後はcommitされない。
+ *
+ * @param[in]       pFunc       検索関数
+ * @param[in,out]   pFuncParam  検索関数に渡す引数
+ * @retval      true    検索関数がtrueを戻した
+ * @retval      false   検索関数が最後までtrueを返さなかった
+ * @note
+ *      - 戻り値がtrueの場合、検索関数のpChannelは解放しない。必要があれば#ln_term()を実行すること。
+ */
 bool ln_db_channel_search_readonly(ln_db_func_cmp_t pFunc, void *pFuncParam);
+
+
+/** channel情報検索(read only)(no key restore)
+ *      比較関数を使用してchannel情報を検索する。
+ *      鍵は復元されない。
+ *      最後はcommitされない。
+ *
+ * @param[in]       pFunc       検索関数
+ * @param[in,out]   pFuncParam  検索関数に渡す引数
+ * @retval      true    検索関数がtrueを戻した
+ * @retval      false   検索関数が最後までtrueを返さなかった
+ * @note
+ *      - 戻り値がtrueの場合、検索関数のpChannelは解放しない。必要があれば#ln_term()を実行すること。
+ */
+bool ln_db_channel_search_nk_readonly(ln_db_func_cmp_t pFunc, void *pFuncParam);
 
 
 /** load pChannel->status

--- a/ln/ln_db_lmdb.c
+++ b/ln/ln_db_lmdb.c
@@ -591,11 +591,12 @@ static int channel_save(const ln_channel_t *pChannel, ln_lmdb_db_t *pDb);
 static int channel_item_load(ln_channel_t *pChannel, const backup_param_t *pBackupParam, ln_lmdb_db_t *pDb);
 static int channel_item_save(const ln_channel_t *pChannel, const backup_param_t *pBackupParam, ln_lmdb_db_t *pDb);
 static int channel_secret_load(ln_channel_t *pChannel, ln_lmdb_db_t *pDb);
+static int channel_secret_restore(ln_channel_t *pChannel);
 static int channel_cursor_open(lmdb_cursor_t *pCur, bool bWritable);
 static void channel_cursor_close(lmdb_cursor_t *pCur, bool bWritable);
 static void channel_addhtlc_dbname(char *pDbName, int num);
 static bool channel_comp_func_cnldel(ln_channel_t *pChannel, void *p_db_param, void *p_param);
-static bool channel_search(ln_db_func_cmp_t pFunc, void *pFuncParam, bool bWritable);
+static bool channel_search(ln_db_func_cmp_t pFunc, void *pFuncParam, bool bWritable, bool bRestore);
 
 static int node_db_open(ln_lmdb_db_t *pDb, const char *pDbName, int OptTxn, int OptDb);
 
@@ -885,7 +886,7 @@ void ln_db_term(void)
  * channel
  ********************************************************************/
 
-int ln_lmdb_channel_load(ln_channel_t *pChannel, MDB_txn *txn, MDB_dbi dbi)
+int ln_lmdb_channel_load(ln_channel_t *pChannel, MDB_txn *txn, MDB_dbi dbi, bool bRestore)
 {
     int         retval;
     MDB_val     key, data;
@@ -948,17 +949,9 @@ int ln_lmdb_channel_load(ln_channel_t *pChannel, MDB_txn *txn, MDB_dbi dbi)
         goto LABEL_EXIT;
     }
 
-    //復元データからさらに復元
-    if (!ln_derkey_restore(&pChannel->keys_local, &pChannel->keys_remote)) {
-        retval = -1;
-        LOGE("ERR\n");
-        goto LABEL_EXIT;
-    }
-    if (!btc_script_2of2_create_redeem_sorted(&pChannel->funding_tx.wit_script, &pChannel->funding_tx.key_order,
-        pChannel->keys_local.basepoints[LN_BASEPOINT_IDX_FUNDING], pChannel->keys_remote.basepoints[LN_BASEPOINT_IDX_FUNDING])) {
-        retval = -1;
-        LOGE("ERR\n");
-        goto LABEL_EXIT;
+    if (bRestore) {
+        //復元データからさらに復元
+        retval = channel_secret_restore(pChannel);
     }
 
 LABEL_EXIT:
@@ -1106,13 +1099,19 @@ bool ln_db_channel_del_prm(const ln_channel_t *pChannel, void *p_db_param)
 
 bool ln_db_channel_search(ln_db_func_cmp_t pFunc, void *pFuncParam)
 {
-    return channel_search(pFunc, pFuncParam, true);
+    return channel_search(pFunc, pFuncParam, true, true);
 }
 
 
 bool ln_db_channel_search_readonly(ln_db_func_cmp_t pFunc, void *pFuncParam)
 {
-    return channel_search(pFunc, pFuncParam, false);
+    return channel_search(pFunc, pFuncParam, false, __GCC_ATOMIC_TEST_AND_SET_TRUEVAL);
+}
+
+
+bool ln_db_channel_search_nk_readonly(ln_db_func_cmp_t pFunc, void *pFuncParam)
+{
+    return channel_search(pFunc, pFuncParam, false, false);
 }
 
 
@@ -1300,7 +1299,7 @@ bool ln_db_channel_chk_mynode(uint64_t ShortChannelId)
             ret = MDB_DBI_OPEN(cur.txn, name, 0, &cur.dbi);
             if (ret == 0) {
                 memset(p_channel, 0, sizeof(ln_channel_t));
-                int retval = ln_lmdb_channel_load(p_channel, cur.txn, cur.dbi);
+                int retval = ln_lmdb_channel_load(p_channel, cur.txn, cur.dbi, true);
                 ln_term(p_channel);
                 if ((retval == 0) && (ShortChannelId == p_channel->short_channel_id)) {
                     //LOGD("own channel: %016" PRIx64 "\n", ShortChannelId);
@@ -4105,6 +4104,29 @@ static int channel_secret_load(ln_channel_t *pChannel, ln_lmdb_db_t *pDb)
 }
 
 
+static int channel_secret_restore(ln_channel_t *pChannel)
+{
+    int retval = 0;
+    if (!ln_derkey_restore(&pChannel->keys_local, &pChannel->keys_remote)) {
+        retval = -1;
+        LOGE("ERR\n");
+        goto LABEL_EXIT;
+    }
+    if (!btc_script_2of2_create_redeem_sorted(
+                &pChannel->funding_tx.wit_script,
+                &pChannel->funding_tx.key_order,
+                pChannel->keys_local.basepoints[LN_BASEPOINT_IDX_FUNDING],
+                pChannel->keys_remote.basepoints[LN_BASEPOINT_IDX_FUNDING])) {
+        retval = -1;
+        LOGE("ERR\n");
+    }
+    LOGD("key restored.\n");
+
+LABEL_EXIT:
+    return retval;
+}
+
+
 /**
  *
  * @param[out]      pCur
@@ -4190,7 +4212,7 @@ static bool channel_comp_func_cnldel(ln_channel_t *pChannel, void *p_db_param, v
 }
 
 
-static bool channel_search(ln_db_func_cmp_t pFunc, void *pFuncParam, bool bWritable)
+static bool channel_search(ln_db_func_cmp_t pFunc, void *pFuncParam, bool bWritable, bool bRestore)
 {
     bool            result = false;
     int             retval;
@@ -4214,7 +4236,7 @@ static bool channel_search(ln_db_func_cmp_t pFunc, void *pFuncParam, bool bWrita
             ret = MDB_DBI_OPEN(cur.txn, name, 0, &cur.dbi);
             if (ret == 0) {
                 memset(p_channel, 0, sizeof(ln_channel_t));
-                retval = ln_lmdb_channel_load(p_channel, cur.txn, cur.dbi);
+                retval = ln_lmdb_channel_load(p_channel, cur.txn, cur.dbi, bRestore);
                 if (retval == 0) {
                     result = (*pFunc)(p_channel, (void *)&cur, pFuncParam);
                     if (result) {

--- a/ln/ln_db_lmdb.h
+++ b/ln/ln_db_lmdb.h
@@ -216,12 +216,13 @@ const char *ln_lmdb_get_waltpath(void);
  * @param[out]      pChannel
  * @param[in]       txn
  * @param[in]       pdbi
+ * @param[in]       bRestore        true:restore keys from basepoint
  * @retval      0       成功
  * @attention
  *      -
  *      - 新規 pChannel に読込を行う場合は、事前に #ln_init()を行っておくこと(seedはNULLでよい)
  */
-int ln_lmdb_channel_load(ln_channel_t *pChannel, MDB_txn *txn, MDB_dbi dbi);
+int ln_lmdb_channel_load(ln_channel_t *pChannel, MDB_txn *txn, MDB_dbi dbi, bool bRestore);
 
 
 /** closeしたDB("cn")を出力

--- a/ln/ln_node.c
+++ b/ln/ln_node.c
@@ -227,7 +227,7 @@ bool ln_node_search_nodeanno(ln_msg_node_announcement_t *pNodeAnno, utl_buf_t *p
 uint64_t ln_node_total_msat(void)
 {
     uint64_t amount = 0;
-    ln_db_channel_search_readonly(comp_func_total_msat, &amount);
+    ln_db_channel_search_nk_readonly(comp_func_total_msat, &amount);
     return amount;
 }
 
@@ -298,7 +298,7 @@ bool HIDDEN ln_node_search_node_id(uint8_t *pNodeId, uint64_t ShortChannelId)
     comp_param_srcnodeid_t param;
     param.p_node_id = pNodeId;
     param.short_channel_id = ShortChannelId;
-    bool ret = ln_db_channel_search_readonly(comp_func_srch_nodeid, &param);
+    bool ret = ln_db_channel_search_nk_readonly(comp_func_srch_nodeid, &param);
     LOGD("ret=%d\n", ret);
     return ret;
 }

--- a/ln/ln_routing.cpp
+++ b/ln/ln_routing.cpp
@@ -354,7 +354,7 @@ static bool loaddb(nodes_result_t *p_result, const uint8_t *pPayerId)
 
     prm_channel.p_result = p_result;
     prm_channel.p_payer = pPayerId;
-    ln_db_channel_search_readonly(comp_func_channel, &prm_channel);
+    ln_db_channel_search_nk_readonly(comp_func_channel, &prm_channel);
 
     //channel_anno
     void *p_cur;

--- a/ln/tests/test_ln_proto_updateaddhtlc.cpp
+++ b/ln/tests/test_ln_proto_updateaddhtlc.cpp
@@ -61,6 +61,7 @@ FAKE_VALUE_FUNC(bool, ln_db_preimage_cur_open, void **);
 FAKE_VALUE_FUNC(bool, ln_db_preimage_cur_get, void *, bool *, ln_db_preimage_t *);
 FAKE_VALUE_FUNC(bool, ln_db_channel_search, ln_db_func_cmp_t, void *);
 FAKE_VALUE_FUNC(bool, ln_db_channel_search_readonly, ln_db_func_cmp_t, void *);
+FAKE_VALUE_FUNC(bool, ln_db_channel_search_nk_readonly, ln_db_func_cmp_t, void *);
 FAKE_VALUE_FUNC(bool, ln_db_phash_save, const uint8_t*, const uint8_t*, ln_comtx_output_type_t, uint32_t);
 FAKE_VALUE_FUNC(bool, ln_db_preimage_search, ln_db_func_preimage_t, void*);
 FAKE_VALUE_FUNC(bool, ln_db_preimage_set_expiry, void *, uint32_t);
@@ -90,6 +91,7 @@ protected:
         RESET_FAKE(ln_db_preimage_cur_get)
         RESET_FAKE(ln_db_channel_search)
         RESET_FAKE(ln_db_channel_search_readonly)
+        RESET_FAKE(ln_db_channel_search_nk_readonly)
         RESET_FAKE(ln_db_phash_save)
         RESET_FAKE(ln_db_preimage_search)
         RESET_FAKE(ln_db_preimage_set_expiry)

--- a/ptarmd/cmd_json.c
+++ b/ptarmd/cmd_json.c
@@ -2094,7 +2094,7 @@ static void create_bolt11_r_field(ln_r_field_t **ppRField, uint8_t *pRFieldNum, 
     prm.pp_field = ppRField;
     prm.amount_msat = AmountMsat;
     prm.p_fieldnum = pRFieldNum;
-    ln_db_channel_search_readonly(comp_func_cnl, &prm);
+    ln_db_channel_search_nk_readonly(comp_func_cnl, &prm);
 
     if (*pRFieldNum != 0) {
         LOGD("add r_field: %d\n", *pRFieldNum);

--- a/ptarmd/lnapp.c
+++ b/ptarmd/lnapp.c
@@ -2186,6 +2186,7 @@ static void cb_error_recv(lnapp_conf_t *p_conf, void *p_param)
 //LN_CB_INIT_RECV: init受信
 static void cb_init_recv(lnapp_conf_t *p_conf, void *p_param)
 {
+    (void)p_param;
     DBGTRACE_BEGIN
 
     //init受信待ち合わせ解除(*1)

--- a/showdb/showdb.c
+++ b/showdb/showdb.c
@@ -635,7 +635,7 @@ static void dumpit_channel(MDB_txn *txn, MDB_dbi dbi)
         ln_channel_t *p_channel = (ln_channel_t *)UTL_DBG_MALLOC(sizeof(ln_channel_t));
         memset(p_channel, 0, sizeof(ln_channel_t));
 
-        int retval = ln_lmdb_channel_load(p_channel, txn, dbi);
+        int retval = ln_lmdb_channel_load(p_channel, txn, dbi, true);
         if (retval != 0) {
             //printf(M_QQ("load") ":" M_QQ("%s"), mdb_strerror(retval));
             return;


### PR DESCRIPTION
DBからのchannel読み込み時、basepointでのkey復元と、funding_txの2-of-2復元を行わない関数を追加。
Raspberry Piでの速度向上を目的とする。

    * 全amountの合計取得

    * invoice作成のr-filed

    * short_channel_idに対応するnode_id取得


keyを初めて使用する際に復元する、というやり方がよいだろうが、今回はこれで。