### PR TITLE
gquery7

### DIFF
--- a/ln/ln_anno.h
+++ b/ln/ln_anno.h
@@ -46,7 +46,7 @@ bool /*HIDDEN*/ ln_channel_update_send(ln_channel_t *pChannel);
 bool HIDDEN ln_channel_update_recv(ln_channel_t *pChannel, const uint8_t *pData, uint16_t Len);
 bool ln_channel_update_disable(ln_channel_t *pChannel);
 
-bool ln_query_short_channel_ids_send(ln_channel_t *pChannel);
+bool ln_query_short_channel_ids_send(ln_channel_t *pChannel, const uint8_t *pEncodedIds, uint16_t Len);
 bool HIDDEN ln_query_short_channel_ids_recv(ln_channel_t *pChannel, const uint8_t *pData, uint16_t Len);
 bool ln_reply_short_channel_ids_end_send(ln_channel_t *pChannel, const ln_msg_query_short_channel_ids_t *pMsg);
 bool HIDDEN ln_reply_short_channel_ids_end_recv(ln_channel_t *pChannel, const uint8_t *pData, uint16_t Len);

--- a/ln/ln_msg_anno.c
+++ b/ln/ln_msg_anno.c
@@ -750,8 +750,9 @@ static void query_short_channel_ids_print(const ln_msg_query_short_channel_ids_t
     LOGD("-[query_short_channel_ids]-------------------------------\n");
     LOGD("chain_hash: ");
     DUMPD(pMsg->p_chain_hash, BTC_SZ_HASH256);
-    LOGD("encoded_short_ids: ");
     size_t len = pMsg->len;
+    LOGD("len=%lu\n", len);
+    LOGD("encoded_short_ids: ");
     if (len > 100) {
         len = 100;
     }
@@ -943,8 +944,9 @@ static void reply_channel_range_print(const ln_msg_reply_channel_range_t *pMsg)
     LOGD("first_blocknum: %" PRIu32 "\n", pMsg->first_blocknum);
     LOGD("number_of_blocks: %" PRIu32 "\n", pMsg->number_of_blocks);
     LOGD("complete: %02x\n", pMsg->complete);
-    LOGD("encoded_short_ids: ");
     size_t len = pMsg->len;
+    LOGD("len=%lu\n", len);
+    LOGD("encoded_short_ids: ");
     if (len > 100) {
         len = 100;
     }

--- a/ln/ln_setupctl.c
+++ b/ln/ln_setupctl.c
@@ -95,6 +95,9 @@ bool /*HIDDEN*/ ln_init_send(ln_channel_t *pChannel, bool bInitRouteSync, bool b
     msg.gflen = 0;
     msg.p_globalfeatures = NULL;
     pChannel->lfeature_local = mInitLocalFeatures[0] | (bInitRouteSync ? LN_INIT_LF_ROUTE_SYNC : 0);
+#ifdef USE_GQUERY
+    pChannel->lfeature_local |= LN_INIT_LF_OPT_GSP_QUERY;
+#endif  //USE_GQUERY
     msg.lflen = sizeof(pChannel->lfeature_local);
     msg.p_localfeatures = &pChannel->lfeature_local;
     LOGD("localfeatures: ");

--- a/ln/tests/test_ln_anno.cpp
+++ b/ln/tests/test_ln_anno.cpp
@@ -122,7 +122,7 @@ TEST_F(ln, no_gossip_queries)
     memset(&qsci, 0, sizeof(qsci));
     memset(&qcr, 0, sizeof(qcr));
 
-    ASSERT_FALSE(ln_query_short_channel_ids_send(&channel));
+    ASSERT_FALSE(ln_query_short_channel_ids_send(&channel, NULL, 0));
     ASSERT_TRUE(ln_query_short_channel_ids_recv(&channel, NULL, 0));
     ASSERT_FALSE(ln_reply_short_channel_ids_end_send(&channel, &qsci));
     ASSERT_FALSE(ln_reply_short_channel_ids_end_recv(&channel, NULL, 0));

--- a/options.mak
+++ b/options.mak
@@ -98,6 +98,7 @@ ifeq ($(ENABLE_DEVELOPER_MODE),1)
 	CFLAGS += -DDEVELOPER_MODE
 endif
 
+#CFLAGS += -DUSE_GQUERY
 
 # for syscall()
 CFLAGS += -D_GNU_SOURCE

--- a/ptarmd/lnapp.c
+++ b/ptarmd/lnapp.c
@@ -921,6 +921,15 @@ static void *thread_main_start(void *pArg)
     // send `channel_update` for private/before publish channel
     send_cnlupd_before_announce(p_conf);
 
+#ifdef USE_GQUERY
+    ret = ln_query_channel_range_send(p_channel, 0, UINT32_MAX);
+    if (ret) {
+        (void)ln_gossip_timestamp_filter_send(p_channel);
+    } else {
+        LOGE("fail: ln_query_channel_range_send\n");
+    }
+#endif  //USE_GQUERY
+
     {
         // method: connected
         // $1: short_channel_id


### PR DESCRIPTION
* disable gossip_queries
* send query_short_channel_ids
* reply no channel_ids

相手からannouncementをもらうことはできるが、相手へ送るところはできていないので、無効にしておく。
また、相手へannouncementを要求するところも、まだ条件付きである。