### PR TITLE
fix local/remote unilateral close

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,4 +33,5 @@ logs
 ptarm_node_*.conf
 *.swp
 *.swo
+*.swn
 .exrc

--- a/btc/btc_sig.h
+++ b/btc/btc_sig.h
@@ -45,6 +45,7 @@ extern "C" {
 
 #define BTC_SZ_FIELD            (32)                ///< secp256k1の世界
 #define BTC_SZ_SIGN_RS          (64)                ///< サイズ:RS形式の署名
+#define BTC_SZ_SIGN_DER_MAX     (73)                ///< DER format max
 
 #define SIGHASH_ALL             (0x01)
 

--- a/ln/ln.c
+++ b/ln/ln.c
@@ -709,7 +709,8 @@ bool ln_close_create_tx(ln_channel_t *pChannel, ln_close_force_t *pClose)
     //remote commit_tx
     bool ret = ln_commit_tx_create_remote_close(
         &pChannel->commit_info_remote, &pChannel->update_info,
-        &keys_local_work, &keys_remote_work, pClose);
+        &keys_local_work, &keys_remote_work, &pChannel->shutdown_scriptpk_local,
+        pClose);
     if (!ret) {
         LOGE("fail: create_to_remote\n");
         ln_close_free_forcetx(pClose);

--- a/ln/ln.c
+++ b/ln/ln.c
@@ -1171,7 +1171,19 @@ bool ln_is_offered_htlc_timeout(const ln_channel_t *pChannel, uint16_t UpdateIdx
 
 const utl_buf_t *ln_preimage_remote(const btc_tx_t *pTx)
 {
-    return (pTx->vin[0].wit_item_cnt == 5) ? &pTx->vin[0].witness[3] : NULL;
+    utl_buf_t *p_buf = NULL;
+    switch (pTx->vin[0].wit_item_cnt) {
+    case 3: //offered HTLC outputs
+        p_buf = &pTx->vin[0].witness[1];
+        break;
+    case 5: //HTLC success tx
+        p_buf = &pTx->vin[0].witness[3];
+        break;
+    default:
+        return NULL;
+    }
+    if (p_buf->len != LN_SZ_PREIMAGE) return NULL;
+    return p_buf;
 }
 
 

--- a/ln/ln_commit_tx.c
+++ b/ln/ln_commit_tx.c
@@ -1061,7 +1061,7 @@ static bool create_local_htlc_tx(
             DUMPD(preimage, LN_SZ_PREIMAGE);
         } else {
             LOGD("[received]have preimage=NO\n");
-            LOGD("skip create HTLC tx\n");
+            LOGD("stop create HTLC tx (input only)\n");
             return true;
         }
     } else if (pHtlcInfo->type == LN_COMMIT_TX_OUTPUT_TYPE_OFFERED) {

--- a/ln/ln_commit_tx.h
+++ b/ln/ln_commit_tx.h
@@ -134,6 +134,7 @@ bool HIDDEN ln_commit_tx_create_remote_close(
     const ln_update_info_t *pUpdateInfo,
     const ln_derkey_local_keys_t *pKeysLocal,
     const ln_derkey_remote_keys_t *pKeysRemote,
+    const utl_buf_t *pScriptPk,
     ln_close_force_t *pClose);
 
 

--- a/ln/ln_htlc_tx.h
+++ b/ln/ln_htlc_tx.h
@@ -146,4 +146,28 @@ bool HIDDEN ln_htlc_tx_verify(const btc_tx_t *pTx,
     const utl_buf_t *pWitScript);
 
 
+bool HIDDEN ln_spend_htlc_offered_output_tx_create(
+    btc_tx_t *pTx,
+    uint64_t Value, //dummy
+    const utl_buf_t *pScriptPk,
+    const uint8_t *pTxid,
+    int Index);
+bool HIDDEN ln_spend_htlc_received_output_tx_create(
+    btc_tx_t *pTx,
+    uint64_t Value, //dummy
+    const utl_buf_t *pScriptPk,
+    const uint8_t *pTxid,
+    int Index,
+    uint32_t CltvExpiry);
+bool HIDDEN ln_spend_htlc_offered_output_tx_set_vin0(
+    btc_tx_t *pTx,
+    const uint8_t *pPreimage,
+    const utl_buf_t *pWitScript);
+bool HIDDEN ln_spend_htlc_received_output_tx_set_vin0(
+    btc_tx_t *pTx,
+    const utl_buf_t *pWitScript);
+bool HIDDEN ln_spend_htlc_output_tx_adjust_fee(btc_tx_t *pTx, uint32_t FeeratePerKw);
+bool HIDDEN ln_spend_htlc_output_tx_sign_vin0(btc_tx_t *pTx, uint64_t Value, const uint8_t *pPrivKey);
+
+
 #endif /* LN_HTLC_TX_H__ */

--- a/ln/ln_normalope.c
+++ b/ln/ln_normalope.c
@@ -605,6 +605,7 @@ bool ln_fulfill_htlc_set(ln_channel_t *pChannel, uint64_t HtlcId, const uint8_t 
     const ln_update_t *p_update = &pChannel->update_info.updates[update_idx];
     if (pPreimage) {
         ln_htlc_t *p_htlc = &pChannel->update_info.htlcs[p_update->type_specific_idx];
+        utl_buf_free(&p_htlc->buf_preimage);
         if (!utl_buf_alloccopy(&p_htlc->buf_preimage, pPreimage, LN_SZ_PREIMAGE)) return false;
     }
 
@@ -1221,6 +1222,11 @@ void ln_idle_proc_inactive(ln_channel_t *pChannel)
     } else {
         /*ignore*/poll_update_add_htlc_forward_inactive(pChannel);
     }
+
+    //this function load update_fulfill/fail_htlc
+    //  but the updates are cleared by `ln_update_info_clear_pending_updates`
+    //  but preimages are remaind
+    /*ignore*/poll_update_del_htlc_forward(pChannel);
 }
 
 

--- a/ln/ln_normalope.h
+++ b/ln/ln_normalope.h
@@ -73,4 +73,20 @@ bool ln_fulfill_htlc_set(ln_channel_t *pChannel, uint64_t HtlcId, const uint8_t 
 bool ln_fail_htlc_set(ln_channel_t *pChannel, uint64_t HtlcId, uint8_t UpdateType, const utl_buf_t *pReason);
 
 
+bool ln_update_fulfill_htlc_forward(
+    uint64_t NeighborShortChannelId, uint64_t NeighborId, const uint8_t *pPreimage);
+
+
+bool ln_update_fulfill_htlc_forward_2(
+    uint64_t NeighborShortChannelId, uint64_t NeighborId, const uint8_t *pPreimage, void *pCur);
+
+
+bool ln_update_fail_htlc_forward(
+    uint64_t NeighborShortChannelId, uint64_t NeighborId, const uint8_t *pReason, uint16_t Len);
+
+
+bool ln_update_fail_htlc_forward_2(
+    uint64_t NeighborShortChannelId, uint64_t NeighborId, const uint8_t *pReason, uint16_t Len, void *pCur);
+
+
 #endif /* LN_NORMALOPE_H__ */

--- a/ln/tests/test_ln.cpp
+++ b/ln/tests/test_ln.cpp
@@ -76,7 +76,7 @@ extern "C" {
 // FAKE_VALUE_FUNC(bool, ln_msg_funding_signed_read, ln_msg_funding_signed_t *, const uint8_t *, uint16_t );
 typedef uint8_t (fake_sig_t)[LN_SZ_SIGNATURE];
 FAKE_VALUE_FUNC(bool, ln_commit_tx_create_remote, ln_commit_info_t *, const ln_update_info_t *, const ln_derkey_local_keys_t *, const ln_derkey_remote_keys_t *, fake_sig_t **);
-FAKE_VALUE_FUNC(bool, ln_commit_tx_create_remote_close, const ln_commit_info_t *, const ln_update_info_t *, const ln_derkey_local_keys_t *, const ln_derkey_remote_keys_t *, ln_close_force_t *);
+FAKE_VALUE_FUNC(bool, ln_commit_tx_create_remote_close, const ln_commit_info_t *, const ln_update_info_t *, const ln_derkey_local_keys_t *, const ln_derkey_remote_keys_t *, const utl_buf_t *, ln_close_force_t *);
 
 
 ////////////////////////////////////////////////////////////////////////

--- a/ln/tests/test_ln_htlcflag.cpp
+++ b/ln/tests/test_ln_htlcflag.cpp
@@ -75,7 +75,7 @@ FAKE_VALUE_FUNC(bool, ln_msg_funding_signed_write, utl_buf_t *, const ln_msg_fun
 FAKE_VALUE_FUNC(bool, ln_msg_funding_signed_read, ln_msg_funding_signed_t *, const uint8_t *, uint16_t );
 typedef uint8_t (fake_sig_t)[LN_SZ_SIGNATURE];
 FAKE_VALUE_FUNC(bool, ln_commit_tx_create_remote, ln_commit_info_t *, const ln_update_info_t *, const ln_derkey_local_keys_t *, const ln_derkey_remote_keys_t *, fake_sig_t **);
-FAKE_VALUE_FUNC(bool, ln_commit_tx_create_remote_close, const ln_commit_info_t *, const ln_update_info_t *, const ln_derkey_local_keys_t *, const ln_derkey_remote_keys_t *, ln_close_force_t *);
+FAKE_VALUE_FUNC(bool, ln_commit_tx_create_remote_close, const ln_commit_info_t *, const ln_update_info_t *, const ln_derkey_local_keys_t *, const ln_derkey_remote_keys_t *, const utl_buf_t *, ln_close_force_t *);
 
 ////////////////////////////////////////////////////////////////////////
 

--- a/ln/tests/test_ln_proto_acceptchannel.cpp
+++ b/ln/tests/test_ln_proto_acceptchannel.cpp
@@ -79,7 +79,7 @@ FAKE_VALUE_FUNC(bool, ln_msg_funding_signed_write, utl_buf_t *, const ln_msg_fun
 FAKE_VALUE_FUNC(bool, ln_msg_funding_signed_read, ln_msg_funding_signed_t *, const uint8_t *, uint16_t );
 typedef uint8_t (fake_sig_t)[LN_SZ_SIGNATURE];
 FAKE_VALUE_FUNC(bool, ln_commit_tx_create_remote, ln_commit_info_t *, const ln_update_info_t *, const ln_derkey_local_keys_t *, const ln_derkey_remote_keys_t *, fake_sig_t **);
-FAKE_VALUE_FUNC(bool, ln_commit_tx_create_remote_close, const ln_commit_info_t *, const ln_update_info_t *, const ln_derkey_local_keys_t *, const ln_derkey_remote_keys_t *, ln_close_force_t *);
+FAKE_VALUE_FUNC(bool, ln_commit_tx_create_remote_close, const ln_commit_info_t *, const ln_update_info_t *, const ln_derkey_local_keys_t *, const ln_derkey_remote_keys_t *, const utl_buf_t *, ln_close_force_t *);
 
 
 ////////////////////////////////////////////////////////////////////////

--- a/ln/tests/test_ln_proto_openchannel.cpp
+++ b/ln/tests/test_ln_proto_openchannel.cpp
@@ -79,7 +79,7 @@ FAKE_VALUE_FUNC(bool, ln_msg_funding_signed_write, utl_buf_t *, const ln_msg_fun
 FAKE_VALUE_FUNC(bool, ln_msg_funding_signed_read, ln_msg_funding_signed_t *, const uint8_t *, uint16_t );
 typedef uint8_t (fake_sig_t)[LN_SZ_SIGNATURE];
 FAKE_VALUE_FUNC(bool, ln_commit_tx_create_remote, ln_commit_info_t *, const ln_update_info_t *, const ln_derkey_local_keys_t *, const ln_derkey_remote_keys_t *, fake_sig_t **);
-FAKE_VALUE_FUNC(bool, ln_commit_tx_create_remote_close, const ln_commit_info_t *, const ln_update_info_t *, const ln_derkey_local_keys_t *, const ln_derkey_remote_keys_t *, ln_close_force_t *);
+FAKE_VALUE_FUNC(bool, ln_commit_tx_create_remote_close, const ln_commit_info_t *, const ln_update_info_t *, const ln_derkey_local_keys_t *, const ln_derkey_remote_keys_t *, const utl_buf_t *, ln_close_force_t *);
 
 
 ////////////////////////////////////////////////////////////////////////

--- a/ln/tests/test_ln_proto_updateaddhtlc.cpp
+++ b/ln/tests/test_ln_proto_updateaddhtlc.cpp
@@ -81,7 +81,7 @@ FAKE_VALUE_FUNC(bool, ln_msg_funding_signed_write, utl_buf_t *, const ln_msg_fun
 FAKE_VALUE_FUNC(bool, ln_msg_funding_signed_read, ln_msg_funding_signed_t *, const uint8_t *, uint16_t );
 typedef uint8_t (fake_sig_t)[LN_SZ_SIGNATURE];
 FAKE_VALUE_FUNC(bool, ln_commit_tx_create_remote, ln_commit_info_t *, const ln_update_info_t *, const ln_derkey_local_keys_t *, const ln_derkey_remote_keys_t *, fake_sig_t **);
-FAKE_VALUE_FUNC(bool, ln_commit_tx_create_remote_close, const ln_commit_info_t *, const ln_update_info_t *, const ln_derkey_local_keys_t *, const ln_derkey_remote_keys_t *, ln_close_force_t *);
+FAKE_VALUE_FUNC(bool, ln_commit_tx_create_remote_close, const ln_commit_info_t *, const ln_update_info_t *, const ln_derkey_local_keys_t *, const ln_derkey_remote_keys_t *, const utl_buf_t *, ln_close_force_t *);
 
 
 ////////////////////////////////////////////////////////////////////////

--- a/ln/tests/test_ln_proto_updatefee.cpp
+++ b/ln/tests/test_ln_proto_updatefee.cpp
@@ -71,7 +71,7 @@ FAKE_VALUE_FUNC(bool, ln_db_preimage_set_expiry, void *, uint32_t);
 
 typedef uint8_t (fake_sig_t)[LN_SZ_SIGNATURE];
 FAKE_VALUE_FUNC(bool, ln_commit_tx_create_remote, ln_commit_info_t *, const ln_update_info_t *, const ln_derkey_local_keys_t *, const ln_derkey_remote_keys_t *, fake_sig_t **);
-FAKE_VALUE_FUNC(bool, ln_commit_tx_create_remote_close, const ln_commit_info_t *, const ln_update_info_t *, const ln_derkey_local_keys_t *, const ln_derkey_remote_keys_t *, ln_close_force_t *);
+FAKE_VALUE_FUNC(bool, ln_commit_tx_create_remote_close, const ln_commit_info_t *, const ln_update_info_t *, const ln_derkey_local_keys_t *, const ln_derkey_remote_keys_t *, const utl_buf_t *, ln_close_force_t *);
 
 FAKE_VALUE_FUNC(bool, ln_msg_update_fee_write, utl_buf_t *, const ln_msg_update_fee_t *);
 FAKE_VALUE_FUNC(bool, ln_msg_update_fee_read, ln_msg_update_fee_t *, const uint8_t *, uint16_t );

--- a/ptarmd/monitoring.c
+++ b/ptarmd/monitoring.c
@@ -117,13 +117,13 @@ static bool funding_spent(lnapp_conf_t *pConf, monparam_t *pParam, void *pDbPara
 static bool channel_reconnect(lnapp_conf_t *pConf);
 static bool node_connect_ipv4(const uint8_t *pNodeId, const char *pIpAddr, uint16_t Port);
 
-static bool close_unilateral_local_offered(ln_channel_t *pChannel, bool *pDel, bool spent, ln_close_force_t *pCloseDat, int lp, void *pDbParam);
+static bool close_unilateral_local_offered(ln_channel_t *pChannel, bool *pDel, bool spent, ln_close_force_t *pCloseDat, int lp);
 static bool close_unilateral_local_received(bool spent);
 
-static bool close_unilateral_remote(ln_channel_t *pChannel, void *pDbParam);
-static void close_unilateral_remote_offered(ln_channel_t *pChannel, bool *pDel, ln_close_force_t *pCloseDat, int lp, void *pDbParam);
+static bool close_unilateral_remote(ln_channel_t *pChannel);
+static void close_unilateral_remote_received(ln_channel_t *pChannel, bool *pDel, ln_close_force_t *pCloseDat, int lp);
 static bool close_unilateral_local_sendreq(bool *pDel, const btc_tx_t *pTx, const btc_tx_t *pHtlcTx, int Num);
-static bool updatea_fail_htlc_forward(ln_channel_t *pChannel, ln_close_force_t *pCloseDat, int lp);
+static bool update_fail_htlc_forward(ln_channel_t *pChannel, ln_close_force_t *pCloseDat, int lp);
 
 static bool close_revoked_first(ln_channel_t *pChannel, btc_tx_t *pTx, uint32_t confm, void *pDbParam);
 static bool close_revoked_after(ln_channel_t *pChannel, uint32_t confm, void *pDbParam);
@@ -273,7 +273,6 @@ bool monitor_close_unilateral_local(ln_channel_t *pChannel, void *pDbParam)
 
         if (p_tx->vin_cnt <= 0) {
             LOGD("skip tx[%d]\n", lp);
-            del = false;
             continue;
         }
 
@@ -311,7 +310,7 @@ bool monitor_close_unilateral_local(ln_channel_t *pChannel, void *pDbParam)
         bool send_req = false;
         switch (p_tx->vout[0].opt) {
         case LN_COMMIT_TX_OUTPUT_TYPE_OFFERED:
-            send_req = close_unilateral_local_offered(pChannel, &del, !unspent, &close_dat, lp, pDbParam);
+            send_req = close_unilateral_local_offered(pChannel, &del, !unspent, &close_dat, lp);
             break;
         case LN_COMMIT_TX_OUTPUT_TYPE_RECEIVED:
             send_req = close_unilateral_local_received(!unspent);
@@ -339,7 +338,7 @@ bool monitor_close_unilateral_local(ln_channel_t *pChannel, void *pDbParam)
                     ln_close_change_stat(pChannel, NULL, pDbParam);
                 } else if (p_tx->vout[0].opt == LN_COMMIT_TX_OUTPUT_TYPE_OFFERED) {
                     LOGD("\n");
-                    if (!updatea_fail_htlc_forward(pChannel, &close_dat, lp)) {
+                    if (!update_fail_htlc_forward(pChannel, &close_dat, lp)) {
                         LOGE("fail: ???\n");
                     }
                 }
@@ -355,7 +354,7 @@ bool monitor_close_unilateral_local(ln_channel_t *pChannel, void *pDbParam)
 }
 
 
-static bool updatea_fail_htlc_forward(ln_channel_t *pChannel, ln_close_force_t *pCloseDat, int lp)
+static bool update_fail_htlc_forward(ln_channel_t *pChannel, ln_close_force_t *pCloseDat, int lp)
 {
     uint16_t update_idx;
     if (!ln_update_info_get_update(
@@ -623,10 +622,10 @@ static bool funding_spent(lnapp_conf_t *pConf, monparam_t *pParam, void *pDbPara
             del = monitor_close_unilateral_local(p_channel, pDbParam);
             break;
         case LN_STATUS_CLOSE_UNI_REMOTE_LAST:
-            del = close_unilateral_remote(p_channel, pDbParam);
+            del = close_unilateral_remote(p_channel);
             break;
         case LN_STATUS_CLOSE_UNI_REMOTE_SECOND_LAST:
-            del = close_unilateral_remote(p_channel, pDbParam);
+            del = close_unilateral_remote(p_channel);
             break;
         case LN_STATUS_CLOSE_REVOKED:
             LOGD("closed: revoked transaction close\n");
@@ -759,10 +758,9 @@ static bool node_connect_ipv4(const uint8_t *pNodeId, const char *pIpAddr, uint1
 }
 
 
-// Unilateral Close(自分がcommit_tx展開): Offered HTLC output
 //Unilateral Close Handling: Local Commitment Transaction
 //  HTLC Output Handling: Local Commitment, Local Offers
-static bool close_unilateral_local_offered(ln_channel_t *pChannel, bool *pDel, bool spent, ln_close_force_t *pCloseDat, int lp, void *pDbParam)
+static bool close_unilateral_local_offered(ln_channel_t *pChannel, bool *pDel, bool spent, ln_close_force_t *pCloseDat, int lp)
 {
     LOGD("offered HTLC output\n");
     if (!spent) {
@@ -770,16 +768,10 @@ static bool close_unilateral_local_offered(ln_channel_t *pChannel, bool *pDel, b
         //  commit_txが展開されてcltv_expiryブロック経過するまではBIP68エラーになる
         return true; //return send request
     }
-    uint16_t update_idx;
-    if (!ln_update_info_get_update(
-        &pChannel->update_info, &update_idx, LN_UPDATE_TYPE_ADD_HTLC, pCloseDat->p_htlc_idxs[lp])) return false;
-    const ln_update_t *p_update = &pChannel->update_info.updates[update_idx];
-    if (!p_update) return false;
+
     const ln_htlc_t *p_htlc = ln_htlc(pChannel, pCloseDat->p_htlc_idxs[lp]);
     if (!p_htlc) return false;
 
-    //extract the preimage for backwinding
-    LOGD("hop node\n");
     LOGD("  neighbor_short_channel_id=%016" PRIx64 "(vout=%d)\n",
         p_htlc->neighbor_short_channel_id, pCloseDat->p_tx[lp].vin[0].index);
 
@@ -788,11 +780,12 @@ static bool close_unilateral_local_offered(ln_channel_t *pChannel, bool *pDel, b
         LOGE("fail: get confirmation\n");
         return false;
     }
+
     btc_tx_t tx = BTC_TX_INIT;
     uint8_t txid[BTC_SZ_TXID];
     btc_tx_txid(&pCloseDat->p_tx[LN_CLOSE_IDX_COMMIT], txid);
-    if (!btcrpc_search_outpoint(&tx, M_SEARCH_OUTPOINT(confirm),
-            txid, pCloseDat->p_tx[lp].vin[0].index)) {
+    if (!btcrpc_search_outpoint(
+        &tx, M_SEARCH_OUTPOINT(confirm), txid, pCloseDat->p_tx[lp].vin[0].index)) {
         LOGD("not found txid: ");
         TXIDD(txid);
         LOGD("index=%d\n", lp);
@@ -800,29 +793,24 @@ static bool close_unilateral_local_offered(ln_channel_t *pChannel, bool *pDel, b
         btc_tx_free(&tx);
         return false;
     }
+
     const utl_buf_t *p_buf = ln_preimage_remote(&tx);
     if (!p_buf) {
+        LOGE("fail: get preimage\n");
         btc_tx_free(&tx);
         return false;
     }
+
     LOGD("backwind preimage: ");
     DUMPD(p_buf->buf, p_buf->len);
-
-    //register preimage
-    //  (自分が持っているのと同じ状態にする)
-    ln_db_preimage_t preimage;
-    memcpy(preimage.preimage, p_buf->buf, LN_SZ_PREIMAGE);
-    preimage.amount_msat = 0;
-    preimage.expiry = UINT32_MAX;
-    ln_db_preimage_save(&preimage, pDbParam);
-    btc_tx_free(&tx);
-
     if (!ln_update_fulfill_htlc_forward(
-        p_htlc->neighbor_short_channel_id, p_htlc->neighbor_id, preimage.preimage)) {
+        p_htlc->neighbor_short_channel_id, p_htlc->neighbor_id, p_buf->buf)) {
         LOGE("fail: ???\n");
+        btc_tx_free(&tx);
         return false;
     }
 
+    btc_tx_free(&tx);
     return false; //not return send request
 }
 
@@ -858,127 +846,150 @@ static bool close_unilateral_local_received(bool spent)
  *  Received HTLC outputs
  *      cltv_expiry後、即座に使用可能
  */
-static bool close_unilateral_remote(ln_channel_t *pChannel, void *pDbParam)
+static bool close_unilateral_remote(ln_channel_t *pChannel)
 {
-    bool del = true;
     ln_close_force_t close_dat;
 
     LOGD("closed: unilateral close[remote]\n");
 
-    bool ret = ln_close_create_tx(pChannel, &close_dat);
-    if (ret) {
-        for (int lp = 0; lp < close_dat.num; lp++) {
-            const btc_tx_t *p_tx = &close_dat.p_tx[lp];
-            if (lp == LN_CLOSE_IDX_COMMIT) {
-                //LOGD("$$$ commit_tx\n");
-            } else if (lp == LN_CLOSE_IDX_TO_LOCAL) {
-                //LOGD("$$$ to_local tx\n");
-            } else if (lp == LN_CLOSE_IDX_TO_REMOTE) {
-                if (p_tx->vin_cnt > 0) {
-                    LOGD("$$$ to_remote tx ==> DB\n");
-
-                    uint8_t pub[BTC_SZ_PUBKEY];
-                    btc_keys_priv2pub(pub, p_tx->vin[0].witness[0].buf);
-
-                    ln_db_wallet_t wlt = LN_DB_WALLET_INIT(LN_DB_WALLET_TYPE_TO_REMOTE);
-                    set_wallet_data(&wlt, p_tx);
-                    utl_buf_t witbuf[2] = {
-                        { p_tx->vin[0].witness[0].buf, BTC_SZ_PRIVKEY },
-                        { pub, sizeof(pub) }
-                    };
-                    wlt.wit_item_cnt = 2;
-                    wlt.p_wit_items = witbuf;
-                    (void)ln_db_wallet_save(&wlt);
-                }
-            } else {
-                LOGD("$$$ HTLC[%d]\n", lp - LN_CLOSE_IDX_HTLC);
-
-                if ((p_tx->vin_cnt == 0) && (p_tx->vout_cnt == 0)) {
-                    LOGD("  no resolved tx\n");
-                    del = false;
-                } else if (p_tx->vin[0].wit_item_cnt > 0) {
-                    //INPUT spent check
-                    bool unspent;
-                    bool ret = btcrpc_check_unspent(ln_remote_node_id(pChannel), &unspent, NULL,
-                                    p_tx->vin[0].txid, p_tx->vin[0].index);
-                    if (ret && !unspent) {
-                        LOGD("already spent\n");
-                        ln_db_wallet_del(p_tx->vin[0].txid, p_tx->vin[0].index);
-                        continue;
-                    }
-
-                    //これをINPUTとするwalletの有無
-                    bool saved = ln_db_wallet_load(NULL, p_tx->vin[0].txid, p_tx->vin[0].index);
-                    if (!saved) {
-                        //まだ保存していないので、保存する
-                        int32_t blkcnt;
-                        ret = btcrpc_getblockcount(&blkcnt);
-                        LOGD("blkcnt=%" PRIu32 "\n", blkcnt);
-                        if ((p_tx->locktime == 0) || (ret && (blkcnt > 0) && (p_tx->locktime <= (uint32_t)blkcnt))) {
-                            if (p_tx->vin_cnt > 0) {
-                                LOGD("$$$ remote HTLC[%d] ==> DB(%" PRId32 ")\n", lp, blkcnt);
-
-                                ln_db_wallet_t wlt = LN_DB_WALLET_INIT(LN_DB_WALLET_TYPE_HTLC_OUTPUT);
-                                set_wallet_data(&wlt, p_tx);
-                                wlt.amount = close_dat.p_tx[LN_CLOSE_IDX_COMMIT].vout[wlt.index].value;     //HTLC_txはfeeが引かれているためoriginalの値を使う
-                                ln_db_wallet_save(&wlt);
-                            }
-                        } else {
-                            del = false;
-                        }
-                    }
-                } else {
-                    if ((p_tx->vout_cnt > 0) && (p_tx->vout[0].opt == LN_COMMIT_TX_OUTPUT_TYPE_OFFERED)) {
-                        //preimageを取得できていない
-                        LOGD("  not have preimage\n");
-                        close_unilateral_remote_offered(pChannel, &del, &close_dat, lp, pDbParam);
-                    } else {
-                        LOGD("\n");
-                    }
-                }
-            }
-        }
-
-        ln_close_free_forcetx(&close_dat);
-    } else {
-        del = false;
+    if (!ln_close_create_tx(pChannel, &close_dat)) {
+        LOGE("fail: ???\n");
+        return false;
     }
 
-    LOGD("del=%d\n", del);
+    bool del = true;
+    for (int lp = 0; lp < close_dat.num; lp++) {
+        const btc_tx_t *p_tx = &close_dat.p_tx[lp];
 
+        if (lp == LN_CLOSE_IDX_COMMIT) {
+            //LOGD("$$$ commit_tx\n");
+            continue;
+        } else if (lp == LN_CLOSE_IDX_TO_LOCAL) {
+            //LOGD("$$$ to_local tx\n");
+            continue;
+        } else if (lp == LN_CLOSE_IDX_TO_REMOTE) {
+            if (p_tx->vin_cnt) {
+                LOGD("$$$ to_remote tx ==> DB\n");
+
+                uint8_t pub[BTC_SZ_PUBKEY];
+                btc_keys_priv2pub(pub, p_tx->vin[0].witness[0].buf);
+
+                ln_db_wallet_t wlt = LN_DB_WALLET_INIT(LN_DB_WALLET_TYPE_TO_REMOTE);
+                set_wallet_data(&wlt, p_tx);
+                utl_buf_t wit_items[2] = {
+                    { p_tx->vin[0].witness[0].buf, BTC_SZ_PRIVKEY },
+                    { pub, sizeof(pub) }
+                };
+                wlt.wit_item_cnt = ARRAY_SIZE(wit_items);
+                wlt.p_wit_items = wit_items;
+                (void)ln_db_wallet_save(&wlt);
+            }
+            continue;
+        } else {
+            LOGD("$$$ HTLC[%d]\n", lp - LN_CLOSE_IDX_HTLC);
+        }
+
+        LOGD("$$$ HTLC[%d]\n", lp - LN_CLOSE_IDX_HTLC);
+
+        if (p_tx->vin_cnt <= 0) {
+            LOGD("skip tx[%d]\n", lp);
+            continue;
+        }
+
+        //check own tx is broadcasted
+        uint8_t txid[BTC_SZ_TXID];
+        btc_tx_txid(p_tx, txid);
+        LOGD("txid[%d]= ", lp);
+        TXIDD(txid);
+        if (btcrpc_is_tx_broadcasted(txid)) {
+            LOGD("already broadcasted[%d] --> OK\n", lp);
+            continue;
+        }
+
+        //check each close_dat.p_tx[] INPUT is broadcasted
+        //  ret:
+        //    true: input tx is broadcasted
+        //    false: not
+        //  unspent:
+        //    true: input is unspent
+        //    false: spent
+        bool unspent;
+        if (!btcrpc_check_unspent(
+            ln_remote_node_id(pChannel), &unspent, NULL,
+            p_tx->vin[0].txid, p_tx->vin[0].index)) {
+            LOGE("fail: check unspent\n");
+            del = false;
+            continue;
+        }
+
+        LOGD("  INPUT txid: ");
+        TXIDD(p_tx->vin[0].txid);
+        LOGD("    index: %d\n", p_tx->vin[0].index);
+        LOGD("      --> unspent[%d]=%d\n", lp, unspent);
+
+        if (p_tx->vout[0].opt == LN_COMMIT_TX_OUTPUT_TYPE_OFFERED) {
+            if (unspent && p_tx->vin[0].wit_item_cnt) { //unspent && have preimage
+                //broadcast
+                utl_buf_t buf = UTL_BUF_INIT;
+                if (!btc_tx_write(p_tx, &buf)) {
+                    LOGE("fail: ???\n");
+                    utl_buf_free(&buf);
+                    continue;
+                }
+                if (btcrpc_send_rawtx(txid, NULL, buf.buf, buf.len)) {
+                    LOGD("$$$ broadcast\n");
+                } else {
+                    LOGE("fail: broadcast\n");
+                    del = false;
+                }
+                utl_buf_free(&buf);
+            }
+        } else if (p_tx->vout[0].opt == LN_COMMIT_TX_OUTPUT_TYPE_RECEIVED) {
+            if (unspent) {
+                //broadcast
+                utl_buf_t buf = UTL_BUF_INIT;
+                if (!btc_tx_write(p_tx, &buf)) {
+                    LOGE("fail: ???\n");
+                    utl_buf_free(&buf);
+                    continue;
+                }
+                if (btcrpc_send_rawtx(txid, NULL, buf.buf, buf.len)) {
+                    LOGD("$$$ broadcast\n");
+                    //remote preimage is blocked! (to be timeout)
+                    if (!update_fail_htlc_forward(pChannel, &close_dat, lp)) {
+                        LOGE("fail: ???\n");
+                    }
+                } else {
+                    LOGE("fail: broadcast\n");
+                    del = false;
+                }
+                utl_buf_free(&buf);
+            } else {
+                close_unilateral_remote_received(pChannel, &del, &close_dat, lp);
+            }
+        } else {
+            LOGE("fail: ???\n");
+        }
+    }
+
+    ln_close_free_forcetx(&close_dat);
+    LOGD("del=%d\n", del);
     return del;
 }
 
 
-// Unilateral Close(相手がcommit_tx展開): Offered HTLC output
-//  相手からofferされているから、preimageがあれば取り戻す
 //Unilateral Close Handling: Remote Commitment Transaction
 //  HTLC Output Handling: Remote Commitment, Remote Offers
-static void close_unilateral_remote_offered(ln_channel_t *pChannel, bool *pDel, ln_close_force_t *pCloseDat, int lp, void *pDbParam)
+static void close_unilateral_remote_received(ln_channel_t *pChannel, bool *pDel, ln_close_force_t *pCloseDat, int lp)
 {
-    //XXX:
-    //Probably this function will be for `Received` HTLC output not `Offered`...
-
-    LOGD("offered HTLC output\n");
-
-    //XXX: We should return a return value
+    LOGD("received HTLC output\n");
 
     const ln_htlc_t *p_htlc = ln_htlc(pChannel, pCloseDat->p_htlc_idxs[lp]);
     if (!p_htlc) return;
 
-    bool unspent;
-    if (btcrpc_check_unspent(
-        ln_remote_node_id(pChannel), &unspent, NULL, pCloseDat->p_tx[lp].vin[0].txid,
-        pCloseDat->p_tx[lp].vin[0].index)) {
-        if (!unspent) {
-            LOGD("already spent\n");
-            ln_db_wallet_del(pCloseDat->p_tx[lp].vin[0].txid, pCloseDat->p_tx[lp].vin[0].index);
-            return;
-        }
-    }
-
     LOGD("  neighbor_short_channel_id=%016" PRIx64 "(vout=%d)\n",
         p_htlc->neighbor_short_channel_id, pCloseDat->p_tx[lp].vin[0].index);
+
     uint32_t confirm;
     if (!btcrpc_get_confirmations(&confirm, ln_funding_info_txid(&pChannel->funding_info))) {
         LOGE("fail: get confirmation\n");
@@ -997,20 +1008,23 @@ static void close_unilateral_remote_offered(ln_channel_t *pChannel, bool *pDel, 
         btc_tx_free(&tx);
         return;
     }
-    //preimageを登録(自分が持っているのと同じ状態にする)
+
     const utl_buf_t *p_buf = ln_preimage_remote(&tx);
     if (!p_buf) {
+        LOGE("fail: get preimage\n");
         btc_tx_free(&tx);
         return;
     }
     LOGD("backwind preimage: ");
     DUMPD(p_buf->buf, p_buf->len);
 
-    ln_db_preimage_t preimage;
-    memcpy(preimage.preimage, p_buf->buf, LN_SZ_PREIMAGE);
-    preimage.amount_msat = 0;
-    preimage.expiry = UINT32_MAX;
-    ln_db_preimage_save(&preimage, pDbParam);
+    if (!ln_update_fulfill_htlc_forward(
+        p_htlc->neighbor_short_channel_id, p_htlc->neighbor_id, p_buf->buf)) {
+        LOGE("fail: ???\n");
+        btc_tx_free(&tx);
+        return;
+    }
+
     btc_tx_free(&tx);
 }
 

--- a/ptarmd/monitoring.c
+++ b/ptarmd/monitoring.c
@@ -1030,7 +1030,7 @@ static bool close_unilateral_local_sendreq(bool *pDel, const btc_tx_t *pTx, cons
              (pTx->vout[0].opt == LN_COMMIT_TX_OUTPUT_TYPE_RECEIVED) ) {
             for (int lp = 0; lp < Num; lp++) {
                 if (pHtlcTx[lp].vin_cnt > 0) {
-                    LOGD("$$$ to_local tx[%d] ==> DB\n", lp);
+                    LOGD("$$$ spending tx[%d] ==> DB\n", lp);
 
                     ln_db_wallet_t wlt = LN_DB_WALLET_INIT(LN_DB_WALLET_TYPE_HTLC_OUTPUT);
                     set_wallet_data(&wlt, &pHtlcTx[lp]);


### PR DESCRIPTION
local/remote unilateral closeの修正
- HTLC outputsを直接回収するトランザクションの作成、およびそこからpreimageの摘出
- onchainのpreimageおよびtimeoutを別のチャンネルへ中継（update_fulfill/fail_htlc）
- closing中のチャネルに別のチャネルで受信したpreimageを反映させる