### PR TITLE
fix ptarmd quit process

### DIFF
--- a/ptarmd/cmd_json.c
+++ b/ptarmd/cmd_json.c
@@ -234,6 +234,8 @@ void cmd_json_stop(void)
         jrpc_server_stop(&mJrpc);
         LOGD("stop jrpc_server\n");
         mRunning = false;
+    } else {
+        LOGD("stopeed\n");
     }
 }
 

--- a/ptarmd/p2p_cli.c
+++ b/ptarmd/p2p_cli.c
@@ -223,6 +223,7 @@ LABEL_EXIT:
 
 void p2p_cli_stop_all(void)
 {
+    LOGD("stop\n");
     for (int lp = 0; lp < M_SOCK_CLIENT_MAX; lp++) {
         if (mAppConf[lp].sock != -1) {
             lnapp_stop(&mAppConf[lp]);

--- a/ptarmd/p2p_svr.c
+++ b/ptarmd/p2p_svr.c
@@ -138,6 +138,10 @@ void *p2p_svr_start(void *pArg)
         } else {
             //継続
         }
+        if (!mLoop) {
+            LOGD("stop\n");
+            break;
+        }
 
         int idx;
         for (idx = 0; idx < (int)ARRAY_SIZE(mAppConf); idx++) {
@@ -151,7 +155,12 @@ void *p2p_svr_start(void *pArg)
             mAppConf[idx].sock = accept(sock, (struct sockaddr *)&cl_addr, &cl_len);
             if (mAppConf[idx].sock < 0) {
                 LOGE("accept: %s\n", strerror(errno));
-                goto LABEL_EXIT;
+                break;
+            }
+            if (!mLoop) {
+                LOGD("stop\n");
+                close(mAppConf[idx].sock);
+                break;
             }
 
             //スレッド起動
@@ -185,12 +194,13 @@ LABEL_EXIT:
 
 void p2p_svr_stop_all(void)
 {
+    LOGD("stop\n");
+    mLoop = false;
     for (int lp = 0; lp < M_SOCK_SERVER_MAX; lp++) {
         if (mAppConf[lp].sock != -1) {
             lnapp_stop(&mAppConf[lp]);
         }
     }
-    mLoop = false;
 }
 
 

--- a/ptarmd/ptarmd.c
+++ b/ptarmd/ptarmd.c
@@ -253,9 +253,11 @@ void ptarmd_stop(void)
         mRunning = false;
         LOGD("stopage order\n");
         cmd_json_stop();
+        monitor_stop();
         p2p_svr_stop_all();
         p2p_cli_stop_all();
-        monitor_stop();
+    } else {
+        LOGD("stopped\n");
     }
 }
 

--- a/tests/4nodes_test/example_st3.sh
+++ b/tests/4nodes_test/example_st3.sh
@@ -88,29 +88,19 @@ sleep 10
 # mining
 bitcoin-cli -conf=`pwd`/regtest.conf -datadir=`pwd` generate 6
 
-# 少し待つ
-echo wait............
-sleep 10
-
 while :
 do
-    ./showdb -c -d node_3333 | jq '.[][].short_channel_id' > n3.txt
-    ./showdb -c -d node_4444 | jq '.[][].short_channel_id' > n4.txt
-    ./showdb -c -d node_5555 | jq '.[][].short_channel_id' > n5.txt
-    ./showdb -c -d node_6666 | jq '.[][].short_channel_id' > n6.txt
-    cmp n3.txt n4.txt
-    RES1=$?
-    cmp n3.txt n5.txt
-    RES2=$?
-    cmp n3.txt n6.txt
-    RES3=$?
+    CHN3=`./showdb -c -d node_3333 | jq '.[]|length'`
+    CHN4=`./showdb -c -d node_4444 | jq '.[]|length'`
+    CHN5=`./showdb -c -d node_5555 | jq '.[]|length'`
+    CHN6=`./showdb -c -d node_6666 | jq '.[]|length'`
+    NOD3=`./showdb -n -d node_3333 | jq '.[]|length'`
+    NOD4=`./showdb -n -d node_4444 | jq '.[]|length'`
+    NOD5=`./showdb -n -d node_5555 | jq '.[]|length'`
+    NOD6=`./showdb -n -d node_6666 | jq '.[]|length'`
+    echo CHAN3=$CHN3:$NOD3 CHAN4=$CHN4:$NOD4 CHAN5=$CHN5:$NOD5 CHAN6=$CHN6:$NOD6
 
-    LEN3=`cat n3.txt | wc -c`
-    LEN4=`cat n4.txt | wc -c`
-    LEN5=`cat n5.txt | wc -c`
-    LEN6=`cat n6.txt | wc -c`
-
-    if [ -n "$LEN3" ] && [ -n "$LEN4" ] && [ -n "$LEN5" ] && [ -n "$LEN6" ] && [ "$LEN3" -ne 0 ] && [ "$LEN4" -ne 0 ] && [ "$LEN5" -ne 0 ] && [ "$LEN6" -ne 0 ] && [ "$RES1" -eq 0 ] && [ "$RES2" -eq 0 ] && [ "$RES3" -eq 0 ]; then
+    if [ "$CHN3" -eq 9 ] && [ "$CHN4" -eq 9 ] && [ "$CHN5" -eq 9 ] && [ "$CHN6" -eq 9 ] && [ "$NOD3" -eq 4 ] && [ "$NOD4" -eq 4 ] && [ "$NOD5" -eq 4 ] && [ "$NOD6" -eq 4 ]; then
         break
     fi
     sleep 3

--- a/tests/4nodes_test/example_st_quit.sh
+++ b/tests/4nodes_test/example_st_quit.sh
@@ -2,7 +2,20 @@
 
 # ノードの停止
 #
-./ptarmcli -q 3334
-./ptarmcli -q 4445
-./ptarmcli -q 5556
-./ptarmcli -q 6667
+
+echo ------------------STOP-----------------------
+for i in 3334 4445 5556 6667
+do
+    ./ptarmcli -q $i
+done
+
+while :
+do
+	PROC_COUNT=`ps -C ptarmd | grep ptarmd | wc -l`
+	echo live procs: $PROC_COUNT
+	if [ $PROC_COUNT -eq 0 ]; then
+		break;
+	fi
+	sleep 1
+done
+echo ------------------STOP DONE-----------------------

--- a/tools/log_filter.sh
+++ b/tools/log_filter.sh
@@ -11,6 +11,8 @@ grep -n -e "\/E" -e "fail\:"  tests/4nodes_test/node_*/logs/log | \
         -e "not real value" \
         -e "channel_id is 0" \
         -e "recv_peer]fail: timeout(" \
-        -e "already connected"
+        -e "already connected" \
+        -e "cmd_json_connect]fail: connect test" \
+        -e "Connection reset by peer"
 cd -
 )


### PR DESCRIPTION
`all_tests.sh`を実行してエラーになっている場合、以下のようなログがあった。

* JSONRPCでquitを受け取ったが、monitoringの再接続動作と重なってすぐに切断 or 相手が既にquit状態になっている
* `ping`を打ったが、相手が先にquitしている

そういうことから、切断前後を見直した。
* monitoringスレッドを先に終わらせる
  * それでもタイミングによっては再接続するので、再接続エラーはlog_filter.shでスルー
* socketのaccept()待ちになっているところは、accept後に終了フラグをチェック
* announcementの完了チェックを、announcement数(9つ)とnode_announcement数(3つ)で比較する
  * 以前の比較方法で問題があったわけではないが、数の方が確実な気がしている
