### PR TITLE
lnapp: no unilateral close if status none

### DIFF
--- a/ptarmd/lnapp.c
+++ b/ptarmd/lnapp.c
@@ -457,8 +457,9 @@ bool lnapp_close_channel_force(lnapp_conf_t *pConf)
     pthread_mutex_lock(&pConf->mux_conf);
     bool ret = false;
 
-    if (ln_status_is_closing(&pConf->channel)) {
-        LOGE("fail: already closing\n");
+    if ( (ln_status_get(&pConf->channel) < LN_STATUS_ESTABLISH) ||
+         ln_status_is_closing(&pConf->channel) ) {
+        LOGE("fail: not normal operation\n");
         goto LABEL_EXIT;
     }
 


### PR DESCRIPTION
force closeの開始条件として、closing状態でないこと、以外に、establish以前でないこと、を追加。