### PR TITLE
Reduce `strlen()`.

### DIFF
--- a/btc/btc_crypto.c
+++ b/btc/btc_crypto.c
@@ -330,7 +330,7 @@ bool btc_rng_init(void)
 
     //XXX: TODO: we not set the device-specific identifier yet
     if (mbedtls_ctr_drbg_seed(&mRng, mbedtls_entropy_func, &mEntropy,
-        (const unsigned char *)M_RNG_APP_SPECIFIC_DATA_STR, strlen(M_RNG_APP_SPECIFIC_DATA_STR))) return false;
+        (const unsigned char *)M_RNG_APP_SPECIFIC_DATA_STR, sizeof(M_RNG_APP_SPECIFIC_DATA_STR) - 1)) return false;
 
     mbedtls_ctr_drbg_set_prediction_resistance(&mRng, MBEDTLS_CTR_DRBG_PR_ON);
 #endif

--- a/btc/btc_keys.c
+++ b/btc/btc_keys.c
@@ -433,10 +433,15 @@ bool btc_keys_create(btc_keys_t *pKeys)
 /********************************************************************
  * private functions
  ********************************************************************/
+static bool zerolen(const char *pStr)
+{
+    assert(pStr != NULL);
+    return (pStr[0] == '\0');
+}
 
 static bool addr_is_p2pkh(const char *pAddr)
 {
-    if (strlen(pAddr) < 1) return false;
+    if (zerolen(pAddr)) return false;
 
     if (pAddr[0] == '1') return true; //mainnet
     if (pAddr[0] == 'm') return true; //testnet
@@ -446,7 +451,7 @@ static bool addr_is_p2pkh(const char *pAddr)
 
 static bool addr_is_p2sh(const char *pAddr)
 {
-    if (strlen(pAddr) < 1) return false;
+    if (zerolen(pAddr)) return false;
 
     if (pAddr[0] == '3') return true; //mainnet
     if (pAddr[0] == '2') return true; //testnet

--- a/btc/btc_keys.c
+++ b/btc/btc_keys.c
@@ -22,6 +22,7 @@
 /** @file   btc_keys.c
  *  @brief  bitcoin処理: 鍵関連
  */
+#include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -63,6 +64,8 @@ bool btc_keys_wif2priv(uint8_t *pPrivKey, btc_chain_t *pChain, const char *pWifP
     size_t sz_priv = sizeof(b58dec);
     int idx;
     int tail;
+
+    assert(pWifPriv != NULL);
 
     //b58tobin packs the data behind the buffer
     //if the data is larger than the buffer, skip leading zeros
@@ -312,6 +315,8 @@ bool btc_keys_addr2hash(uint8_t *pHash, int *pPrefix, const char *pAddr)
 {
     bool ret;
 
+    assert(pAddr != NULL);
+
     if (addr_is_p2pkh(pAddr) || addr_is_p2sh(pAddr)) {
         uint8_t bin[1 + BTC_SZ_HASH160 + 4];
         size_t sz = sizeof(bin);
@@ -460,6 +465,8 @@ static bool addr_is_p2sh(const char *pAddr)
 
 static bool addr_is_segwit(const char *pAddr)
 {
+    assert(pAddr != NULL);
+
     if (strlen(pAddr) < 3) return false;
 
     if (pAddr[0] == 'b' && pAddr[1] == 'c' && pAddr[2] == '1') return true; //mainnet

--- a/btc/btc_segwit_addr.c
+++ b/btc/btc_segwit_addr.c
@@ -37,6 +37,8 @@ size_t btc_bech32_encode_buf_len(const char *hrp, size_t data_len)
 
 bool btc_bech32_encode(char *output, size_t output_len, const char *hrp, const uint8_t *data, size_t data_len, bool ln)
 {
+    assert(hrp != NULL);
+
     if (hrp[0] == '\0') return false;
     if (output_len < strlen(hrp) + data_len + 8) return false;
     return bech32_encode(output, hrp, data, data_len, ln);
@@ -49,6 +51,8 @@ bool btc_bech32_decode(char* hrp, size_t hrp_len, uint8_t *data, size_t *data_le
     // if (hrp_len < strlen(input) - 6) return false;
     // if (strlen(input) < 8) return false;
     // if (*data_len < strlen(input) - 8) return false;
+
+    assert(input != NULL);
 
     //more rigorous test
     size_t data_len_tmp = 0;

--- a/btc/btc_segwit_addr.c
+++ b/btc/btc_segwit_addr.c
@@ -30,12 +30,14 @@
 
 size_t btc_bech32_encode_buf_len(const char *hrp, size_t data_len)
 {
+    assert(hrp != NULL);
+
     return strlen(hrp) + data_len + 8;
 }
 
 bool btc_bech32_encode(char *output, size_t output_len, const char *hrp, const uint8_t *data, size_t data_len, bool ln)
 {
-    if (!strlen(hrp)) return false;
+    if (hrp[0] == '\0') return false;
     if (output_len < strlen(hrp) + data_len + 8) return false;
     return bech32_encode(output, hrp, data, data_len, ln);
 }

--- a/btc/examples/tx_create.c
+++ b/btc/examples/tx_create.c
@@ -564,6 +564,8 @@ int main(void)
 
 static bool misc_str2bin(uint8_t *pBin, uint32_t BinLen, const char *pStr)
 {
+    assert(pStr != NULL);
+
     if (strlen(pStr) != BinLen * 2) {
         printf("fail: invalid buffer size: %zu != %" PRIu32 " * 2\n", strlen(pStr), BinLen);
         return false;

--- a/btc/examples/tx_print.c
+++ b/btc/examples/tx_print.c
@@ -1,4 +1,5 @@
 #define LOG_TAG "ex"
+#include <assert.h>
 #include <stdio.h>
 #include <inttypes.h>
 #include <stdlib.h>
@@ -10,6 +11,8 @@
 
 static bool misc_str2bin(uint8_t *pBin, uint32_t BinLen, const char *pStr)
 {
+    assert(pStr != NULL);
+
     if (strlen(pStr) != BinLen * 2) {
         fprintf(stderr, "fail: invalid buffer size: %zu != %" PRIu32 " * 2\n", strlen(pStr), BinLen);
         return false;

--- a/btc/examples/tx_print.c
+++ b/btc/examples/tx_print.c
@@ -79,7 +79,7 @@ int main(void)
 #if 1
     printf("=======================================\n");
     const char TXSTR[] = "0200000001516aef63107e8d4e909e3cd7a8e5b0bef1bd92a6a2a301ea06837ce26404da2a00000000002350528002882e000000000000220020eb474b65fe06d3c94bbf1cf6752859a6da090408e1af72bde932050a192a1bed90340800000000001600141e7cf6d85b86f2aca987b5519871e5891cd9b1d42a247220";
-    size_t len = strlen(TXSTR);
+    size_t len = sizeof(TXSTR) - 1;
     uint8_t *tx = (uint8_t *)UTL_DBG_MALLOC(len / 2);
     misc_str2bin(tx, len/2, TXSTR);
 

--- a/btc/segwit_addr.c
+++ b/btc/segwit_addr.c
@@ -242,6 +242,6 @@ bool segwit_addr_decode(int* witver, uint8_t* witdata, size_t* witdata_len, uint
 }
 
 size_t hrp_len(uint8_t hrp_type) {
-    return strlen(hrp_str[hrp_type]);
+    return sizeof(hrp_str[hrp_type]) - 1;
 }
 

--- a/btc/segwit_addr.c
+++ b/btc/segwit_addr.c
@@ -118,6 +118,8 @@ bool bech32_encode(char *output, const char *hrp, const uint8_t *data, size_t da
  *  Returns true if succesful.
  */
 bool bech32_decode(char* hrp, uint8_t *data, size_t *data_len, const char *input, bool ln) {
+    assert(input != NULL);
+
     uint32_t chk = 1;
     size_t i;
     size_t input_len = strlen(input);

--- a/ln/ln_db_lmdb.c
+++ b/ln/ln_db_lmdb.c
@@ -3826,11 +3826,11 @@ bool ln_db_reset(void)
     channel_cursor_close(&cur, true);
 
     //rm node and anno directories
-    const char *p_cmd = "rm -rf ";
-    char cmdline[strlen(p_cmd) + M_DB_PATH_STR_MAX + 1];
-    snprintf(cmdline, sizeof(cmdline), "%s%s", p_cmd, ln_lmdb_get_node_db_path());
+    const char cmd[] = "rm -rf ";
+    char cmdline[sizeof(cmd) + M_DB_PATH_STR_MAX];
+    snprintf(cmdline, sizeof(cmdline), "%s%s", &cmd[0], ln_lmdb_get_node_db_path());
     system(cmdline);
-    snprintf(cmdline, sizeof(cmdline), "%s%s", p_cmd, ln_lmdb_get_anno_db_path());
+    snprintf(cmdline, sizeof(cmdline), "%s%s", &cmd[0], ln_lmdb_get_anno_db_path());
     system(cmdline);
     return true;
 }

--- a/ln/ln_db_lmdb.c
+++ b/ln/ln_db_lmdb.c
@@ -22,6 +22,7 @@
 /** @file   ln_db_lmdb.c
  *  @brief  DB access(LMDB)
  */
+#include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <inttypes.h>
@@ -837,6 +838,8 @@ bool ln_db_init(char *pWif, char *pNodeName, uint16_t *pPort, bool bStdErr)
     int             retval;
     ln_lmdb_db_t    db;
 
+    assert(pWif != NULL && pNodeName != NULL && pPort != NULL);
+
     LOGD("node: %s\n", pNodeName);
 
     if (mPath[0] == '\0') {
@@ -991,6 +994,7 @@ int ln_lmdb_channel_load(ln_channel_t *pChannel, MDB_txn *pTxn, MDB_dbi Dbi, boo
     //index++;
 
     for (size_t lp = 0; lp < M_NUM_CHANNEL_BUFS; lp++) {
+        assert(p_variable_items[lp].p_name != NULL);
         key.mv_size = strlen(p_variable_items[lp].p_name);
         key.mv_data = (CONST_CAST char*)p_variable_items[lp].p_name;
         retval = mdb_get(pTxn, Dbi, &key, &data);
@@ -2675,6 +2679,7 @@ bool ln_db_invoice_save(const char *pInvoice, uint64_t AddAmountMsat, const uint
 
     key.mv_size = BTC_SZ_HASH256;
     key.mv_data = (CONST_CAST uint8_t *)pPaymentHash;
+    assert(pInvoice != NULL);
     size_t len = strlen(pInvoice);
     data.mv_size = len + 1 + sizeof(AddAmountMsat);    //invoice(\0含む) + uint64_t
     uint8_t *p_data = (uint8_t *)UTL_DBG_MALLOC(data.mv_size);
@@ -3988,6 +3993,8 @@ LABEL_EXIT:
 
 static bool set_path(char *pPath, size_t Size, const char *pDir, const char *pName)
 {
+    assert(pDir != NULL);
+    assert(pName != NULL);
     if (strlen(pDir) + 1 + strlen(pName) > M_DB_PATH_STR_MAX) return false;
     snprintf(pPath, Size, "%s/%s", pDir, pName);
     return true;
@@ -4032,6 +4039,7 @@ static int channel_htlc_load(ln_channel_t *pChannel, ln_lmdb_db_t *pDb)
 
         //fixed
         for (size_t lp2 = 0; lp2 < ARRAY_SIZE(DBHTLC_VALUES); lp2++) {
+            assert(DBHTLC_VALUES[lp2].p_name != NULL);
             key.mv_size = strlen(DBHTLC_VALUES[lp2].p_name);
             key.mv_data = (CONST_CAST char*)DBHTLC_VALUES[lp2].p_name;
             retval = mdb_get(pDb->p_txn, dbi, &key, &data);
@@ -4212,6 +4220,7 @@ static int channel_save(const ln_channel_t *pChannel, ln_lmdb_db_t *pDb)
     //index++;
 
     for (size_t lp = 0; lp < M_NUM_CHANNEL_BUFS; lp++) {
+        assert(p_variable_items[lp].p_name != NULL);
         key.mv_size = strlen(p_variable_items[lp].p_name);
         key.mv_data = (CONST_CAST char*)p_variable_items[lp].p_name;
         data.mv_size = p_variable_items[lp].p_buf->len;
@@ -4235,6 +4244,7 @@ static int channel_item_load(ln_channel_t *pChannel, const fixed_item_t *pItems,
     int     retval;
     MDB_val key, data;
 
+    assert(pItems->p_name != NULL);
     key.mv_size = strlen(pItems->p_name);
     key.mv_data = (CONST_CAST char*)pItems->p_name;
     retval = mdb_get(pDb->p_txn, pDb->dbi, &key, &data);
@@ -4275,6 +4285,7 @@ static int channel_item_save(const ln_channel_t *pChannel, const fixed_item_t *p
         pDb = &db;
     }
 
+    assert(pItems->p_name != NULL);
     key.mv_size = strlen(pItems->p_name);
     key.mv_data = (CONST_CAST char*)pItems->p_name;
     data.mv_size = pItems->data_len;
@@ -5796,6 +5807,7 @@ static int fixed_items_load(void *pData, ln_lmdb_db_t *pDb, const fixed_item_t *
     MDB_val key, data;
 
     for (size_t lp = 0; lp < Num; lp++) {
+        assert(pItems[lp].p_name != NULL);
         key.mv_size = strlen(pItems[lp].p_name);
         key.mv_data = (CONST_CAST char *)pItems[lp].p_name;
         retval = mdb_get(pDb->p_txn, pDb->dbi, &key, &data);
@@ -5827,6 +5839,7 @@ static int fixed_items_save(const void *pData, ln_lmdb_db_t *pDb, const fixed_it
     MDB_val key, data;
 
     for (size_t lp = 0; lp < Num; lp++) {
+        assert(pItems[lp].p_name != NULL);
         key.mv_size = strlen(pItems[lp].p_name);
         key.mv_data = (CONST_CAST char *)pItems[lp].p_name;
         data.mv_size = pItems[lp].data_len;

--- a/ln/ln_invoice.c
+++ b/ln/ln_invoice.c
@@ -454,9 +454,10 @@ LABEL_EXIT:
     return ret;
 }
 
-static bool read_prefix(uint8_t *type, size_t *len, char *hrp)
+static bool read_prefix(uint8_t *type, size_t *len, const char *hrp)
 {
     const char *s;
+    assert(hrp != NULL);
 
     //note: check from the longer one for the longest match
     s  = ln_prefix_str[LN_INVOICE_REGTEST];

--- a/ptarmd/cmd_json.c
+++ b/ptarmd/cmd_json.c
@@ -694,7 +694,7 @@ LABEL_EXIT:
 }
 
 
-/** invice削除 : ptarmcli -e
+/** invoice削除 : ptarmcli -e
  *
  */
 static cJSON *cmd_eraseinvoice(jrpc_context *ctx, cJSON *params, cJSON *id)

--- a/ptarmd/conf.c
+++ b/ptarmd/conf.c
@@ -95,11 +95,11 @@ bool conf_btcrpc_load(const char *pConfFile, rpc_conf_t *pRpcConf)
     if (pRpcConf->rpcport == 0) {
         pRpcConf->rpcport = 8332;
     }
-    if (strlen(pRpcConf->rpcurl) == 0) {
+    if (pRpcConf->rpcurl[0] == '\0') {
         strcpy(pRpcConf->rpcurl, "127.0.0.1");
     }
 
-    if ((strlen(pRpcConf->rpcuser) == 0) || (strlen(pRpcConf->rpcpasswd) == 0)) {
+    if (pRpcConf->rpcuser[0] == '\0' || pRpcConf->rpcpasswd[0] == '\0') {
         LOGE("fail: no rpcuser or rpcpassword[%s]", pConfFile);
         return false;
     }

--- a/ptarmd/ptarmd.c
+++ b/ptarmd/ptarmd.c
@@ -41,6 +41,7 @@
  *                             +---------------+
  * </pre>
  */
+#include <assert.h>
 #include <stdio.h>
 #include <inttypes.h>
 #include <stdlib.h>
@@ -440,6 +441,8 @@ void ptarmd_call_script(ptarmd_event_t event, const char *param)
     struct stat buf;
     char script[PATH_MAX];
     char path[PATH_MAX];
+
+    assert(param != NULL);
 
     errno = 0;
     getcwd(path, sizeof(path));

--- a/ptarmd/ptarmd_main.c
+++ b/ptarmd/ptarmd_main.c
@@ -198,10 +198,10 @@ int main(int argc, char *argv[])
     }
 
 #if defined(USE_BITCOIND)
-    if ((strlen(rpc_conf.rpcuser) == 0) || (strlen(rpc_conf.rpcpasswd) == 0)) {
+    if (rpc_conf.rpcuser[0] == '\0' || rpc_conf.rpcpasswd[0] == '\0') {
         //bitcoin.confから読込む
         bret = conf_btcrpc_load_default(&rpc_conf);
-        if (!bret || (strlen(rpc_conf.rpcuser) == 0) || (strlen(rpc_conf.rpcpasswd) == 0)) {
+        if (!bret || rpc_conf.rpcuser[0] == '\0' || rpc_conf.rpcpasswd[0] == '\0') {
             goto LABEL_EXIT;
         }
     }

--- a/utl/utl_addr.c
+++ b/utl/utl_addr.c
@@ -20,6 +20,7 @@
  *  under the License.
  */
 
+#include <assert.h>
 #include <stdio.h>
 #include <string.h>
 
@@ -34,6 +35,9 @@ bool utl_addr_ipv4_str2bin(uint8_t b[4], const char *s)
 {
     int bi = 0;
     int decc = 0;
+
+    assert(s != NULL);
+
     for (int si = 0; si < (int)strlen(s) + 1; si++) {
         if (s[si] >= '0' && s[si] <= '9') { //decimal
             //over

--- a/utl/utl_dbg.c
+++ b/utl/utl_dbg.c
@@ -22,6 +22,7 @@
 /** @file   utl_dbg.c
  *  @brief  utl処理: 汎用処理
  */
+#include <assert.h>
 #include <stdlib.h>
 #include <sys/stat.h>
 #include <sys/types.h>
@@ -207,6 +208,8 @@ void HIDDEN *utl_dbg_calloc(size_t Block, size_t Size, const char* pFname, int L
 
 char HIDDEN *utl_dbg_strdup(const char *pStr, const char* pFname, int Line, const char *pFunc)
 {
+    assert(pStr != NULL);
+
     char *p = strdup(pStr);
     if (p) {
         for (int lp = 0; lp < 100; lp++) {

--- a/utl/utl_opts.c
+++ b/utl/utl_opts.c
@@ -20,6 +20,7 @@
  *  under the License.
  */
 
+#include <assert.h>
 #include <string.h>
 
 #include "utl_dbg.h"
@@ -210,6 +211,7 @@ static utl_opt_t *findn_opts(utl_opt_t *opts, const char *name, int len)
 
 static utl_opt_t *find_opts(utl_opt_t *opts, const char *name)
 {
+    assert(name != NULL);
     return findn_opts(opts, name, strlen(name));
 }
 

--- a/utl/utl_str.c
+++ b/utl/utl_str.c
@@ -20,6 +20,7 @@
  *  under the License.
  */
 
+#include <assert.h>
 #include <string.h>
 #include <ctype.h>
 
@@ -36,6 +37,8 @@
 bool utl_str_scan_u16(uint16_t *n, const char* s)
 {
     const char* UINT16_MAX_STR = "65535";
+
+    assert(s != NULL && n != NULL);
 
     if (!s[0]) return false;
     if (s[0] == '0' && s[1] != '\0') return false; //leading zeros are not allowed
@@ -63,6 +66,8 @@ bool utl_str_scan_u16(uint16_t *n, const char* s)
 bool utl_str_scan_u32(uint32_t *n, const char* s)
 {
     const char* UINT32_MAX_STR = "4294967295";
+
+    assert(s != NULL && n != NULL);
 
     if (!s[0]) return false;
     if (s[0] == '0' && s[1] != '\0') return false; //leading zeros are not allowed
@@ -169,6 +174,8 @@ bool utl_str_str2bin_rev(uint8_t *pBin, uint32_t BinLen, const char *pStr)
 
 void utl_str_bin2str(char *pStr, const uint8_t *pBin, uint32_t BinLen)
 {
+    assert(pStr != NULL && pBin != NULL);
+
     *pStr = '\0';
     for (uint32_t lp = 0; lp < BinLen; lp++) {
         char str[3];
@@ -180,6 +187,8 @@ void utl_str_bin2str(char *pStr, const uint8_t *pBin, uint32_t BinLen)
 
 void utl_str_bin2str_rev(char *pStr, const uint8_t *pBin, uint32_t BinLen)
 {
+    assert(pStr != NULL && pBin != NULL);
+
     *pStr = '\0';
     for (uint32_t lp = 0; lp < BinLen; lp++) {
         char str[3];
@@ -192,6 +201,8 @@ void utl_str_bin2str_rev(char *pStr, const uint8_t *pBin, uint32_t BinLen)
 bool utl_str_itoa(char *pStr, uint32_t Size, uint64_t Value)
 {
     uint8_t digit = (Value) ? utl_int_digit(Value, 10) : 1;
+
+    assert(pStr != NULL);
 
     if (Size <= digit) return false;
     pStr[digit] = '\0';
@@ -206,6 +217,8 @@ bool utl_str_itoa(char *pStr, uint32_t Size, uint64_t Value)
 
 bool utl_str_copy_and_fill_zeros(char *pDst, const char *pSrc, uint32_t Size)
 {
+    assert(pDst != NULL && pSrc != NULL);
+
     if (Size < strlen(pSrc)) return false;
     strncpy(pDst, pSrc, Size); //`strncpy` fills zeros
     return true;
@@ -214,6 +227,8 @@ bool utl_str_copy_and_fill_zeros(char *pDst, const char *pSrc, uint32_t Size)
 
 bool utl_str_copy_and_append_zero(char *pBuf, uint32_t BufSize, const uint8_t *pData, uint32_t DataSize)
 {
+    assert(pBuf != NULL && pData != NULL);
+
     if (BufSize <= DataSize) return false;
     strncpy(pBuf, (const char *)pData, DataSize); //`strncpy` fills zeros
     pBuf[DataSize] = 0;

--- a/utl/utl_str.c
+++ b/utl/utl_str.c
@@ -38,11 +38,11 @@ bool utl_str_scan_u16(uint16_t *n, const char* s)
     const char* UINT16_MAX_STR = "65535";
 
     if (!s[0]) return false;
-    if (s[0] == '0' && strlen(s) > 1) return false; //leading zeros are not allowed
+    if (s[0] == '0' && s[1] != '\0') return false; //leading zeros are not allowed
 
     //check overflow
-    if (strlen(s) > strlen(UINT16_MAX_STR)) return false;
-    if (strlen(s) == strlen(UINT16_MAX_STR)) {
+    if (strlen(s) > sizeof(UINT16_MAX_STR) - 1) return false;
+    if (strlen(s) == sizeof(UINT16_MAX_STR) - 1) {
         for (int i = 0; i < (int)strlen(s); i++) {
             if (s[i] > UINT16_MAX_STR[i]) return false;
             if (s[i] == UINT16_MAX_STR[i]) continue;
@@ -65,7 +65,7 @@ bool utl_str_scan_u32(uint32_t *n, const char* s)
     const char* UINT32_MAX_STR = "4294967295";
 
     if (!s[0]) return false;
-    if (s[0] == '0' && strlen(s) > 1) return false; //leading zeros are not allowed
+    if (s[0] == '0' && s[1] != '\0') return false; //leading zeros are not allowed
 
     //check overflow
     if (strlen(s) > strlen(UINT32_MAX_STR)) return false;


### PR DESCRIPTION
`strlen()` doesn't checks `NULL` and often underlying vulnerability by buffer overflows.
So the best way is not to use. The better way is to check `NULL`.