### PR TITLE
Reduce getfee

### DIFF
--- a/ptarmd/monitoring.c
+++ b/ptarmd/monitoring.c
@@ -1172,6 +1172,7 @@ static uint32_t get_latest_feerate_kw(void)
 
 static bool update_btc_values(void)
 {
+#ifdef USE_BITCOINJ
     int32_t height;
     bool ret = btcrpc_getblockcount(&height);
     if (ret && (height != mMonParam.height)) {
@@ -1187,6 +1188,9 @@ static bool update_btc_values(void)
             mMonParam.feerate_per_kw = 0;
         }
     }
+#else
+    bool ret = btcrpc_getblockcount(&mMonParam.height);
+#endif
     return ret;
 }
 

--- a/ptarmd/monitoring.c
+++ b/ptarmd/monitoring.c
@@ -1172,15 +1172,21 @@ static uint32_t get_latest_feerate_kw(void)
 
 static bool update_btc_values(void)
 {
-    if (mFeeratePerKw == 0) {
-        mMonParam.feerate_per_kw = get_latest_feerate_kw();
-    } else {
-        mMonParam.feerate_per_kw = mFeeratePerKw;
+    int32_t height;
+    bool ret = btcrpc_getblockcount(&height);
+    if (ret && (height != mMonParam.height)) {
+        mMonParam.height = height;
+
+        //update feerate if blockcount changed
+        if (mFeeratePerKw == 0) {
+            mMonParam.feerate_per_kw = get_latest_feerate_kw();
+        } else {
+            mMonParam.feerate_per_kw = mFeeratePerKw;
+        }
+        if (mMonParam.feerate_per_kw < LN_FEERATE_PER_KW_MIN) {
+            mMonParam.feerate_per_kw = 0;
+        }
     }
-    if (mMonParam.feerate_per_kw < LN_FEERATE_PER_KW_MIN) {
-        mMonParam.feerate_per_kw = 0;
-    }
-    bool ret = btcrpc_getblockcount(&mMonParam.height);
     return ret;
 }
 


### PR DESCRIPTION
負荷軽減のため、SPVの場合のみfeerate取得をブロック高更新時のみにする(bitcoindの場合は30秒間隔のまま)。
feerateサービスにJSONを取得しに行くため、あまり頻度は高くない方がよいと思われる、というのもある。