### PR TITLE
decodeinvoice

### DIFF
--- a/ln/ln_invoice.h
+++ b/ln/ln_invoice.h
@@ -27,6 +27,22 @@ typedef struct {
 } ln_r_field_t;
 
 
+/** @enum   ln_invoice_desc_type_t
+ *  @brief  description
+ */
+typedef enum {
+    LN_INVOICE_DESC_NONE,
+    LN_INVOICE_DESC_TYPE_STRING,
+    LN_INVOICE_DESC_TYPE_HASH256,
+} ln_invoice_desc_type_t;
+
+
+typedef struct {
+    ln_invoice_desc_type_t  type;
+    utl_buf_t               data;
+} ln_invoice_desc_t;
+
+
 /** @struct ln_invoice_t;
  *  @brief  BOLT#11 invoice
  */
@@ -38,6 +54,7 @@ typedef struct {
     uint32_t    min_final_cltv_expiry;
     uint8_t     pubkey[BTC_SZ_PUBKEY];
     uint8_t     payment_hash[BTC_SZ_HASH256];
+    ln_invoice_desc_t   description;
     uint8_t     r_field_num;
     ln_r_field_t r_field[];
 } ln_invoice_t;
@@ -63,6 +80,9 @@ bool ln_invoice_decode(ln_invoice_t **pp_invoice_data, const char* invoice);
 
 bool ln_invoice_decode_2(ln_invoice_t **pp_invoice_data, const char* invoice, uint32_t len);
 
+void ln_invoice_decode_free(ln_invoice_t *p_invoice_data);
+
+
 /** BOLT11 形式invoice作成
  *
  * @param[out]      ppInvoice
@@ -70,6 +90,7 @@ bool ln_invoice_decode_2(ln_invoice_t **pp_invoice_data, const char* invoice, ui
  * @param[in]       pPaymentHash
  * @param[in]       Amount
  * @param[in]       Expiry          invoice expiry
+ * @param[in]       pDesc           description
  * @param[in]       pRField
  * @param[in]       RFieldNum       pRField数
  * @param[in]       MinFinalCltvExpiry  min_final_cltv_expiry
@@ -77,8 +98,16 @@ bool ln_invoice_decode_2(ln_invoice_t **pp_invoice_data, const char* invoice, ui
  * @attention
  *      - ppInoviceはUTL_DBG_MALLOC()で確保するため、、使用後にUTL_DBG_FREE()すること
  */
-bool ln_invoice_create(char **ppInvoice, uint8_t Type, const uint8_t *pPaymentHash, uint64_t Amount, uint32_t Expiry,
-                        const ln_r_field_t *pRField, uint8_t RFieldNum, uint32_t MinFinalCltvExpiry);
+bool ln_invoice_create(
+            char **ppInvoice,
+            uint8_t Type,
+            const uint8_t *pPaymentHash,
+            uint64_t Amount,
+            uint32_t Expiry,
+            const ln_invoice_desc_t *pDesc,
+            const ln_r_field_t *pRField,
+            uint8_t RFieldNum,
+            uint32_t MinFinalCltvExpiry);
 
 #ifdef __cplusplus
 }

--- a/ln/ln_payment.c
+++ b/ln/ln_payment.c
@@ -429,11 +429,11 @@ static ln_payment_error_t route_invoice(
     pRoute->hop_num = route_result.hop_num;
     memcpy(pRoute->hop_datain, route_result.hop_datain, sizeof(ln_hop_datain_t) * (1 + LN_HOP_MAX));
 
-    UTL_DBG_FREE(p_invoice_data);
+    ln_invoice_decode_free(p_invoice_data);
     return LN_PAYMENT_OK;
 
 LABEL_ERROR:
-    UTL_DBG_FREE(p_invoice_data);
+    ln_invoice_decode_free(p_invoice_data);
     return retval;
 }
 

--- a/ln/tests/test_ln_bech32.cpp
+++ b/ln/tests/test_ln_bech32.cpp
@@ -59,7 +59,7 @@ extern "C" {
 class bech32: public testing::Test {
 protected:
     virtual void SetUp() {
-        utl_log_init_stderr();
+        //utl_log_init_stderr();
         //RESET_FAKE(external_function)
         utl_dbg_malloc_cnt_reset();
         btc_init(BTC_BLOCK_CHAIN_BTCTEST, false);

--- a/ln/tests/test_ln_bech32.cpp
+++ b/ln/tests/test_ln_bech32.cpp
@@ -11,7 +11,7 @@ extern "C" {
 #undef LOG_TAG
 #include "../../utl/utl_log.c"
 #include "../../utl/utl_dbg.c"
-// #include "../../utl/utl_buf.c"
+#include "../../utl/utl_buf.c"
 #include "../../utl/utl_push.c"
 #include "../../utl/utl_time.c"
 #include "../../utl/utl_int.c"
@@ -59,7 +59,7 @@ extern "C" {
 class bech32: public testing::Test {
 protected:
     virtual void SetUp() {
-        //utl_log_init_stderr();
+        utl_log_init_stderr();
         //RESET_FAKE(external_function)
         utl_dbg_malloc_cnt_reset();
         btc_init(BTC_BLOCK_CHAIN_BTCTEST, false);
@@ -202,8 +202,8 @@ TEST_F(bech32, invoice_valid)
         ASSERT_EQ(0, memcmp(p_invoice_data->payment_hash, p_invoice_data2->payment_hash, BTC_SZ_HASH256));
         ASSERT_EQ(p_invoice_data->expiry, p_invoice_data2->expiry);
 
-        UTL_DBG_FREE(p_invoice_data2);
-        UTL_DBG_FREE(p_invoice_data);
+        ln_invoice_decode_free(p_invoice_data2);
+        ln_invoice_decode_free(p_invoice_data);
         UTL_DBG_FREE(p_invoice);
     }
 }

--- a/ptarmcli/ptarmcli.c
+++ b/ptarmcli/ptarmcli.c
@@ -206,7 +206,7 @@ int main(int argc, char *argv[])
         { "emptywallet", required_argument, NULL, M_OPT_EMPTYWALLET },
         { "initroutesync", no_argument, NULL, M_OPT_INITROUTESYNC },
         { "private", no_argument, NULL, M_OPT_PRIVCHANNEL },
-        { "createinvoice", required_argument, NULL, 'i' },
+        { "addinvoice", required_argument, NULL, 'i' },
         { "decodeinvoice", required_argument, NULL, M_OPT_DECODEINVOICE },
         { "debug", required_argument, NULL, M_OPT_DEBUG },
         { 0, 0, 0, 0 }
@@ -266,7 +266,7 @@ int main(int argc, char *argv[])
         fprintf(stderr, "\n");
 
         fprintf(stderr, "\tPAYMENT:\n");
-        fprintf(stderr, "\t\t--createinvoice,-i AMOUNT_MSAT : add preimage, and show payment_hash\n");
+        fprintf(stderr, "\t\t--addinvoice,-i AMOUNT_MSAT : add preimage, and show payment_hash\n");
         fprintf(stderr, "\t\t--decodeinvoice BOLT11_INVOICE : decode invoice\n");
         fprintf(stderr, "\t\t-e PAYMENT_HASH : erase payment_hash\n");
         fprintf(stderr, "\t\t-e ALL : erase all payment_hash\n");


### PR DESCRIPTION
`ptarmcli --decodeinvoice`追加

* descriptionは"ptarmigan"固定のまま(cmd_json.cで指定しているので、cliで受け取るようにもできる)
  * BOLT11では639文字以上の場合にはhashにするようなことが書かれている
  * そんなに長い必要もないだろうし、現在は固定文字列なので、cmd_jsonは暫定で20文字チェックをしている
* `ptarmcli --addinvoice`を`ptarmcli -i`と同じように使える
* `ln_invoice_decode()`での結果は`ln_invoice_decode_free()`で解放すること
* `ptarmcli -r`でptarmcliがinvoiceデコード内容を標準出力に吐き出していたが、取りやめた。
  * 送金開始時の戻り値にしてもよいかもしれない