### PR TITLE
remove log of secrets

### DIFF
--- a/ln/ln_commit_tx.c
+++ b/ln/ln_commit_tx.c
@@ -1058,7 +1058,7 @@ static bool create_local_htlc_tx(
             memcpy(
                 preimage, pUpdateInfo->htlcs[pHtlcInfo->htlc_idx].buf_preimage.buf,
                 pUpdateInfo->htlcs[pHtlcInfo->htlc_idx].buf_preimage.len);
-            DUMPD(preimage, LN_SZ_PREIMAGE);
+            //DUMPD(preimage, LN_SZ_PREIMAGE);
         } else {
             LOGD("[received]have preimage=NO\n");
             LOGD("stop create HTLC tx (input only)\n");
@@ -1441,7 +1441,7 @@ static bool create_remote_spend_htlc_output_tx(
             memcpy(
                 preimage, pUpdateInfo->htlcs[pHtlcInfo->htlc_idx].buf_preimage.buf,
                 pUpdateInfo->htlcs[pHtlcInfo->htlc_idx].buf_preimage.len);
-            DUMPD(preimage, LN_SZ_PREIMAGE);
+            //DUMPD(preimage, LN_SZ_PREIMAGE);
 
             if (!ln_spend_htlc_offered_output_tx_set_vin0(&tx, preimage, &pHtlcInfo->wit_script)) {
                 LOGE("fail: ???\n");

--- a/ln/ln_db_lmdb.c
+++ b/ln/ln_db_lmdb.c
@@ -2882,8 +2882,9 @@ bool ln_db_preimage_del(const uint8_t *pPreimage)
     if (pPreimage) {
         MDB_val key;
 
-        LOGD("remove: ");
-        DUMPD(pPreimage, LN_SZ_PREIMAGE);
+        //LOGD("remove: ");
+        //DUMPD(pPreimage, LN_SZ_PREIMAGE);
+        LOGD("remove\n");
         key.mv_size = LN_SZ_PREIMAGE;
         key.mv_data = (CONST_CAST uint8_t *)pPreimage;
         retval = mdb_del(db.p_txn, db.dbi, &key, NULL);
@@ -5647,8 +5648,9 @@ static bool preimage_cmp_func(const uint8_t *pPreimage, uint64_t Amount, uint32_
     const uint8_t *hash = (const uint8_t *)pParam;
     uint8_t preimage_hash[BTC_SZ_HASH256];
 
-    LOGD("compare preimage : ");
-    DUMPD(pPreimage, LN_SZ_PREIMAGE);
+    //LOGD("compare preimage : ");
+    //DUMPD(pPreimage, LN_SZ_PREIMAGE);
+    LOGD("compare preimage\n");
     ln_payment_hash_calc(preimage_hash, pPreimage);
 
     if (memcmp(preimage_hash, hash, BTC_SZ_HASH256)) {
@@ -5674,8 +5676,9 @@ static bool preimage_cmp_all_func(const uint8_t *pPreimage, uint64_t Amount, uin
     preimage_close_t *param = (preimage_close_t *)pParam;
     uint8_t preimage_hash[BTC_SZ_HASH256];
 
-    LOGD("compare preimage : ");
-    DUMPD(pPreimage, LN_SZ_PREIMAGE);
+    //LOGD("compare preimage : ");
+    //DUMPD(pPreimage, LN_SZ_PREIMAGE);
+    LOGD("compare preimage\n");
     ln_payment_hash_calc(preimage_hash, pPreimage);
 
     for (int lp = 0; lp < LN_HTLC_MAX; lp++) {

--- a/ln/ln_derkey.c
+++ b/ln/ln_derkey.c
@@ -34,7 +34,7 @@
 
 #include "ln_derkey.h"
 #include "ln_local.h"
-//#define M_DBG_PRINT
+//#define M_DBG_PRINT //XXX: CAUTION!!: display secret
 
 /**************************************************************************
  * prototypes

--- a/ln/ln_establish.c
+++ b/ln/ln_establish.c
@@ -745,8 +745,8 @@ bool HIDDEN ln_channel_reestablish_recv(ln_channel_t *pChannel, const uint8_t *p
             //  AND your_last_per_commitment_secret is correct for that next_remote_revocation_number minus 1:
             uint8_t secret[BTC_SZ_PRIVKEY];
             ln_derkey_local_storage_create_per_commitment_secret(&pChannel->keys_local, secret, LN_SECRET_INDEX_INIT - (msg.next_remote_revocation_number - 1));
-            LOGD("secret: ");
-            DUMPD(secret, BTC_SZ_PRIVKEY);
+            //LOGD("secret: ");
+            //DUMPD(secret, BTC_SZ_PRIVKEY);
             if (memcmp(secret, msg.p_your_last_per_commitment_secret, BTC_SZ_PRIVKEY) == 0) {
                 //MUST NOT broadcast its commitment transaction.
                 //SHOULD fail the channel.

--- a/ln/ln_msg_normalope.c
+++ b/ln/ln_msg_normalope.c
@@ -197,8 +197,9 @@ static void update_fulfill_htlc_print(const ln_msg_update_fulfill_htlc_t *pMsg)
     LOGD("channel_id: ");
     DUMPD(pMsg->p_channel_id, LN_SZ_CHANNEL_ID);
     LOGD("id: %" PRIu64 "\n", pMsg->id);
-    LOGD("p_payment_preimage: ");
-    DUMPD(pMsg->p_payment_preimage, BTC_SZ_PRIVKEY);
+    //LOGD("p_payment_preimage: ");
+    //DUMPD(pMsg->p_payment_preimage, BTC_SZ_PRIVKEY);
+    LOGD("p_payment_preimage: ???\n");
     LOGD("--------------------------------\n");
 #endif  //PTARM_DEBUG
 }
@@ -471,8 +472,9 @@ static void revoke_and_ack_print(const ln_msg_revoke_and_ack_t *pMsg)
     LOGD("-[revoke_and_ack]-------------------------------\n");
     LOGD("channel_id: ");
     DUMPD(pMsg->p_channel_id, LN_SZ_CHANNEL_ID);
-    LOGD("per_commitment_secret: ");
-    DUMPD(pMsg->p_per_commitment_secret, BTC_SZ_PRIVKEY);
+    //LOGD("per_commitment_secret: ");
+    //DUMPD(pMsg->p_per_commitment_secret, BTC_SZ_PRIVKEY);
+    LOGD("per_commitment_secret: ???\n");
     LOGD("next_per_commitment_point: ");
     DUMPD(pMsg->p_next_per_commitment_point, BTC_SZ_PUBKEY);
     LOGD("--------------------------------\n");

--- a/ln/ln_msg_x_normalope.c
+++ b/ln/ln_msg_x_normalope.c
@@ -190,8 +190,9 @@ static void x_update_fulfill_htlc_print(const ln_msg_x_update_fulfill_htlc_t *pM
 {
 #ifdef PTARM_DEBUG
     LOGD("-[x_update_fulfill_htlc]-------------------------------\n");
-    LOGD("p_payment_preimage: ");
-    DUMPD(pMsg->p_payment_preimage, BTC_SZ_PRIVKEY);
+    //LOGD("p_payment_preimage: ");
+    //DUMPD(pMsg->p_payment_preimage, BTC_SZ_PRIVKEY);
+    LOGD("p_payment_preimage: ???\n");
     LOGD("--------------------------------\n");
 #endif  //PTARM_DEBUG
 }

--- a/ln/ln_normalope.c
+++ b/ln/ln_normalope.c
@@ -1661,8 +1661,8 @@ static bool check_recv_add_htlc_bolt4_final(
         utl_push_u64be(&push_reason, pForwardParam->amount_msat); //[8:htlc_msat]
         return false;
     }
-    LOGD("match preimage: ");
-    DUMPD(pPreimage, LN_SZ_PREIMAGE);
+    //LOGD("match preimage: ");
+    //DUMPD(pPreimage, LN_SZ_PREIMAGE);
 
     //C2. if the amount paid is less than the amount expected:
     //      incorrect_payment_amount

--- a/ln/ln_onion.c
+++ b/ln/ln_onion.c
@@ -66,7 +66,7 @@
 
 #define M_EXCHANGE_ENDIAN16(val)    ((uint16_t)((val) >> 8) | (((val) & 0xff) << 8))
 
-//#define M_DBG_FAIL
+//#define M_DBG_FAIL //XXX: CAUTION!!: display secret
 
 
 /**************************************************************************

--- a/ptarmd/monitoring.c
+++ b/ptarmd/monitoring.c
@@ -804,8 +804,9 @@ static void close_unilateral_local_offered(ln_channel_t *pChannel, bool *pDel, l
         return;
     }
 
-    LOGD("backwind preimage: ");
-    DUMPD(p_buf->buf, p_buf->len);
+    //LOGD("backwind preimage: ");
+    //DUMPD(p_buf->buf, p_buf->len);
+    LOGD("backwind preimage\n");
     if (!ln_update_fulfill_htlc_forward(
         p_htlc->neighbor_short_channel_id, p_htlc->neighbor_id, p_buf->buf)) {
         LOGE("fail: ???\n");
@@ -1004,8 +1005,9 @@ static void close_unilateral_remote_received(ln_channel_t *pChannel, bool *pDel,
         btc_tx_free(&tx);
         return;
     }
-    LOGD("backwind preimage: ");
-    DUMPD(p_buf->buf, p_buf->len);
+    //LOGD("backwind preimage: ");
+    //DUMPD(p_buf->buf, p_buf->len);
+    LOGD("backwind preimage\n");
 
     if (!ln_update_fulfill_htlc_forward(
         p_htlc->neighbor_short_channel_id, p_htlc->neighbor_id, p_buf->buf)) {

--- a/ptarmd/wallet.c
+++ b/ptarmd/wallet.c
@@ -109,8 +109,9 @@ bool wallet_from_ptarm(char **ppResult, uint64_t *pAmount, bool bToSend, const c
         memcpy(&amount, p, sizeof(uint64_t));
         //p += sizeof(uint64_t);
 
-        LOGD("[%d]secret: ", lp);
-        DUMPD(p_secret, BTC_SZ_PRIVKEY);
+        //LOGD("[%d]secret: ", lp);
+        //DUMPD(p_secret, BTC_SZ_PRIVKEY);
+        LOGD("[%d]\n", lp);
         LOGD("   type: %02x\n", type);
         LOGD("   amount: %" PRIu64 "\n", amount);
 

--- a/utl/utl_str.c
+++ b/utl/utl_str.c
@@ -141,7 +141,8 @@ bool utl_str_str2bin(uint8_t *pBin, uint32_t BinLen, const char *pStr)
         str[0] = *(pStr + 2 * lp);
         str[1] = *(pStr + 2 * lp + 1);
         if (!isxdigit(str[0]) || !isxdigit(str[1])) {
-            LOGE("fail: str=%s\n", str);
+            //LOGE("fail: str=%s\n", str);
+            LOGE("fail: ???\n");
             ret = false;
             break;
         }


### PR DESCRIPTION
シークレットがログで表示されている部分を削除

`preimage`
だいたいがこれ。
final nodeはhopについては表示しても問題ないが、origin nodeは表示してはいけない。
考えるとめんどうなので、とりあえず一律表示しないようにした。

`per_commitment_secret`
これも消した。
channel_reestablishで送るピアのper_commitment_secretは消していない。

それ以外は、
ptarmd/wallet.c: なんかよくわからんがsecretが表示されていた。
utl/utl_str.c: 汎用的な関数なのでなにが表示されるかわからないのでエラー時の表示を消した。






