### PR TITLE
lnapp: fix to ensure the atomicity of `ln_open_channel_send`

### DIFF
--- a/ptarmd/lnapp.c
+++ b/ptarmd/lnapp.c
@@ -1366,12 +1366,14 @@ static bool send_open_channel(lnapp_conf_t *p_conf, const funding_conf_t *pFundi
         memset(&fundin, 0, sizeof(fundin));
 #endif
 
+        pthread_mutex_lock(&p_conf->mux_channel);
         ret = ln_open_channel_send(&p_conf->channel,
                         &fundin,
                         pFundingConf->funding_sat,
                         pFundingConf->push_sat,
                         feerate_kw,
                         pFundingConf->priv_channel);
+        pthread_mutex_unlock(&p_conf->mux_channel);
         if (ret) {
             LOGD("SEND: open_channel\n");
         } else {

--- a/utl/utl_thread.c
+++ b/utl/utl_thread.c
@@ -40,7 +40,7 @@
 
 void utl_thread_msleep(unsigned long slp)
 {
-    struct timespec req = { 0, (long)(slp * 1000000UL) };
+    struct timespec req = { (time_t)(slp / 1000), (long)(slp % 1000 * 1000000UL) };
     nanosleep(&req, NULL);
 }
 


### PR DESCRIPTION
ln_open_channel_sendが完了する前に、accept_channelを受信した時、"not funder"と判定されるエラーを修正