### PR TITLE
p2p: remove `peer_conn`

### DIFF
--- a/ptarmd/monitoring.c
+++ b/ptarmd/monitoring.c
@@ -596,14 +596,6 @@ static bool channel_reconnect(ln_channel_t *pChannel)
         conn_addr[lp].port = 0;
     }
 
-    //conn_addr[0]
-    //clientとして接続したときの接続先情報があれば、そこに接続する
-    peer_conn_t last_peer_conn;
-    if (p2p_load_peer_conn(&last_peer_conn, p_node_id)) {
-        strcpy(conn_addr[0].ipaddr, last_peer_conn.ipaddr);
-        conn_addr[0].port = last_peer_conn.port;
-        LOGD("conn_addr[0]: %s:%d\n", conn_addr[0].ipaddr, conn_addr[0].port);
-    }
 
     //conn_addr[1]
     //pChannel->last_connected_addrがあれば、それを使う

--- a/ptarmd/p2p.c
+++ b/ptarmd/p2p.c
@@ -61,9 +61,6 @@
  * static variables
  ********************************************************************/
 
-static peer_conn_t mLastPeerConn;
-pthread_mutex_t mMuxLastPeerConn = PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP;
-
 volatile bool           mActive = true;
 
 
@@ -191,11 +188,6 @@ bool p2p_initiator_start(const peer_conn_t *pConn, int *pErrCode)
     fprintf(stderr, "[client]node_id=");
     utl_dbg_dump(stderr, pConn->node_id, BTC_SZ_PUBKEY, true);
 
-    //store for reconnection
-    if (!p2p_store_peer_conn(pConn)) {
-        LOGE("fail: store peer conn");
-    }
-
     peer_conn_handshake_t conn_handshake;
     conn_handshake.initiator = true;
     conn_handshake.sock = sock;
@@ -239,31 +231,6 @@ LABEL_EXIT:
         close(sock);
     }
     return bret;
-}
-
-
-bool p2p_store_peer_conn(const peer_conn_t* pPeerConn)
-{
-    pthread_mutex_lock(&mMuxLastPeerConn);
-    mLastPeerConn = *pPeerConn;
-    pthread_mutex_unlock(&mMuxLastPeerConn);
-
-    return true;
-}
-
-
-bool p2p_load_peer_conn(peer_conn_t* pPeerConn, const uint8_t *pNodeId)
-{
-    bool ret = false;
-
-    pthread_mutex_lock(&mMuxLastPeerConn);
-    if (memcmp(mLastPeerConn.node_id, pNodeId, BTC_SZ_PUBKEY) == 0) {
-        *pPeerConn = mLastPeerConn;
-        ret = true;
-    }
-    pthread_mutex_unlock(&mMuxLastPeerConn);
-
-    return ret;
 }
 
 

--- a/ptarmd/p2p.h
+++ b/ptarmd/p2p.h
@@ -58,18 +58,6 @@ bool p2p_connect_test(const char *pIpAddr, uint16_t Port);
 bool p2p_initiator_start(const peer_conn_t *pConn, int *pErrCode);
 
 
-/** [p2p] 接続情報を保存
- *
- */
-bool p2p_store_peer_conn(const peer_conn_t* pPeerConn);
-
-
-/** [p2p] 接続情報を復元
- *
- */
-bool p2p_load_peer_conn(peer_conn_t* pPeerConn, const uint8_t *pNodeId);
-
-
 /** [p2p]開始
  *
  */


### PR DESCRIPTION
古いワークアラウンドの処理を削除