### PR TITLE
Private channel

### DIFF
--- a/ln/ln.h
+++ b/ln/ln.h
@@ -109,7 +109,7 @@ extern "C" {
 
 // channel.fund_flag
 #define LN_FUNDFLAG_FUNDER              (1 << 0)    ///< 1:funder / 0:fundee
-#define LN_FUNDFLAG_NO_ANNO_CH          (1 << 1)    ///< 1:announcement_signatures未送信 / 0:announcement_signatures送信不要 or 送信済み
+#define LN_FUNDFLAG_NO_ANNO_CH          (1 << 1)    ///< 1:announcement_signatures未送信(後で送信する) / 0:announcement_signatures送信不要 or 送信済み(もう送信しない)
 #define LN_FUNDFLAG_FUNDING             (1 << 2)    ///< 1:open_channel～funding_lockedまで
 #define LN_FUNDFLAG_OPENED              (1 << 7)    ///< 1:opened
 

--- a/ln/ln_establish.h
+++ b/ln/ln_establish.h
@@ -47,10 +47,12 @@
  * @param[in]           FundingSat      fundingするamount[satoshi]
  * @param[in]           PushSat         push_msatするamount[satoshi]
  * @param[in]           FeeRate         feerate_per_kw
+ * @param[in]           PrivChannel     !=0: private channel
  * retval       true    成功
  */
 bool /*HIDDEN*/ ln_open_channel_send(
-    ln_channel_t *pChannel, const ln_fundin_t *pFundin, uint64_t FundingSat, uint64_t PushSat, uint32_t FeeRate);
+    ln_channel_t *pChannel, const ln_fundin_t *pFundin, uint64_t FundingSat, uint64_t PushSat, uint32_t FeeRate,
+    uint8_t PrivChannel);
 bool HIDDEN ln_open_channel_recv(ln_channel_t *pChannel, const uint8_t *pData, uint16_t Len);
 bool HIDDEN ln_accept_channel_send(ln_channel_t *pChannel);
 bool HIDDEN ln_accept_channel_recv(ln_channel_t *pChannel, const uint8_t *pData, uint16_t Len);

--- a/ln/ln_msg_establish.h
+++ b/ln/ln_msg_establish.h
@@ -38,7 +38,6 @@
 
 #define CHANNEL_FLAGS_ANNOCNL           (1 << 0)
 #define CHANNEL_FLAGS_MASK              CHANNEL_FLAGS_ANNOCNL   ///< open_channel.channel_flagsのBOLT定義あり
-#define CHANNEL_FLAGS_VALUE             CHANNEL_FLAGS_ANNOCNL   ///< TODO:open_channel.channel_flags
 
 
 /**************************************************************************

--- a/ln/tests/test_ln_proto_openchannel.cpp
+++ b/ln/tests/test_ln_proto_openchannel.cpp
@@ -277,7 +277,7 @@ TEST_F(ln, ln_open_channel_recv_ok)
             pMsg->p_delayed_payment_basepoint = pubkey;
             pMsg->p_htlc_basepoint = pubkey;
             pMsg->p_first_per_commitment_point = pubkey;
-            pMsg->channel_flags = CHANNEL_FLAGS_VALUE;
+            pMsg->channel_flags = CHANNEL_FLAGS_ANNOCNL;
             pMsg->shutdown_len = 0;
             pMsg->p_shutdown_scriptpubkey = NULL;
             return true;
@@ -335,7 +335,7 @@ TEST_F(ln, ln_open_channel_recv_sender1)
             pMsg->p_delayed_payment_basepoint = pubkey;
             pMsg->p_htlc_basepoint = pubkey;
             pMsg->p_first_per_commitment_point = pubkey;
-            pMsg->channel_flags = CHANNEL_FLAGS_VALUE;
+            pMsg->channel_flags = CHANNEL_FLAGS_ANNOCNL;
             pMsg->shutdown_len = 0;
             pMsg->p_shutdown_scriptpubkey = NULL;
             return true;
@@ -394,7 +394,7 @@ TEST_F(ln, ln_open_channel_recv_sender2)
             pMsg->p_delayed_payment_basepoint = pubkey;
             pMsg->p_htlc_basepoint = pubkey;
             pMsg->p_first_per_commitment_point = pubkey;
-            pMsg->channel_flags = CHANNEL_FLAGS_VALUE;
+            pMsg->channel_flags = CHANNEL_FLAGS_ANNOCNL;
             pMsg->shutdown_len = 0;
             pMsg->p_shutdown_scriptpubkey = NULL;
             return true;

--- a/ptarmd/cmd_json.c
+++ b/ptarmd/cmd_json.c
@@ -582,6 +582,15 @@ static cJSON *cmd_fund(jrpc_context *ctx, cJSON *params, cJSON *id)
         //デフォルト値
         fundconf.feerate_per_kw = 0;
     }
+    //private channel
+    json = cJSON_GetArrayItem(params, index++);
+    if (json && (json->type == cJSON_Number)) {
+        fundconf.priv_channel = json->valueint;
+        LOGD("priv_chanel=%" PRIu32 "\n", fundconf.priv_channel);
+    } else {
+        //デフォルト値
+        fundconf.priv_channel = 0;
+    }
 
     LOGD("$$$: [JSONRPC]fund\n");
 

--- a/ptarmd/lnapp.c
+++ b/ptarmd/lnapp.c
@@ -1402,7 +1402,8 @@ static bool send_open_channel(lnapp_conf_t *p_conf, const funding_conf_t *pFundi
                         &fundin,
                         pFunding->funding_sat,
                         pFunding->push_sat,
-                        feerate_kw);
+                        feerate_kw,
+                        pFunding->priv_channel);
         if (ret) {
             LOGD("SEND: open_channel\n");
         } else {

--- a/ptarmd/ptarmd.h
+++ b/ptarmd/ptarmd.h
@@ -194,6 +194,7 @@ typedef struct funding_conf_t {
     uint64_t        funding_sat;
     uint64_t        push_sat;
     uint32_t        feerate_per_kw;
+    uint8_t         priv_channel;           //not 0: private channel
 } funding_conf_t;
 
 

--- a/tests/4nodes_test/example_st3.sh
+++ b/tests/4nodes_test/example_st3.sh
@@ -79,7 +79,7 @@ sleep 3
 # node_6666からnode_5555へチャネルを開く。
 ./fund-test-in.sh > node_6666/fund6666_5555.conf
 sleep 1
-./ptarmcli -c conf/peer5555.conf -f node_6666/fund6666_5555.conf --private 6667
+./ptarmcli -c conf/peer5555.conf -f node_6666/fund6666_5555.conf 6667
 
 # 少し待つ
 echo wait...

--- a/tests/4nodes_test/example_st3.sh
+++ b/tests/4nodes_test/example_st3.sh
@@ -79,7 +79,7 @@ sleep 3
 # node_6666からnode_5555へチャネルを開く。
 ./fund-test-in.sh > node_6666/fund6666_5555.conf
 sleep 1
-./ptarmcli -c conf/peer5555.conf -f node_6666/fund6666_5555.conf 6667
+./ptarmcli -c conf/peer5555.conf -f node_6666/fund6666_5555.conf --private 6667
 
 # 少し待つ
 echo wait...


### PR DESCRIPTION
`ptarmcli -f --private`とすると、`open_channel.channel_flags.announce_channel`を0とする。
また、`announcement_signatures`を送信しない。