### PR TITLE
gquery8: anno DB key change BigEndian for sort

### DIFF
--- a/ln/ln_db.h
+++ b/ln/ln_db.h
@@ -547,12 +547,19 @@ bool ln_db_annoown_del(uint64_t ShortChannelId);
  ********************************************************************/
 
 /** channel_announcement/channel_update/node_announcement送受信ノード情報削除
- * announcement送信済みのnode_idを保持しているので、起動時に全削除する。
- * また、チャネル接続時には接続先node_idの情報を削除する。
+ * announcement送信済みnode_idから削除する。
  *
  * @param[in]       pNodeId     削除対象のnode_id(NULL時は全削除)
  */
 bool ln_db_annoinfos_del(const uint8_t *pNodeId);
+
+
+/** channel_announcement/channel_update/node_announcement送受信ノード情報追加
+ * announcement送信済みnode_idに追加する。
+ *
+ * @param[in]       pNodeId     削除対象のnode_id(NULL時は全削除)
+ */
+bool ln_db_annoinfos_add(const uint8_t *pNodeId);
 
 
 /********************************************************************

--- a/ln/ln_msg_anno.c
+++ b/ln/ln_msg_anno.c
@@ -51,7 +51,7 @@
  * macros
  ********************************************************************/
 
-#define M_ZLIB_CHUNK	        (1024)
+#define M_ZLIB_CHUNK            (1024)
 
 #ifdef DEVELOPER_MODE
 #define DBG_PRINT_READ_CNL

--- a/ptarmd/lnapp.h
+++ b/ptarmd/lnapp.h
@@ -94,10 +94,6 @@ typedef struct lnapp_conf_t {
     
     //routing_sync
     ptarmd_routesync_t  routesync;              ///< local routing_sync
-    uint32_t            firstblock;             ///< [query/reply_channel_range]
-    uint32_t            lastblock;              ///< [query/reply_channel_range]
-    uint32_t            firsttimestamp;         ///< [gossip_timestamp_filter]
-    uint32_t            lasttimestamp;          ///< [gossip_timestamp_filter]
 
     //lnappワーク
     volatile bool   loop;                   ///< true:channel動作中

--- a/showdb/showdb.c
+++ b/showdb/showdb.c
@@ -863,7 +863,7 @@ static void dumpit_annoinfo(MDB_txn *txn, MDB_dbi dbi, ln_lmdb_dbtype_t dbtype)
 
             uint64_t short_channel_id;
             char str_sci[LN_SZ_SHORTCHANNELID_STR + 1];
-            memcpy(&short_channel_id, key.mv_data, sizeof(short_channel_id));
+            short_channel_id = utl_int_pack_u64be(key.mv_data);
             ln_short_channel_id_string(str_sci, short_channel_id);
             printf("%s\n", str_sci);
         } else if ((dbtype == LN_LMDB_DBTYPE_ANNOINFO_NODE) && (key.mv_size == M_SZ_ANNOINFO_NODE)) {


### PR DESCRIPTION
* anno DBのkeyでshort_channel_idを使っている場合、今まではLittleEndianだったが、BigEndianに変更する。
  * Gossip Queriesではshort_channel_idを昇順にすることが求められているため。
* announcementを送信済み(annoinfo DB)にする関数追加
  * 未送信にする際、node_idが無くなってもkeyだけは残すようにする
* `ln_gquery_t`は、まだ準備しているだけ。