### PR TITLE
gquery5

### DIFF
--- a/ln/ln.c
+++ b/ln/ln.c
@@ -601,7 +601,7 @@ bool ln_channel_update_get_peer(const ln_channel_t *pChannel, utl_buf_t *pCnlUpd
 
     btc_script_pubkey_order_t order = ln_node_id_order(pChannel, NULL);
     uint8_t dir = (order == BTC_SCRYPT_PUBKEY_ORDER_OTHER) ? 0 : 1;  //相手のchannel_update
-    ret = ln_db_annocnlupd_load(pCnlUpd, NULL, pChannel->short_channel_id, dir);
+    ret = ln_db_annocnlupd_load(pCnlUpd, NULL, pChannel->short_channel_id, dir, NULL);
     if (ret && (pMsg != NULL)) {
         ret = ln_msg_channel_update_read(pMsg, pCnlUpd->buf, pCnlUpd->len);
     }

--- a/ln/ln_db.h
+++ b/ln/ln_db.h
@@ -40,8 +40,8 @@ extern "C" {
  ********************************************************************/
 
 #define LN_DB_CNLANNO_ANNO          'A'     ///< channel_announcement用KEYの末尾: channel_announcement
-#define LN_DB_CNLANNO_UPD1          'B'     ///< channel_announcement用KEYの末尾: channel_update 1
-#define LN_DB_CNLANNO_UPD2          'C'     ///< channel_announcement用KEYの末尾: channel_update 2
+#define LN_DB_CNLANNO_UPD0          'B'     ///< channel_announcement用KEYの末尾: channel_update dir=0
+#define LN_DB_CNLANNO_UPD1          'C'     ///< channel_announcement用KEYの末尾: channel_update dir=1
 
 #define LN_DB_WALLET_TYPE_TO_LOCAL   ((uint8_t)1)
 #define LN_DB_WALLET_TYPE_TO_REMOTE  ((uint8_t)2)
@@ -352,9 +352,10 @@ bool ln_db_annocnl_save(const utl_buf_t *pCnlAnno, uint64_t ShortChannelId, cons
  * @param[out]      pTimeStamp          pCnlAnnoのTimeStamp
  * @param[in]       ShortChannelId      読み込むshort_channel_id
  * @param[in]       Dir                 0:node1, 1:node2
+ * @param[in]       pDbParam            非NULL:指定されたdb paramを使用する
  * @retval      true    成功
  */
-bool ln_db_annocnlupd_load(utl_buf_t *pCnlUpd, uint32_t *pTimeStamp, uint64_t ShortChannelId, uint8_t Dir);
+bool ln_db_annocnlupd_load(utl_buf_t *pCnlUpd, uint32_t *pTimeStamp, uint64_t ShortChannelId, uint8_t Dir, void *pDbParam);
 
 
 /** channel_update書込み
@@ -468,18 +469,10 @@ bool ln_db_annocnlinfo_search_nodeid(void *pCur, uint64_t ShortChannelId, char T
 bool ln_db_annocnl_cur_get(void *pCur, uint64_t *pShortChannelId, char *pType, uint32_t *pTimeStamp, utl_buf_t *pBuf);
 
 
-/** channel_announcement関連情報の前方取得
- *
- * #ln_db_annocnl_cur_get()ではcursorが進んでしまうため、戻す場合に使う想定。
- *
- * @param[in]       pCur
- * @param[out]      pShortChannelId         short_channel_id
- * @param[out]      pType                   LN_DB_CNLANNO_xxx(channel_announcement / channel_update)
- * @param[out]      pTimeStamp              channel_announcementのtimestamp
- * @param[out]      pBuf                    取得したデータ(p_typeに応じて内容は変わる)
- * @retval  true    成功
+/** channel_announcement関連情報の前方移動
+ * 
  */
-bool ln_db_annocnl_cur_getback(void *pCur, uint64_t *pShortChannelId, char *pType, uint32_t *pTimeStamp, utl_buf_t *pBuf);
+bool ln_db_annocnl_cur_back(void *pCur);
 
 
 /** ln_db_annocnl_cur_get()したDBの削除

--- a/ln/ln_msg_anno.c
+++ b/ln/ln_msg_anno.c
@@ -649,7 +649,7 @@ static void channel_update_print(const ln_msg_channel_update_t *pMsg)
     LOGD("timestamp(fmt): %s\n", utl_time_fmt(time, pMsg->timestamp));
     LOGD("message_flags: 0x%02x\n", pMsg->message_flags);
     LOGD("channel_flags: 0x%02x\n", pMsg->channel_flags);
-    LOGD("  direction: %s\n", ln_cnlupd_direction(pMsg) ? "node_2" : "node_1"); //XXX:
+    LOGD("  direction: %d\n", ln_cnlupd_direction(pMsg)); //XXX:
     LOGD("  %s\n", ln_cnlupd_enable(pMsg) ? "enable" : "disable"); //XXX:
     LOGD("cltv_expiry_delta: %u\n", pMsg->cltv_expiry_delta);
     LOGD("htlc_minimum_msat: %" PRIu64 "\n", pMsg->htlc_minimum_msat);

--- a/ln/ln_normalope.c
+++ b/ln/ln_normalope.c
@@ -1310,7 +1310,7 @@ static bool check_recv_add_htlc_bolt4_forward(
         return false;
     }
     uint8_t dir = ln_order_to_dir(ln_node_id_order(pChannel, peer_id));
-    if (!ln_db_annocnlupd_load(&cnlupd_buf, NULL, pDataOut->short_channel_id, dir)) {
+    if (!ln_db_annocnlupd_load(&cnlupd_buf, NULL, pDataOut->short_channel_id, dir, NULL)) {
         LOGE("fail: ln_db_annocnlupd_load: %016" PRIx64 ", dir=%d\n",
             pDataOut->short_channel_id, dir);
         M_SET_ERR(pChannel, LNERR_INV_VALUE, "no channel_update");

--- a/ln/ln_routing.cpp
+++ b/ln/ln_routing.cpp
@@ -200,13 +200,13 @@ static void dumpit_chan(nodes_result_t *p_result, char type, const utl_buf_t *p_
         M_DBGLOGV("[cnl]node2= ");
         M_DBGDUMPV(p_nodes->ninfo[1].node_id, BTC_SZ_PUBKEY);
         break;
+    case LN_DB_CNLANNO_UPD0:
     case LN_DB_CNLANNO_UPD1:
-    case LN_DB_CNLANNO_UPD2:
         if (p_result->node_num > 0) {
             p_nodes = &p_result->p_nodes[p_result->node_num - 1];
 
             ln_msg_channel_update_t upd;
-            int idx = type - LN_DB_CNLANNO_UPD1;
+            int idx = type - LN_DB_CNLANNO_UPD0;
             bool bret = ln_channel_update_get_params(&upd, p_buf->buf, p_buf->len);
             if (bret && ((upd.channel_flags & LN_CNLUPD_CHFLAGS_DISABLE) == 0)) {
                 if (p_nodes->short_channel_id == upd.short_channel_id) {

--- a/ln/tests/test_ln_htlcflag.cpp
+++ b/ln/tests/test_ln_htlcflag.cpp
@@ -54,7 +54,7 @@ extern "C" {
 //FAKE関数
 
 FAKE_VOID_FUNC(ln_db_preimage_cur_close, void *);
-FAKE_VALUE_FUNC(bool, ln_db_annocnlupd_load, utl_buf_t *, uint32_t *, uint64_t, uint8_t);
+FAKE_VALUE_FUNC(bool, ln_db_annocnlupd_load, utl_buf_t *, uint32_t *, uint64_t, uint8_t, void*);
 FAKE_VALUE_FUNC(bool, ln_db_preimage_del, const uint8_t *);
 FAKE_VALUE_FUNC(bool, ln_db_preimage_cur_open, void **);
 FAKE_VALUE_FUNC(bool, ln_db_preimage_cur_get, void *, bool *, ln_db_preimage_t *);

--- a/ln/tests/test_ln_proto_acceptchannel.cpp
+++ b/ln/tests/test_ln_proto_acceptchannel.cpp
@@ -57,7 +57,7 @@ extern "C" {
 //FAKE関数
 
 FAKE_VOID_FUNC(ln_db_preimage_cur_close, void *);
-FAKE_VALUE_FUNC(bool, ln_db_annocnlupd_load, utl_buf_t *, uint32_t *, uint64_t, uint8_t);
+FAKE_VALUE_FUNC(bool, ln_db_annocnlupd_load, utl_buf_t *, uint32_t *, uint64_t, uint8_t, void*);
 FAKE_VALUE_FUNC(bool, ln_db_preimage_del, const uint8_t *);
 FAKE_VALUE_FUNC(bool, ln_db_preimage_cur_open, void **);
 FAKE_VALUE_FUNC(bool, ln_db_preimage_cur_get, void *, bool *, ln_db_preimage_t *);

--- a/ln/tests/test_ln_proto_openchannel.cpp
+++ b/ln/tests/test_ln_proto_openchannel.cpp
@@ -56,7 +56,7 @@ extern "C" {
 //FAKE関数
 
 FAKE_VOID_FUNC(ln_db_preimage_cur_close, void *);
-FAKE_VALUE_FUNC(bool, ln_db_annocnlupd_load, utl_buf_t *, uint32_t *, uint64_t, uint8_t);
+FAKE_VALUE_FUNC(bool, ln_db_annocnlupd_load, utl_buf_t *, uint32_t *, uint64_t, uint8_t, void*);
 FAKE_VALUE_FUNC(bool, ln_db_preimage_del, const uint8_t *);
 FAKE_VALUE_FUNC(bool, ln_db_preimage_cur_open, void **);
 FAKE_VALUE_FUNC(bool, ln_db_preimage_cur_get, void *, bool *, ln_db_preimage_t *);

--- a/ln/tests/test_ln_proto_updateaddhtlc.cpp
+++ b/ln/tests/test_ln_proto_updateaddhtlc.cpp
@@ -56,7 +56,7 @@ extern "C" {
 //FAKE関数
 
 FAKE_VOID_FUNC(ln_db_preimage_cur_close, void *);
-FAKE_VALUE_FUNC(bool, ln_db_annocnlupd_load, utl_buf_t *, uint32_t *, uint64_t, uint8_t);
+FAKE_VALUE_FUNC(bool, ln_db_annocnlupd_load, utl_buf_t *, uint32_t *, uint64_t, uint8_t, void*);
 FAKE_VALUE_FUNC(bool, ln_db_preimage_del, const uint8_t *);
 FAKE_VALUE_FUNC(bool, ln_db_preimage_cur_open, void **);
 FAKE_VALUE_FUNC(bool, ln_db_preimage_cur_get, void *, bool *, ln_db_preimage_t *);

--- a/ln/tests/test_ln_proto_updatechannel.cpp
+++ b/ln/tests/test_ln_proto_updatechannel.cpp
@@ -54,7 +54,7 @@ extern "C" {
 //FAKE関数
 
 FAKE_VOID_FUNC(ln_db_preimage_cur_close, void *);
-FAKE_VALUE_FUNC(bool, ln_db_annocnlupd_load, utl_buf_t *, uint32_t *, uint64_t, uint8_t);
+FAKE_VALUE_FUNC(bool, ln_db_annocnlupd_load, utl_buf_t *, uint32_t *, uint64_t, uint8_t, void*);
 FAKE_VALUE_FUNC(bool, ln_db_preimage_del, const uint8_t *);
 FAKE_VALUE_FUNC(bool, ln_db_preimage_cur_open, void **);
 FAKE_VALUE_FUNC(bool, ln_db_preimage_cur_get, void *, bool *, ln_db_preimage_t *);

--- a/ln/tests/test_ln_proto_updatefee.cpp
+++ b/ln/tests/test_ln_proto_updatefee.cpp
@@ -55,7 +55,7 @@ extern "C" {
 //FAKE関数
 
 FAKE_VOID_FUNC(ln_db_preimage_cur_close, void *);
-FAKE_VALUE_FUNC(bool, ln_db_annocnlupd_load, utl_buf_t *, uint32_t *, uint64_t, uint8_t);
+FAKE_VALUE_FUNC(bool, ln_db_annocnlupd_load, utl_buf_t *, uint32_t *, uint64_t, uint8_t, void*);
 FAKE_VALUE_FUNC(bool, ln_db_preimage_del, const uint8_t *);
 FAKE_VALUE_FUNC(bool, ln_db_preimage_cur_open, void **);
 FAKE_VALUE_FUNC(bool, ln_db_preimage_cur_get, void *, bool *, ln_db_preimage_t *);

--- a/ptarmd/lnapp.h
+++ b/ptarmd/lnapp.h
@@ -128,7 +128,6 @@ typedef struct lnapp_conf_t {
 
     //send announcement
     uint64_t        last_anno_cnl;                      ///< [#send_channel_anno()]最後にannouncementしたchannel
-    uint64_t        last_annocnl_sci;                   ///< [#send_channel_anno()]最後にcur_getしたchannel_announcementのshort_channel_id
     bool            annosig_send_req;                   ///< true: open_channel.announce_channel=1 and announcement_signatures not send
     bool            annodb_updated;                     ///< true: flag to notify annodb update
     bool            annodb_cont;                        ///< true: announcement連続送信中

--- a/showdb/showdb.c
+++ b/showdb/showdb.c
@@ -607,7 +607,7 @@ static void ln_print_announce_short(const uint8_t *pData, uint16_t Len)
             ln_msg_channel_update_t msg;
             bool ret = ln_msg_channel_update_read(&msg, pData, Len);
             if (ret) {
-                printf(INDENT3 M_QQ("type") ": " M_QQ("channel_update %s") ",\n", (msg.channel_flags & LN_CNLUPD_CHFLAGS_DIRECTION) ? "2" : "1");
+                printf(INDENT3 M_QQ("type") ": " M_QQ("channel_update %d") ",\n", (msg.channel_flags & LN_CNLUPD_CHFLAGS_DIRECTION));
 
                 char str_sci[LN_SZ_SHORTCHANNELID_STR + 1];
                 ln_short_channel_id_string(str_sci, msg.short_channel_id);
@@ -866,11 +866,11 @@ static void dumpit_annoinfo(MDB_txn *txn, MDB_dbi dbi, ln_lmdb_dbtype_t dbtype)
             case LN_DB_CNLANNO_ANNO:
                 printf("channel_announcement: ");
                 break;
+            case LN_DB_CNLANNO_UPD0:
+                printf("channel_update 0: ");
+                break;
             case LN_DB_CNLANNO_UPD1:
                 printf("channel_update 1: ");
-                break;
-            case LN_DB_CNLANNO_UPD2:
-                printf("channel_update 2: ");
                 break;
             default:
                 fprintf(stderr, "keyname=%02x: %d\n", keyname[M_SZ_ANNOINFO_CNL - 1], __LINE__);


### PR DESCRIPTION
Gossip Queriesの布石。

* announcement送信を、1ループで1セット(`channel_announcement`, `channel_update` (dir=0, 1), `node_announcement` (node0, 1))送信するように変更
* `ln_db_annocnlupd_load()`でDBオープン済みでも使用できるように引数追加
* `channel_update`のdirectionを`0`と`1`に統一