### PR TITLE
lmdb: fix skip value

### DIFF
--- a/ln/ln_db_lmdb.h
+++ b/ln/ln_db_lmdb.h
@@ -144,8 +144,6 @@ extern "C" {
 #define LN_DB_KEY_RLEN              (3)                 ///< [revoked]key長
 
 #define LN_DB_DBI_ROUTE_SKIP        "route_skip"
-#define LN_DB_ROUTE_SKIP_TEMP       ((uint8_t)1)    // 一時的にskip
-#define LN_DB_ROUTE_SKIP_WORK       ((uint8_t)2)    // 一時的にrouteに含める
 
 
 /**************************************************************************

--- a/showdb/showdb.c
+++ b/showdb/showdb.c
@@ -929,6 +929,9 @@ static void dumpit_route_skip(MDB_txn *txn, MDB_dbi dbi)
                 case LN_DB_ROUTE_SKIP_TEMP:
                     printf(M_QQ("temp") "]");
                     break;
+                case LN_DB_ROUTE_SKIP_PERM:
+                    printf(M_QQ("perm") "]");
+                    break;
                 case LN_DB_ROUTE_SKIP_WORK:
                     printf(M_QQ("work") "]");
                     break;


### PR DESCRIPTION
`LN_DB_ROUTE_SKIP_TEMP` and `LN_DB_ROUTE_SKIP_WORK` are duplicated.