### PR TITLE
ptarmcli: paytowallet result

### DIFF
--- a/ptarmd/cmd_json.c
+++ b/ptarmd/cmd_json.c
@@ -1511,7 +1511,7 @@ static cJSON *cmd_walletback(jrpc_context *ctx, cJSON *params, cJSON *id)
     ret = wallet_from_ptarm(&p_result, &vout_amount, tosend, addr, feerate_per_kw);
     if (ret) {
         result = cJSON_CreateObject();
-        cJSON_AddItemToObject(result, "txid", cJSON_CreateString(p_result));
+        cJSON_AddItemToObject(result, "message", cJSON_CreateString(p_result));
         cJSON_AddItemToObject(result, "amount", cJSON_CreateNumber64(vout_amount));
         UTL_DBG_FREE(p_result);
     } else {

--- a/ptarmd/wallet.c
+++ b/ptarmd/wallet.c
@@ -162,8 +162,11 @@ bool wallet_from_ptarm(char **ppResult, uint64_t *pAmount, bool bToSend, const c
                 ln_db_wallet_del(wallet.tx.vin[lp].txid, wallet.tx.vin[lp].index);
             }
 
-            *ppResult = (char *)UTL_DBG_MALLOC(BTC_SZ_TXID * 2 + 1);
-            utl_str_bin2str_rev(*ppResult, txid, BTC_SZ_TXID);
+            char str_txid[BTC_SZ_TXID * 2 + 1];
+            utl_str_bin2str_rev(str_txid, txid, BTC_SZ_TXID);
+            size_t len = 256 + sizeof(str_txid);
+            *ppResult = (char *)UTL_DBG_MALLOC(len);
+            snprintf(*ppResult, len, "pay to '%s', txid=%s", pAddr, str_txid);
         } else {
             LOGE("fail: broadcast\n");
         }


### PR DESCRIPTION
`ptarmcli --paytowallet`のJSON resultを"txid"から"message"に変更。
`--paytowallet=1`のときはtxidだけを出力していたが、送金先アドレスも見せるようにする。