### PR TITLE
pay_fundin.py: lock input

### DIFF
--- a/install/pay_fundin.py
+++ b/install/pay_fundin.py
@@ -122,9 +122,11 @@ def aggregate_inputs(fundamount, feerate):
             #print('skip')
             continue
 
+        do_lock = lockunspent(str(lu[i]['txid']), lu[i]['vout'])
+        if not do_lock:
+            continue
         sum += lu[i]['amount']
         txlist.append("{\"txid\":\"" + str(lu[i]['txid']) + "\",\"vout\":" + str(lu[i]['vout']) + "}")
-        lockunspent(str(lu[i]['txid']), lu[i]['vout'])
         inputs += 1
 
         if sum >= fundamount:

--- a/install/pay_fundin.py
+++ b/install/pay_fundin.py
@@ -80,7 +80,7 @@ def fund_in(name, funding_sat, push_msat):
     print("[TXID] " + sendtx, file=sys.stderr)
 
     # lock unspent(NOTE: not auto unlock!!)
-    lockvout = lockunspent(sendtx)
+    lockvout = lockunspent(sendtx, 0)
     print('[LOCK]', lockvout, file=sys.stderr)
 
     #CREATE CONF
@@ -124,6 +124,7 @@ def aggregate_inputs(fundamount, feerate):
 
         sum += lu[i]['amount']
         txlist.append("{\"txid\":\"" + str(lu[i]['txid']) + "\",\"vout\":" + str(lu[i]['vout']) + "}")
+        lockunspent(str(lu[i]['txid']), lu[i]['vout'])
         inputs += 1
 
         if sum >= fundamount:
@@ -236,8 +237,8 @@ def signrawtx(signhex):
     return sendtx
 
 
-def lockunspent(sendtx):
-    outpoint = '{\\"txid\\":\\"' + sendtx + '\\",\\"vout\\":0}'
+def lockunspent(txid, txindex):
+    outpoint = '{\\"txid\\":\\"' + txid + '\\",\\"vout\\":' + str(txindex) + '}'
     lockvout = subprocess.run(('bitcoin-cli lockunspent false "[' + outpoint + ']"'), shell = True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
     return lockvout.stdout.decode("utf8").strip() == 'true'
 


### PR DESCRIPTION
pay_fundin.pyは、bitcoindのunspentなoutpointを集めてfunding_txへのinputとなるトランザクションを作っている。
通常はそれだけでよいのだが、テスト中にregtestでfeerateを維持するために適当に送金し続けるスクリプトを動かし続けているため、pay_fundin.py実行中に送金されてunspentでなくなるということが発生した。

通常は発生しないという気もするが、ptarmd以外にもbitcoindを使うアプリが動いている可能性もあるため、inputにするoutpointは`lockunspent`で極力固めるようにする。