### PR TITLE
lnapp: forget pthread_mutex_unlock() if ln_recv() failed.

### DIFF
--- a/ptarmd/lnapp.c
+++ b/ptarmd/lnapp.c
@@ -1467,9 +1467,8 @@ static void *thread_recv_start(void *pArg)
                 LOGD("DISC: fail recv message\n");
                 lnapp_close_channel_force(ln_remote_node_id(p_conf->p_channel));
                 stop_threads(p_conf);
-                break;
             }
-            if (type == MSGTYPE_INIT) {
+            if ((p_conf->loop) && (type == MSGTYPE_INIT)) {
                 LOGD("$$$ init exchange...\n");
                 uint32_t count = M_WAIT_RESPONSE_MSEC / M_WAIT_RECV_MSG_MSEC;
                 while (p_conf->loop && (count > 0) && ((p_conf->flag_recv & M_FLAGRECV_INIT_EXCHANGED) == 0)) {
@@ -3047,6 +3046,7 @@ static void stop_threads(lnapp_conf_t *p_conf)
         LOGD("=  CHANNEL THREAD END: %016" PRIx64 " =\n", ln_short_channel_id(p_conf->p_channel));
         LOGD("=========================================\n");
     }
+    LOGD("$$$ stopped\n");
 }
 
 

--- a/ptarmd/ptarmd.c
+++ b/ptarmd/ptarmd.c
@@ -251,13 +251,13 @@ void ptarmd_stop(void)
 {
     if (mRunning) {
         mRunning = false;
-        LOGD("stopage order\n");
+        LOGD("$$$ stopage order\n");
         cmd_json_stop();
         monitor_stop();
         p2p_svr_stop_all();
         p2p_cli_stop_all();
     } else {
-        LOGD("stopped\n");
+        LOGD("$$$ stopped\n");
     }
 }
 


### PR DESCRIPTION
ln_recv()で失敗した場合、mutexのunlockを忘れている。