### PR TITLE
gquery10: receive query_short_channel_ids

### DIFF
--- a/ln/ln_db.h
+++ b/ln/ln_db.h
@@ -265,7 +265,7 @@ bool ln_db_channel_search_nk_readonly(ln_db_func_cmp_t pFunc, void *pFuncParam);
 
 
 /** load pChannel->status
- * 
+ *
  * @param[in,out]       pChannel        channel info
  * @retval  load result
  * @note
@@ -275,7 +275,7 @@ bool ln_db_channel_load_status(ln_channel_t *pChannel);
 
 
 /** save pChannel->status
- * 
+ *
  * @param[in]           pChannel        channel info
  * @retval  save result
  */
@@ -283,7 +283,7 @@ bool ln_db_channel_save_status(const ln_channel_t *pChannel, void *pDbParam);
 
 
 /** save pChannel->last_confirm
- * 
+ *
  * @param[in]           pChannel        channel info
  * @retval  save result
  */
@@ -441,9 +441,9 @@ void ln_db_anno_cur_close(void *pCur);
  * @param[in]       ShortChannelId
  * @param[in]       Type
  * @param[in]       bClr                true:保存したノードを削除してから追加する
- * @param[in]       pSendId             送信元/先ノード
+ * @param[in]       pNodeId             追加するnode_id
  */
-bool ln_db_annocnlinfo_add_nodeid(void *pCur, uint64_t ShortChannelId, char Type, bool bClr, const uint8_t *pSendId);
+bool ln_db_annocnlinfo_add_nodeid(void *pCur, uint64_t ShortChannelId, char Type, bool bClr, const uint8_t *pNodeId);
 
 
 /** channel_announcement関連情報送信済み検索
@@ -451,10 +451,10 @@ bool ln_db_annocnlinfo_add_nodeid(void *pCur, uint64_t ShortChannelId, char Type
  * @param[in]       pCur
  * @param[in]       ShortChannelId      検索するshort_channel_id
  * @param[in]       Type                検索するchannel_announcement/channel_update[1/2]
- * @param[in]       pSendId             対象node_id
- * @retval  true    pSendIdへ送信済み
+ * @param[in]       pNodeId             対象node_id
+ * @retval  true    pNodeIdへ送信済み
  */
-bool ln_db_annocnlinfo_search_nodeid(void *pCur, uint64_t ShortChannelId, char Type, const uint8_t *pSendId);
+bool ln_db_annocnlinfo_search_nodeid(void *pCur, uint64_t ShortChannelId, char Type, const uint8_t *pNodeId);
 
 
 /** channel_announcement関連情報の順次取得
@@ -470,7 +470,7 @@ bool ln_db_annocnl_cur_get(void *pCur, uint64_t *pShortChannelId, char *pType, u
 
 
 /** channel_announcement関連情報の前方移動
- * 
+ *
  */
 bool ln_db_annocnl_cur_back(void *pCur);
 
@@ -550,8 +550,10 @@ bool ln_db_annoown_del(uint64_t ShortChannelId);
  * announcement送信済みnode_idから削除する。
  *
  * @param[in]       pNodeId     削除対象のnode_id(NULL時は全削除)
+ * @param[in]       pShortChannelId     (pNodeId非NULL時)削除対象のshort_channel_id(NULL時は全削除)
+ * @param[in]       Num                 pShortChannelId数
  */
-bool ln_db_annoinfos_del(const uint8_t *pNodeId);
+bool ln_db_annoinfos_del(const uint8_t *pNodeId, const uint64_t *pShortChannelId, size_t Num);
 
 
 /** channel_announcement/channel_update/node_announcement送受信ノード情報追加
@@ -576,7 +578,7 @@ bool ln_db_routeskip_save(uint64_t ShortChannelId, bool bTemp);
 
 
 /** "routeskip" temporary skip <--> temporary work
- * 
+ *
  * @param[in]   bWork               true:skip-->work, false:work-->skip
  */
 bool ln_db_routeskip_work(bool bWork);

--- a/ln/ln_msg_anno.c
+++ b/ln/ln_msg_anno.c
@@ -170,7 +170,9 @@ static void announcement_signatures_print(const ln_msg_announcement_signatures_t
     LOGD("-[announcement_signatures]-------------------------------\n");
     LOGD("channel_id: ");
     DUMPD(pMsg->p_channel_id, LN_SZ_CHANNEL_ID);
-    LOGD("short_channel_id: %016" PRIx64 "\n", pMsg->short_channel_id);
+    char str_sci[LN_SZ_SHORTCHANNELID_STR + 1];
+    ln_short_channel_id_string(str_sci, pMsg->short_channel_id);
+    LOGD("short_channel_id: %s(%016" PRIx64 ")\n", str_sci, pMsg->short_channel_id);
     LOGD("node_signature: ");
     DUMPD(pMsg->p_node_signature, LN_SZ_SIGNATURE);
     LOGD("bitcoin_signature: ");
@@ -267,7 +269,9 @@ static void channel_announcement_print(const ln_msg_channel_announcement_t *pMsg
     DUMPD(pMsg->p_features, pMsg->len);
     LOGD("chain_hash: ");
     DUMPD(pMsg->p_chain_hash, BTC_SZ_HASH256);
-    LOGD("short_channel_id: %016" PRIx64 "\n", pMsg->short_channel_id);
+    char str_sci[LN_SZ_SHORTCHANNELID_STR + 1];
+    ln_short_channel_id_string(str_sci, pMsg->short_channel_id);
+    LOGD("short_channel_id: %s(%016" PRIx64 ")\n", str_sci, pMsg->short_channel_id);
     LOGD("node_id_1: ");
     DUMPD(pMsg->p_node_id_1, BTC_SZ_PUBKEY);
     LOGD("node_id_2: ");
@@ -643,7 +647,9 @@ static void channel_update_print(const ln_msg_channel_update_t *pMsg)
     //DUMPD(pMsg->signature, LN_SZ_SIGNATURE);
     //LOGD("chain_hash: ");
     //DUMPD(pMsg->p_chain_hash, BTC_SZ_HASH256);
-    LOGD("short_channel_id: %016" PRIx64 "\n", pMsg->short_channel_id);
+    char str_sci[LN_SZ_SHORTCHANNELID_STR + 1];
+    ln_short_channel_id_string(str_sci, pMsg->short_channel_id);
+    LOGD("short_channel_id: %s(%016" PRIx64 ")\n", str_sci, pMsg->short_channel_id);
     LOGD("timestamp: %u\n", pMsg->timestamp);
     char time[UTL_SZ_TIME_FMT_STR + 1];
     LOGD("timestamp(fmt): %s\n", utl_time_fmt(time, pMsg->timestamp));

--- a/ptarmd/lnapp.c
+++ b/ptarmd/lnapp.c
@@ -1471,10 +1471,17 @@ static void *thread_recv_start(void *pArg)
             }
             if (type == MSGTYPE_INIT) {
                 LOGD("$$$ init exchange...\n");
-                while ((p_conf->flag_recv & M_FLAGRECV_INIT_EXCHANGED) == 0) {
+                uint32_t count = M_WAIT_RESPONSE_MSEC / M_WAIT_RECV_MSG_MSEC;
+                while (p_conf->loop && (count > 0) && ((p_conf->flag_recv & M_FLAGRECV_INIT_EXCHANGED) == 0)) {
                     utl_thread_msleep(M_WAIT_RECV_MSG_MSEC);
+                    count--;
                 }
-                LOGD("$$$ init exchanged\n");
+                if (count > 0) {
+                    LOGD("$$$ init exchanged\n");
+                } else {
+                    LOGE("fail: init exchange timeout\n");
+                    stop_threads(p_conf);
+                }
             }
             //LOGD("mux_channel: end\n");
             pthread_mutex_unlock(&p_conf->mux_channel);

--- a/ptarmd/lnapp.h
+++ b/ptarmd/lnapp.h
@@ -83,7 +83,14 @@ LIST_HEAD(ponglisthead_t, ponglist_t);
  */
 typedef struct lnapp_conf_t {
     //p2p_svr/cli用
-    volatile int    sock;                       ///< -1:未接続
+    volatile int    sock;                   ///< -1:socket未接続
+
+    //lnappワーク
+    volatile bool   loop;                   ///< true:channel動作中
+    volatile uint8_t    flag_recv;          ///< 受信フラグ(M_FLAGRECV_xxx)
+
+
+    //p2p_svr/cli用
     pthread_t       th;                         ///< pthread id
     char            conn_str[SZ_CONN_STR + 1];  ///< 接続成功ログ/接続失敗リスト用
     uint16_t        conn_port;                  ///< 接続成功ログ/接続失敗リスト用
@@ -91,20 +98,16 @@ typedef struct lnapp_conf_t {
     //制御内容通知
     bool            initiator;                  ///< true:Noise Protocol handshakeのinitiator
     uint8_t         node_id[BTC_SZ_PUBKEY];     ///< 接続先(initiator==true時)
-    
+
     //routing_sync
     ptarmd_routesync_t  routesync;              ///< local routing_sync
 
     //lnappワーク
-    volatile bool   loop;                   ///< true:channel動作中
     ln_channel_t    *p_channel;             ///< channelのコンテキスト
-
     int             ping_counter;           ///< 無送受信時にping送信するカウンタ(カウントアップ)
-
     bool            funding_waiting;        ///< true:funding_txの安定待ち
     uint32_t        funding_confirm;        ///< funding_txのconfirmation数
 
-    volatile uint8_t    flag_recv;          ///< 受信フラグ(RECV_MSG_xxx)
 
     //BOLT送信キュー
     utl_buf_t       buf_sendque;            ///< send data array before noise encode
@@ -167,7 +170,7 @@ bool lnapp_funding(lnapp_conf_t *pAppConf, const funding_conf_t *pFundingConf);
  *******************************************/
 
 /** [lnapp]check pong list
- * 
+ *
  *  @retval     true    not receive pong against previous ping sending.
  */
 bool lnapp_check_ponglist(const lnapp_conf_t *pAppConf);


### PR DESCRIPTION
`query_short_channel_ids`受信で、該当するchannel_announcementを未送信状態にする(と、自動で送信する)。

* `query_short_channel_ids`は相手の全チャネルを要求している。
* channel_announcement系だけを未送信にしているだけで、node_announcementはまだやっていない。
* gossip_queriesは有効にしていない。

その他:
* `init`メッセージの交換が完了するまでsocket受信を強制的に止める
  * gossip_queriesの判定が終わり前に相手からgossipのメッセージを受信する可能性がある
  * `init`交換するまではメッセージを送信しないルールなので問題ないはず
* anno: log short_channel_id string
* lnapp: flag_recv value ENUM-->DEFINE