### PR TITLE
ln_normalope: fix to follow the conditions to send closing msgs

### DIFF
--- a/ln/ln.c
+++ b/ln/ln.c
@@ -1116,7 +1116,7 @@ uint64_t ln_estimate_initcommittx_fee(uint32_t FeeratePerKw)
 
 bool ln_is_shutdown_sent(const ln_channel_t *pChannel)
 {
-    return pChannel->shutdown_flag & LN_SHDN_FLAG_SEND;
+    return pChannel->shutdown_flag & LN_SHDN_FLAG_SEND_SHDN;
 }
 
 

--- a/ln/ln.h
+++ b/ln/ln.h
@@ -90,8 +90,11 @@ extern "C" {
 #define LN_CNLUPD_CHFLAGS_DISABLE       (0x02)      ///< b1: disable
 
 // ln_channel_t.shutdown_flag
-#define LN_SHDN_FLAG_SEND               (0x01)      ///< shutdown送信済み
-#define LN_SHDN_FLAG_RECV               (0x02)      ///< shutdown受信済み
+#define LN_SHDN_FLAG_WAIT_SEND_SHDN     (0x01)      ///< waiting to send shutdown
+#define LN_SHDN_FLAG_SEND_SHDN          (0x02)      ///< shutdown sent
+#define LN_SHDN_FLAG_RECV_SHDN          (0x04)      ///< shutdown received
+#define LN_SHDN_FLAG_WAIT_SEND_CLSN     (0x08)      ///< waiting to closing_signed
+#define LN_SHDN_FLAG_SEND_CLSN          (0x10)      ///< closing_signed sent
 
 // ln_close_force_t.p_tx, p_htlc_idxsのインデックス値
 #define LN_CLOSE_IDX_COMMIT             (0)         ///< commit_tx

--- a/ln/ln_close.h
+++ b/ln/ln_close.h
@@ -37,7 +37,13 @@
  * prototypes
  ********************************************************************/
 
-bool /*HIDDEN*/ ln_shutdown_send(ln_channel_t *pChannel);
+bool /*HIDDEN*/ ln_is_shutdowning(ln_channel_t *pChannel);
+bool /*HIDDEN*/ ln_shutdown_set_send(ln_channel_t *pChannel);
+void /*HIDDEN*/ ln_shutdown_reset(ln_channel_t *pChannel);
+bool HIDDEN ln_shutdown_send_needs(ln_channel_t *pChannel);
+bool HIDDEN ln_closing_signed_send_needs(ln_channel_t *pChannel);
+
+bool HIDDEN ln_shutdown_send(ln_channel_t *pChannel);
 bool HIDDEN ln_shutdown_recv(ln_channel_t *pChannel, const uint8_t *pData, uint16_t Len);
 bool HIDDEN ln_closing_signed_send(ln_channel_t *pChannel, ln_msg_closing_signed_t *pClosingSignedMsg);
 bool HIDDEN ln_closing_signed_recv(ln_channel_t *pChannel, const uint8_t *pData, uint16_t Len);

--- a/ln/ln_db_lmdb.c
+++ b/ln/ln_db_lmdb.c
@@ -149,7 +149,7 @@
 #define M_KEY_PAYMENT_ID        "payment_id"
 #define M_SZ_PAYMENT_ID         (sizeof(M_KEY_PAYMENT_ID) - 1)
 
-#define M_DB_VERSION_VAL        ((int32_t)(-65))            ///< DB version
+#define M_DB_VERSION_VAL        ((int32_t)(-66))            ///< DB version
 /*
     -1 : first
     -2 : ln_update_add_htlc_t変更
@@ -256,6 +256,7 @@
     -63: add `payment` env
     -64: rm `ln_update_t::fin_type`
     -65: add `ln_channel_t::update_info::feerate_per_kw_irrevocably_committed`
+    -66: update `ln_channel_t::shutdown_flag`
  */
 
 

--- a/ln/ln_db_lmdb.c
+++ b/ln/ln_db_lmdb.c
@@ -149,7 +149,7 @@
 #define M_KEY_PAYMENT_ID        "payment_id"
 #define M_SZ_PAYMENT_ID         (sizeof(M_KEY_PAYMENT_ID) - 1)
 
-#define M_DB_VERSION_VAL        ((int32_t)(-64))            ///< DB version
+#define M_DB_VERSION_VAL        ((int32_t)(-65))            ///< DB version
 /*
     -1 : first
     -2 : ln_update_add_htlc_t変更
@@ -255,6 +255,7 @@
     -62: add `ln_htlc_t::forward_msg`
     -63: add `payment` env
     -64: rm `ln_update_t::fin_type`
+    -65: add `ln_channel_t::update_info::feerate_per_kw_irrevocably_committed`
  */
 
 
@@ -489,11 +490,12 @@ static const fixed_item_t DBCHANNEL_VALUES[] = {
     //
     M_ITEM(ln_channel_t, channel_id),           //[NORM_01]
     M_ITEM(ln_channel_t, short_channel_id),     //[NORM_02]
-    MM_ITEM(ln_channel_t, update_info, ln_update_info_t, updates),              //[NORM_03]
+    MM_ITEM(ln_channel_t, update_info, ln_update_info_t, updates),                              //[NORM_03]
     //[NORM_03]htlcs --> HTLC
-    MM_ITEM(ln_channel_t, update_info, ln_update_info_t, next_htlc_id),         //[NORM_03]
-    MM_ITEM(ln_channel_t, update_info, ln_update_info_t, fee_updates),          //[NORM_03]
-    MM_ITEM(ln_channel_t, update_info, ln_update_info_t, next_fee_update_id),   //[NORM_03]
+    MM_ITEM(ln_channel_t, update_info, ln_update_info_t, next_htlc_id),                         //[NORM_03]
+    MM_ITEM(ln_channel_t, update_info, ln_update_info_t, fee_updates),                          //[NORM_03]
+    MM_ITEM(ln_channel_t, update_info, ln_update_info_t, feerate_per_kw_irrevocably_committed), //[NORM_03]
+    MM_ITEM(ln_channel_t, update_info, ln_update_info_t, next_fee_update_id),                   //[NORM_03]
 
     //
     //comm

--- a/ln/ln_establish.c
+++ b/ln/ln_establish.c
@@ -50,6 +50,7 @@
 #include "ln_msg_establish.h"
 #include "ln_local.h"
 #include "ln_setupctl.h"
+#include "ln_close.h"
 #include "ln_establish.h"
 
 
@@ -776,6 +777,7 @@ void ln_channel_reestablish_before(ln_channel_t *pChannel)
 {
     bool updated = false;
     ln_update_info_clear_pending_updates(&pChannel->update_info, &updated);
+    ln_shutdown_reset(pChannel);
 }
 
 

--- a/ln/ln_normalope.c
+++ b/ln/ln_normalope.c
@@ -517,7 +517,7 @@ bool HIDDEN ln_revoke_and_ack_recv(ln_channel_t *pChannel, const uint8_t *pData,
     }
 
     //Since htlcs are accessed until callback is done, we clear them after callback
-    /*ignore*/ ln_update_info_clear_irrevocably_committed_htlcs(&pChannel->update_info);
+    /*ignore*/ ln_update_info_clear_irrevocably_committed_updates(&pChannel->update_info);
 
     LOGD("END\n");
     return true;
@@ -1867,7 +1867,7 @@ static bool revoke_and_ack_send(ln_channel_t *pChannel)
         }
     }
 
-    ln_update_info_clear_irrevocably_committed_htlcs(&pChannel->update_info);
+    ln_update_info_clear_irrevocably_committed_updates(&pChannel->update_info);
 
     LOGD("END\n");
     return true;

--- a/ln/ln_update_info.c
+++ b/ln/ln_update_info.c
@@ -627,7 +627,7 @@ void ln_update_info_reset_new_update(ln_update_info_t *pInfo) {
 uint64_t ln_update_info_get_htlc_value_in_flight_msat(ln_update_info_t *pInfo, bool bLocal)
 {
     uint64_t value = 0;
-    for (uint16_t idx; idx < ARRAY_SIZE(pInfo->updates); idx++) {
+    for (uint16_t idx = 0; idx < ARRAY_SIZE(pInfo->updates); idx++) {
         ln_update_t *p_update = &pInfo->updates[idx];
         if (!LN_UPDATE_USED(p_update)) continue;
         if (LN_UPDATE_RECV_ENABLED(p_update, LN_UPDATE_TYPE_ADD_HTLC, bLocal)) {
@@ -644,7 +644,7 @@ uint64_t ln_update_info_get_htlc_value_in_flight_msat(ln_update_info_t *pInfo, b
 uint16_t ln_update_info_get_num_received_htlcs(ln_update_info_t *pInfo, bool bLocal)
 {
     uint16_t num = 0;
-    for (uint16_t idx; idx < ARRAY_SIZE(pInfo->updates); idx++) {
+    for (uint16_t idx = 0; idx < ARRAY_SIZE(pInfo->updates); idx++) {
         ln_update_t *p_update = &pInfo->updates[idx];
         if (!LN_UPDATE_USED(p_update)) continue;
         if (LN_UPDATE_RECV_ENABLED(p_update, LN_UPDATE_TYPE_ADD_HTLC, bLocal)) {
@@ -661,7 +661,7 @@ uint16_t ln_update_info_get_num_received_htlcs(ln_update_info_t *pInfo, bool bLo
 void ln_update_info_clear_pending_updates(ln_update_info_t *pInfo, bool *pUpdated)
 {
     *pUpdated = false;
-    for (uint16_t idx; idx < ARRAY_SIZE(pInfo->updates); idx++) {
+    for (uint16_t idx = 0; idx < ARRAY_SIZE(pInfo->updates); idx++) {
         ln_update_t *p_update = &pInfo->updates[idx];
         if (!LN_UPDATE_USED(p_update)) continue;
         if (p_update->state != LN_UPDATE_STATE_OFFERED_WAIT_SEND &&
@@ -691,6 +691,21 @@ void ln_update_info_clear_pending_updates(ln_update_info_t *pInfo, bool *pUpdate
             LOGE("fail: ???\n");
         }
     }
+}
+
+
+bool ln_update_info_is_channel_clean(ln_update_info_t *pInfo)
+{
+    for (uint16_t idx = 0; idx < ARRAY_SIZE(pInfo->updates); idx++) {
+        if (pInfo->updates[idx].enabled) return false;
+    }
+    for (uint16_t idx = 0; idx < ARRAY_SIZE(pInfo->htlcs); idx++) {
+        if (pInfo->htlcs[idx].enabled) return false;
+    }
+    for (uint16_t idx = 0; idx < ARRAY_SIZE(pInfo->fee_updates); idx++) {
+        if (pInfo->fee_updates[idx].enabled) return false;
+    }
+    return true;
 }
 
 

--- a/ln/ln_update_info.h
+++ b/ln/ln_update_info.h
@@ -57,6 +57,7 @@ typedef struct {
     ln_htlc_t                   htlcs[LN_HTLC_MAX];             ///< htlcs
     uint64_t                    next_htlc_id;                   ///< update_add_htlcで使うidの管理 //XXX: Append immediately before sending
     ln_fee_update_t             fee_updates[LN_FEE_UPDATE_MAX]; ///< fee update
+    uint32_t                    feerate_per_kw_irrevocably_committed;   ///< feerate_per_kw
     uint64_t                    next_fee_update_id;             ///< fee update id
 } ln_update_info_t;
 
@@ -104,7 +105,7 @@ bool ln_update_info_irrevocably_committed_htlcs_exists(ln_update_info_t *pInfo);
 
 bool ln_update_info_commitment_signed_send_needs(ln_update_info_t *pInfo);
 
-void ln_update_info_clear_irrevocably_committed_htlcs(ln_update_info_t *pInfo);
+void ln_update_info_clear_irrevocably_committed_updates(ln_update_info_t *pInfo);
 
 void ln_update_info_reset_new_update(ln_update_info_t *pInfo);
 

--- a/ln/ln_update_info.h
+++ b/ln/ln_update_info.h
@@ -119,5 +119,7 @@ uint16_t ln_update_info_get_num_received_htlcs(ln_update_info_t *pInfo, bool bLo
 //for reconnecting
 void ln_update_info_clear_pending_updates(ln_update_info_t *pInfo, bool *pUpdated);
 
+bool ln_update_info_is_channel_clean(ln_update_info_t *pInfo);
+
 
 #endif /* LN_UPDATE_INFO_H__ */

--- a/ln/tests/test_ln_proto_updatefee.cpp
+++ b/ln/tests/test_ln_proto_updatefee.cpp
@@ -1167,8 +1167,8 @@ TEST_F(ln, pruning)
 
     ASSERT_TRUE(ln_update_info_set_initial_fee_send(&info, 100));
 
-    //100
-    ASSERT_EQ(1, ln_update_info_get_num_fee_updates(&info));
+    //(100)
+    ASSERT_EQ(0, ln_update_info_get_num_fee_updates(&info));
 
     //fail: same value
     ASSERT_FALSE(ln_update_info_set_fee_pre_send(&info, &update_idx, 100));
@@ -1177,8 +1177,8 @@ TEST_F(ln, pruning)
     p_update = &info.updates[update_idx];
     LN_UPDATE_FLAG_SET(p_update, LN_UPDATE_STATE_FLAG_UP_SEND);
 
-    //100, 200
-    ASSERT_EQ(2, ln_update_info_get_num_fee_updates(&info));
+    //(100), 200
+    ASSERT_EQ(1, ln_update_info_get_num_fee_updates(&info));
 
     //fail: same value
     ASSERT_FALSE(ln_update_info_set_fee_pre_send(&info, &update_idx, 200));
@@ -1187,8 +1187,8 @@ TEST_F(ln, pruning)
     p_update = &info.updates[update_idx];
     LN_UPDATE_FLAG_SET(p_update, LN_UPDATE_STATE_FLAG_UP_SEND);
 
-    //100, 200, 300
-    ASSERT_EQ(3, ln_update_info_get_num_fee_updates(&info));
+    //(100), 200, 300
+    ASSERT_EQ(2, ln_update_info_get_num_fee_updates(&info));
 
     //fail: same value
     ASSERT_FALSE(ln_update_info_set_fee_pre_send(&info, &update_idx, 300));
@@ -1197,9 +1197,9 @@ TEST_F(ln, pruning)
     p_update = &info.updates[update_idx];
     LN_UPDATE_FLAG_SET(p_update, LN_UPDATE_STATE_FLAG_UP_SEND);
 
-    //100, 300, 400
+    //(100), 300, 400
     //  200 is pruned
-    ASSERT_EQ(3, ln_update_info_get_num_fee_updates(&info));
+    ASSERT_EQ(2, ln_update_info_get_num_fee_updates(&info));
 
     //fail: same value
     ASSERT_FALSE(ln_update_info_set_fee_pre_send(&info, &update_idx, 400));
@@ -1212,9 +1212,9 @@ TEST_F(ln, pruning)
     p_update = &info.updates[update_idx];
     LN_UPDATE_FLAG_SET(p_update, LN_UPDATE_STATE_FLAG_UP_SEND);
 
-    //100, 400, 500
+    //(100), 400, 500
     //  300 is pruned
-    ASSERT_EQ(3, ln_update_info_get_num_fee_updates(&info));
+    ASSERT_EQ(2, ln_update_info_get_num_fee_updates(&info));
 
     //fail: same value
     ASSERT_FALSE(ln_update_info_set_fee_pre_send(&info, &update_idx, 500));
@@ -1227,9 +1227,9 @@ TEST_F(ln, pruning)
     p_update = &info.updates[update_idx];
     LN_UPDATE_FLAG_SET(p_update, LN_UPDATE_STATE_FLAG_UP_SEND);
 
-    //100, 500, 300
+    //(100), 500, 300
     //  400 is pruned
-    ASSERT_EQ(3, ln_update_info_get_num_fee_updates(&info));
+    ASSERT_EQ(2, ln_update_info_get_num_fee_updates(&info));
 
     //fail: same value
     ASSERT_FALSE(ln_update_info_set_fee_pre_send(&info, &update_idx, 300));
@@ -1273,6 +1273,16 @@ TEST_F(ln, pruning)
     //400
     //  500 is pruned
     ASSERT_EQ(1, ln_update_info_get_num_fee_updates(&info));
+
+    //initial value
+    ASSERT_EQ(100, info.feerate_per_kw_irrevocably_committed);
+
+    //overwrite initial value
+    ln_update_info_clear_irrevocably_committed_updates(&info);
+    ASSERT_EQ(400, info.feerate_per_kw_irrevocably_committed);
+
+    //(400)
+    ASSERT_EQ(0, ln_update_info_get_num_fee_updates(&info));
 
     //fail: same value
     ASSERT_FALSE(ln_update_info_set_fee_pre_send(&info, &update_idx, 400));

--- a/ptarmd/lnapp.c
+++ b/ptarmd/lnapp.c
@@ -437,7 +437,7 @@ bool lnapp_close_channel(lnapp_conf_t *pAppConf)
     lnapp_show_channel_param(p_channel, stderr, "close channel", __LINE__);
 
     const char *p_str;
-    if (ln_shutdown_send(p_channel)) {
+    if (ln_shutdown_set_send(p_channel)) {
         p_str = "close: good way(local) start";
     } else {
         p_str = "fail close: good way(local) start";
@@ -735,16 +735,6 @@ void *lnapp_thread_channel_start(void *pArg)
     }
 
     p_conf->annosig_send_req = ln_open_channel_announce(p_channel);
-
-    if (ln_is_shutdown_sent(p_channel)) {
-        //BOLT02
-        //  upon reconnection:
-        //    if it has sent a previous shutdown:
-        //      MUST retransmit shutdown.
-        if (!ln_shutdown_send(p_channel)) {
-            LOGE("fail: shutdown\n");
-        }
-    }
 
     //初期化完了
     LOGD("*** message inited ***\n");


### PR DESCRIPTION
ln_normalope: fix to follow the conditions to send closing messages

`shutdown`
after sending `commitmemt_signed` (no pending updates)

`closing_signed`
no HTLCs and no updates