### PR TITLE
issue #1365

### DIFF
--- a/ptarmd/cmd_json.c
+++ b/ptarmd/cmd_json.c
@@ -235,7 +235,9 @@ void cmd_json_start(uint16_t Port)
 void cmd_json_stop(void)
 {
     LOGD("stop\n");
-    jrpc_server_stop(&mJrpc);
+    if (mJrpc.port_number != 0) {
+        jrpc_server_stop(&mJrpc);
+    }
 }
 
 
@@ -480,7 +482,9 @@ static cJSON *cmd_stop(jrpc_context *ctx, cJSON *params, cJSON *id)
         ctx->error_code = err;
         ctx->error_message = error_str_cjson(err);
     }
-    jrpc_server_stop(&mJrpc);
+    if (mJrpc.port_number != 0) {
+        jrpc_server_stop(&mJrpc);
+    }
 
     return result;
 }
@@ -764,7 +768,7 @@ static cJSON *cmd_decodeinvoice(jrpc_context *ctx, cJSON *params, cJSON *id)
         chain = "unknown";
     }
     cJSON_AddItemToObject(result, "chain", cJSON_CreateString(chain));
-    
+
     //amount_msat
     cJSON_AddItemToObject(result, "amount_msat", cJSON_CreateNumber64(p_invoice_data->amount_msat));
     //timestamp
@@ -2102,7 +2106,7 @@ static int cmd_close_unilateral_proc(const uint8_t *pNodeId)
     lnapp_stop(p_conf);
 
     //XXX: block reconnection
-    
+
     if (!lnapp_close_channel_force(p_conf)) {
         ret = RPCERR_CLOSE_FAIL;
         goto LABEL_EXIT;

--- a/ptarmd/p2p.c
+++ b/ptarmd/p2p.c
@@ -274,11 +274,14 @@ void *p2p_listener_start(void *pArg)
     ret = bind(sock, (struct sockaddr *)&sv_addr, sizeof(sv_addr));
     if (ret < 0) {
         LOGE("bind: %s\n", strerror(errno));
+        fprintf(stderr, "fail bind: %s\n", strerror(errno));
+        exit(1);
         goto LABEL_EXIT;
     }
     ret = listen(sock, 1);
     if (ret < 0) {
         LOGE("listen: %s\n", strerror(errno));
+        fprintf(stderr, "fail listen: %s\n", strerror(errno));
         goto LABEL_EXIT;
     }
     fprintf(stderr, "listening...\n");


### PR DESCRIPTION
既にポートが使用中の場合に`ptarmd`を起動すると、coreを吐いて終了してしまう。
せめて、coreを吐かないようにさせる。
なお、先にc-lightningでポートを使用中にして`ptarmd`を起動すると、c-lightningがcoreを吐く。

* jsonrpc-c stop only `port_number` != 0
* `bind()`に失敗した場合は、アプリの正常終了を待たずにexit()する
  他のスレッドがbind()の失敗により後に立ち上がってしまい、終了できないことがあった