### PR TITLE
ptarmd: rpcuser/rpcpassword not found error

### DIFF
--- a/ptarmd/conf.c
+++ b/ptarmd/conf.c
@@ -89,6 +89,7 @@ bool conf_btcrpc_load(const char *pConfFile, rpc_conf_t *pRpcConf)
     LOGD("load bitcoin.conf: %s\n", pConfFile);
     if (ini_parse(pConfFile, handler_btcrpc_conf, pRpcConf) != 0) {
         LOGE("fail bitcoin.conf parse[%s]", pConfFile);
+        fprintf(stderr, "fail bitcoin.conf parse[%s]\n", pConfFile);
         return false;
     }
 #if defined(USE_BITCOIND)
@@ -101,6 +102,7 @@ bool conf_btcrpc_load(const char *pConfFile, rpc_conf_t *pRpcConf)
 
     if ((strlen(pRpcConf->rpcuser) == 0) || (strlen(pRpcConf->rpcpasswd) == 0)) {
         LOGE("fail: no rpcuser or rpcpassword[%s]", pConfFile);
+        fprintf(stderr, "fail: no rpcuser or rpcpassword[%s]\n", pConfFile);
         return false;
     }
 #else

--- a/ptarmd/ptarmd_main.c
+++ b/ptarmd/ptarmd_main.c
@@ -215,6 +215,7 @@ int main(int argc, char *argv[])
         //bitcoin.confから読込む
         bret = conf_btcrpc_load_default(&rpc_conf);
         if (!bret || (strlen(rpc_conf.rpcuser) == 0) || (strlen(rpc_conf.rpcpasswd) == 0)) {
+            fprintf(stderr, "fail: wrong conf file.\n");
             goto LABEL_EXIT;
         }
     }


### PR DESCRIPTION
bitcoin.confに`rpcuser``rpcpassword`がない場合にptarmdは起動しないが、エラーメッセージが表示されなかった(confファイル指定も同様)。

```
fail: no rpcuser or rpcpassword[/home/ueno/.bitcoin/bitcoin.conf]
fail: wrong conf file.
```