### PR TITLE
ln_anno: disable to verify sigs of announcements

### DIFF
--- a/ln/ln_anno.c
+++ b/ln/ln_anno.c
@@ -228,10 +228,12 @@ static bool node_announcement_recv(ln_channel_t *pChannel, const uint8_t *pData,
         LOGE("fail: read message\n");
         return false;
     }
+#if 0
     if (!ln_msg_node_announcement_verify(&msg, pData, Len)) {
         LOGE("fail: verify\n");
         return false;
     }
+#endif
 
     LOGV("node_id:");
     DUMPV(msg.p_node_id, BTC_SZ_PUBKEY);
@@ -326,10 +328,12 @@ static bool channel_update_recv(ln_channel_t *pChannel, const uint8_t *pData, ui
             LOGE("fail: invalid pubkey\n");
             return false;
         }
+#if 0
         if (!ln_msg_channel_update_verify(node_id, pData, Len)) {
             LOGE("fail: verify\n");
             return false;
         }
+#endif
     } else {
         //not found
         //  BOLT#11

--- a/ln/tests/test_ln_proto_updatechannel.cpp
+++ b/ln/tests/test_ln_proto_updatechannel.cpp
@@ -407,7 +407,7 @@ TEST_F(ln, recv_updatechannel_ok)
     bool ret = ln_channel_update_recv(&channel, NULL, 0);
     ASSERT_TRUE(ret);
     ASSERT_EQ(1, ln_db_cnlupd_need_to_prune_fake.call_count);
-    ASSERT_EQ(1, ln_msg_channel_update_verify_fake.call_count);
+    //ASSERT_EQ(1, ln_msg_channel_update_verify_fake.call_count); //XXX: dissable to vefiry sigs
     ASSERT_EQ(1, ln_db_cnlupd_save_fake.call_count);
     ASSERT_EQ(1, callback_called);
 
@@ -469,7 +469,7 @@ TEST_F(ln, recv_updatechannel_timestamp_toofar_in)
     bool ret = ln_channel_update_recv(&channel, NULL, 0);
     ASSERT_TRUE(ret);
     ASSERT_EQ(1, ln_db_cnlupd_need_to_prune_fake.call_count);
-    ASSERT_EQ(1, ln_msg_channel_update_verify_fake.call_count);
+    //ASSERT_EQ(1, ln_msg_channel_update_verify_fake.call_count); //XXX: disable to verify sigs
     ASSERT_EQ(1, ln_db_cnlupd_save_fake.call_count);
     ASSERT_EQ(1, callback_called);
 
@@ -532,7 +532,7 @@ TEST_F(ln, recv_updatechannel_timestamp_toofar_out)
     bool ret = ln_channel_update_recv(&channel, NULL, 0);
     ASSERT_TRUE(ret);
     ASSERT_EQ(1, ln_db_cnlupd_need_to_prune_fake.call_count);
-    ASSERT_EQ(1, ln_msg_channel_update_verify_fake.call_count);
+    //ASSERT_EQ(1, ln_msg_channel_update_verify_fake.call_count); //XXX: disable to verify sigs
     ASSERT_EQ(0, ln_db_cnlupd_save_fake.call_count);
     ASSERT_EQ(0, callback_called);
 


### PR DESCRIPTION
workaround
this function is too late at `initial_routing_sync`
we will put this back when the `gossip_querry` implementation is complete