### PR TITLE
ptarmd: change the monitoring cyclic for developer mode to 20s

### DIFF
--- a/ptarmd/monitoring.c
+++ b/ptarmd/monitoring.c
@@ -50,8 +50,12 @@
  **************************************************************************/
 
 #define M_WAIT_START_SEC                (5)         ///< monitoring start[sec]
+#ifdef DEVELOPER_MODE
+//Workaround for `lightning-integration`'s timeout (outside BOLT specifications)
+#define M_WAIT_MON_SEC                  (20)        ///< monitoring cyclic[sec] for developer mode
+#else
 #define M_WAIT_MON_SEC                  (30)        ///< monitoring cyclic[sec]
-
+#endif
 
 /**************************************************************************
  * typedefs


### PR DESCRIPTION
Workaround for `lightning-integration`'s timeout (outside BOLT specifications)