### PR TITLE
ln_normalope: resend msgs at reestablishing

### DIFF
--- a/ln/ln_commit_tx.c
+++ b/ln/ln_commit_tx.c
@@ -485,6 +485,85 @@ LABEL_EXIT:
 }
 
 
+void HIDDEN ln_commit_tx_rewind_one_commit_remote(
+    ln_commit_info_t *pCommitInfo, ln_update_info_t *pUpdateInfo)
+{
+    for (uint16_t idx = 0; idx < LN_UPDATE_MAX; idx++) {
+        ln_update_t *p_update = &pUpdateInfo->updates[idx];
+        if (!LN_UPDATE_USED(p_update)) continue;
+        if (p_update->state == LN_UPDATE_STATE_OFFERED_CS_SEND) {
+            p_update->state = LN_UPDATE_STATE_OFFERED_WAIT_SEND;
+            uint64_t amount_msat = 0;
+            if (p_update->type & LN_UPDATE_TYPE_MASK_HTLC) {
+                amount_msat = pUpdateInfo->htlcs[p_update->type_specific_idx].amount_msat;
+            }
+            switch (p_update->type) {
+            case LN_UPDATE_TYPE_ADD_HTLC:
+                LOGD("CANCEL ADD HTLC OFFERED UPDATE[%u] HTLC[%u](%" PRIu64 ")\n",
+                    idx, p_update->type_specific_idx, amount_msat);
+                pCommitInfo->remote_msat += amount_msat;
+                break;
+            case LN_UPDATE_TYPE_FULFILL_HTLC:
+                LOGD("CANCEL FULFILL HTLC OFFERED UPDATE[%u] HTLC[%u](%" PRIu64 ")\n",
+                    idx, p_update->type_specific_idx, amount_msat);
+                pCommitInfo->remote_msat -= amount_msat;
+                break;
+            case LN_UPDATE_TYPE_FAIL_HTLC:
+            case LN_UPDATE_TYPE_FAIL_MALFORMED_HTLC:
+                LOGD("CANCEL FAIL HTLC OFFERED UPDATE[%u] HTLC[%u](%" PRIu64 ")\n",
+                    idx, p_update->type_specific_idx, amount_msat);
+                pCommitInfo->local_msat -= amount_msat;
+                break;
+            case LN_UPDATE_TYPE_FEE:
+                LOGD("CANCEL FEE OFFERED UPDATE[%u] FEE_UPDATE[%u](%" PRIu64 ")\n",
+                    idx, p_update->type_specific_idx, amount_msat);
+                break;
+            default:
+                LOGE("fail: ???\n");
+            }
+            //The update message will be sent in the idle proc.
+        } else if (p_update->state == LN_UPDATE_STATE_RECEIVED_CS_SEND) {
+            p_update->state = LN_UPDATE_STATE_RECEIVED_RA_SEND;
+            uint64_t amount_msat = 0;
+            if (p_update->type & LN_UPDATE_TYPE_MASK_HTLC) {
+                amount_msat = pUpdateInfo->htlcs[p_update->type_specific_idx].amount_msat;
+            }
+            switch (p_update->type) {
+            case LN_UPDATE_TYPE_ADD_HTLC:
+                LOGD("CANCEL ADD HTLC RECEIVED UPDATE[%u] HTLC[%u](%" PRIu64 ")\n",
+                    idx, p_update->type_specific_idx, amount_msat);
+                pCommitInfo->local_msat += amount_msat;
+                break;
+            case LN_UPDATE_TYPE_FULFILL_HTLC:
+                LOGD("CANCEL FULFILL HTLC RECEIVED UPDATE[%u] HTLC[%u](%" PRIu64 ")\n",
+                    idx, p_update->type_specific_idx, amount_msat);
+                pCommitInfo->local_msat -= amount_msat;
+                break;
+            case LN_UPDATE_TYPE_FAIL_HTLC:
+            case LN_UPDATE_TYPE_FAIL_MALFORMED_HTLC:
+                LOGD("CANCEL FAIL HTLC RECEIVED UPDATE[%u] HTLC[%u](%" PRIu64 ")\n",
+                    idx, p_update->type_specific_idx, amount_msat);
+                pCommitInfo->remote_msat -= amount_msat;
+                break;
+            case LN_UPDATE_TYPE_FEE:
+                LOGD("CANCEL FEE RECEIVED UPDATE[%u] FEE_UPDATE[%u](%" PRIu64 ")\n",
+                    idx, p_update->type_specific_idx, amount_msat);
+                break;
+            default:
+                LOGE("fail: ???\n");
+            }
+        }
+    }
+    pCommitInfo->commit_num--;
+
+    //we can clear `LN_UPDATE_STATE_OFFERED_WAIT_SEND` updates
+    //  and reload and check them from forward db once again
+    ln_update_info_clear_pending_updates(pUpdateInfo);
+
+    return;
+}
+
+
 /********************************************************************
  * private functions
  ********************************************************************/

--- a/ln/ln_commit_tx.h
+++ b/ln/ln_commit_tx.h
@@ -144,4 +144,8 @@ bool ln_commit_tx_set_vin_p2wsh_2of2_rs(
     const utl_buf_t *pWitScript);
 
 
+void HIDDEN ln_commit_tx_rewind_one_commit_remote(
+    ln_commit_info_t *pCommitInfo, ln_update_info_t *pUpdateInfo);
+
+
 #endif /* LN_COMMIT_TX_H__ */

--- a/ln/ln_normalope.c
+++ b/ln/ln_normalope.c
@@ -1355,14 +1355,7 @@ void ln_channel_reestablish_after(ln_channel_t *pChannel)
         //remote.per_commitment_pointを1つ戻して、キャンセルされたupdateメッセージを再送する
         //XXX: If the corresponding `revoke_andk_ack` is received, channel should be failed
         LOGD("$$$ resend: previous update message\n");
-        for (uint16_t idx = 0; idx < LN_UPDATE_MAX; idx++) {
-            ln_update_t *p_update = &pChannel->update_info.updates[idx];
-            if (!LN_UPDATE_USED(p_update)) continue;
-            if (!LN_UPDATE_REMOTE_COMSIGING(p_update)) continue;
-            LN_UPDATE_ENABLE_RESEND_UPDATE(p_update);
-            //The update message will be sent in the idle proc.
-        }
-        pChannel->commit_info_remote.commit_num--;
+        ln_commit_tx_rewind_one_commit_remote(&pChannel->commit_info_remote, &pChannel->update_info);
     }
 
     //BOLT#02

--- a/ln/ln_update_info.c
+++ b/ln/ln_update_info.c
@@ -654,8 +654,9 @@ void ln_update_info_clear_pending_updates(ln_update_info_t *pInfo)
     for (uint16_t idx; idx < ARRAY_SIZE(pInfo->updates); idx++) {
         ln_update_t *p_update = &pInfo->updates[idx];
         if (!LN_UPDATE_USED(p_update)) continue;
-        if (p_update->state != LN_UPDATE_STATE_FLAG_UP_SEND &&
-            p_update->state != LN_UPDATE_STATE_FLAG_UP_RECV) continue; //check not commited
+        if (p_update->state != LN_UPDATE_STATE_OFFERED_WAIT_SEND &&
+            p_update->state != LN_UPDATE_STATE_OFFERED_UP_SEND &&
+            p_update->state != LN_UPDATE_STATE_RECEIVED_UP_RECV) continue; //check not commited
         switch (p_update->type) {
         case LN_UPDATE_TYPE_ADD_HTLC:
             LOGD("clear update add htlc update_idx=%u\n", idx);


### PR DESCRIPTION
due to a remote `commit_num` gap.