### PR TITLE
fix_db: no key create

### DIFF
--- a/ln/ln_db_lmdb.c
+++ b/ln/ln_db_lmdb.c
@@ -1114,8 +1114,8 @@ bool ln_db_channel_search_readonly(ln_db_func_cmp_t pFunc, void *pFuncParam)
 
 bool ln_db_channel_search_nk_readonly(ln_db_func_cmp_t pFunc, void *pFuncParam)
 {
-#warning NOT READONLY and KEY CREATE
-    return channel_search(pFunc, pFuncParam, true, true);
+#warning NOT READONLY
+    return channel_search(pFunc, pFuncParam, true, false);
 }
 
 


### PR DESCRIPTION
#1155 の続き

channel loadの引き続いてkey createさせないことについては、連続動作させても影響がないようだったため、戻す。

read onlyについては現象が発生するため、ここを対処するか、できなければread onlyをなくす。