### PR TITLE
fix: error message data

### DIFF
--- a/ln/ln_setupctl.c
+++ b/ln/ln_setupctl.c
@@ -183,7 +183,7 @@ LABEL_EXIT:
 }
 
 
-bool HIDDEN ln_error_send(ln_channel_t *pChannel, int Err, const char *pFormat, ...)
+bool /*HIDDEN*/ ln_error_send(ln_channel_t *pChannel, int Err, const char *pFormat, ...)
 {
     ln_error_set(pChannel, Err, pFormat);
     ln_msg_error_t msg;

--- a/ln/ln_setupctl.h
+++ b/ln/ln_setupctl.h
@@ -75,7 +75,7 @@ void HIDDEN ln_error_set(ln_channel_t *pChannel, int Err, const char *pFormat, .
 
 bool /*HIDDEN*/ ln_init_send(ln_channel_t *pChannel, bool bInitRouteSync, bool bHaveCnl);
 bool HIDDEN ln_init_recv(ln_channel_t *pChannel, const uint8_t *pData, uint16_t Len);
-bool HIDDEN ln_error_send(ln_channel_t *pChannel, int Err, const char *pFormat, ...);
+bool /*HIDDEN*/ ln_error_send(ln_channel_t *pChannel, int Err, const char *pFormat, ...);
 bool HIDDEN ln_error_recv(ln_channel_t *pChannel, const uint8_t *pData, uint16_t Len);
 bool /*HIDDEN*/ ln_ping_send(ln_channel_t *pChannel, uint16_t PingLen, uint16_t PongLen);
 bool HIDDEN ln_ping_recv(ln_channel_t *pChannel, const uint8_t *pData, uint16_t Len);

--- a/ptarmd/lnapp.c
+++ b/ptarmd/lnapp.c
@@ -2151,24 +2151,6 @@ static void cb_channel_quit(lnapp_conf_t *p_conf, void *p_param)
 static void cb_error_recv(lnapp_conf_t *p_conf, void *p_param)
 {
     const ln_msg_error_t *p_msg = (const ln_msg_error_t *)p_param;
-
-    bool b_dumped = false;
-    char *p_data = NULL;
-    for (uint16_t lp = 0; lp < p_msg->len; lp++) {
-        if (!isprint(p_msg->p_data[lp])) {
-            //表示できない文字が入っている場合はダンプ出力
-            b_dumped = true;
-            p_data = (char *)UTL_DBG_MALLOC(p_msg->len * 2 + 1);
-            utl_str_bin2str(p_data, (const uint8_t *)p_msg->p_data, p_msg->len);
-            break;
-        }
-    }
-    if (!b_dumped) {
-        p_data = (char *)UTL_DBG_MALLOC(p_msg->len + 1);
-        memcpy(p_data, p_msg->p_data, p_msg->len);
-        p_data[p_msg->len] = '\0';
-    }
-    set_lasterror(p_conf, RPCERR_PEER_ERROR, p_data);
     const uint8_t *p_channel_id;
     if ( (ln_short_channel_id(&p_conf->channel) == 0) ||
           utl_mem_is_all_zero(p_msg->p_channel_id, LN_SZ_CHANNEL_ID) ) {
@@ -2176,8 +2158,29 @@ static void cb_error_recv(lnapp_conf_t *p_conf, void *p_param)
     } else {
         p_channel_id = p_msg->p_channel_id;
     }
-    ptarmd_eventlog(p_channel_id, "error message: %s", p_data);
-    UTL_DBG_FREE(p_data);
+
+
+    bool b_printable = true;
+    for (uint16_t lp = 0; lp < p_msg->len; lp++) {
+        if (!isprint(p_msg->p_data[lp])) {
+            b_printable = false;
+            break;
+        }
+    }
+    if (b_printable) {
+        char *p_data = (char *)UTL_DBG_MALLOC(p_msg->len + 1);
+        memcpy(p_data, p_msg->p_data, p_msg->len);
+        p_data[p_msg->len] = '\0';
+        set_lasterror(p_conf, RPCERR_PEER_ERROR, p_data);
+        ptarmd_eventlog(p_channel_id, "error message(ascii): %s", p_data);
+        UTL_DBG_FREE(p_data);
+    } else {
+        char *p_data = (char *)UTL_DBG_MALLOC(p_msg->len * 2 + 1);
+        utl_str_bin2str(p_data, (const uint8_t *)p_msg->p_data, p_msg->len);
+        set_lasterror(p_conf, RPCERR_PEER_ERROR, p_data);
+        ptarmd_eventlog(p_channel_id, "error message(dump): %s", p_data);
+        UTL_DBG_FREE(p_data);
+    }
 
     if (p_conf->funding_waiting) {
         LOGD("stop funding by error\n");


### PR DESCRIPTION
`error`は\0を含まないことがあるため、asciiの場合は自分で付加する。

テスト用に`DEVELOPER_MODE`でビルドした場合、JSON-RPC "DEVsend_error"を追加。