### PR TITLE
use getaddrinfo()

### DIFF
--- a/install/script/started.sh
+++ b/install/script/started.sh
@@ -7,8 +7,8 @@ DATE=`date -u +"%Y-%m-%dT%H:%M:%S.%N"`
 cat << EOS | jq -e '.'
 {
     "method":"started",
-    "date":"$DATE"
+    "date":"$DATE",
     "short_channel_id":"$1",
-    "node_id":"$2",
+    "node_id":"$2"
 }
 EOS

--- a/ptarmcli/conf_cli.c
+++ b/ptarmcli/conf_cli.c
@@ -201,7 +201,7 @@ static int handler_peer_conf(void* user, const char* section, const char* name, 
 
     peer_conf_t* pconfig = (peer_conf_t *)user;
 
-    if (strcmp(name, "ipaddr") == 0) {
+    if ((strcmp(name, "ipaddr") == 0) && (strlen(value) <= SZ_IPV4_LEN)) {
         strcpy(pconfig->ipaddr, value);
     } else if (strcmp(name, "port") == 0) {
         pconfig->port = (uint16_t)atoi(value);

--- a/ptarmcli/ptarmcli.c
+++ b/ptarmcli/ptarmcli.c
@@ -116,7 +116,7 @@
  * static variables
  **************************************************************************/
 
-static char         mPeerAddr[INET6_ADDRSTRLEN];
+static char         mPeerAddr[INET6_ADDRSTRLEN + 1];
 static uint16_t     mPeerPort;
 static char         mPeerNodeId[BTC_SZ_PUBKEY * 2 + 1];
 static char         mBuf[BUFFER_SIZE];
@@ -435,7 +435,8 @@ static void optfunc_addr(int *pOption, bool *pConn)
 {
     (void)pOption; (void)pConn;
 
-    strcpy(mAddr, optarg);
+    strncpy(mAddr, optarg, sizeof(mAddr));
+    mAddr[sizeof(mAddr) - 1] = '\0';
 }
 
 
@@ -507,6 +508,10 @@ static void optfunc_getinfo(int *pOption, bool *pConn)
 
 static void optfunc_disconnect(int *pOption, bool *pConn)
 {
+    if (*pOption == M_OPTIONS_ERR) {
+        return;
+    }
+
     if (*pOption == M_OPT_CONN) {
         //特定接続を切る
         snprintf(mBuf, BUFFER_SIZE,

--- a/ptarmd/btcrpc_bitcoind.c
+++ b/ptarmd/btcrpc_bitcoind.c
@@ -583,11 +583,9 @@ bool btcrpc_getnewaddress(char pAddr[BTC_SZ_ADDR_STR_MAX + 1])
 
     ret = getnewaddress_rpc(&p_root, &p_result, &p_json);
     if (ret) {
-        if (json_is_string(p_result)) {
-            if (strlen(json_string_value(p_result)) <= BTC_SZ_ADDR_STR_MAX) {
-                strcpy(pAddr,  (const char *)json_string_value(p_result));
-                result = true;
-            }
+        if (json_is_string(p_result) && (json_string_length(p_result) <= BTC_SZ_ADDR_STR_MAX)) {
+            strcpy(pAddr,  (const char *)json_string_value(p_result));
+            result = true;
         }
     } else {
         LOGE("fail: getnewaddress_rpc()\n");
@@ -717,7 +715,7 @@ static bool getblocktx(json_t **ppRoot, json_t **ppJsonTx, char **ppBufJson, int
         LOGE("fail: getblockhash_rpc\n");
         return false;
     }
-    if (json_is_string(p_result)) {
+    if (json_is_string(p_result) && (json_string_length(p_result) == BTC_SZ_HASH256 * 2)) {
         strcpy(blockhash, (const char *)json_string_value(p_result));
     } else {
         LOGD("error: M_RESULT\n");
@@ -938,6 +936,9 @@ static bool search_outpoint(btc_tx_t *pTx, int BHeight, const uint8_t *pTxid, ui
         char txid[BTC_SZ_TXID * 2 + 1] = "";
 
         json_array_foreach(p_tx, index, p_value) {
+            if (json_string_length(p_value) != BTC_SZ_TXID * 2) {
+                continue;
+            }
             strcpy(txid, (const char *)json_string_value(p_value));
             btc_tx_t tx = BTC_TX_INIT;
 
@@ -998,6 +999,9 @@ static bool search_vout_block(utl_buf_t *pTxBuf, int BHeight, const utl_buf_t *p
         char txid[BTC_SZ_TXID * 2 + 1] = "";
 
         json_array_foreach(p_tx, index, p_value) {
+            if (json_string_length(p_value) != BTC_SZ_TXID * 2) {
+                continue;
+            }
             strcpy(txid, (const char *)json_string_value(p_value));
             btc_tx_t tx = BTC_TX_INIT;
 

--- a/ptarmd/cmd_json.c
+++ b/ptarmd/cmd_json.c
@@ -2247,7 +2247,8 @@ static int json_connect(cJSON *params, int *pIndex, peer_conn_t *pConn)
     }
     json = cJSON_GetArrayItem(params, (*pIndex)++);
     if (json && (json->type == cJSON_String)) {
-        strcpy(pConn->ipaddr, json->valuestring);
+        strncpy(pConn->ipaddr, json->valuestring, SZ_IPV4_LEN);
+        pConn->ipaddr[SZ_IPV4_LEN] = '\0';
         LOGD("pConn->ipaddr=%s\n", json->valuestring);
     } else {
         LOGE("fail: ipaddr\n");

--- a/ptarmd/conf.c
+++ b/ptarmd/conf.c
@@ -209,13 +209,13 @@ static int handler_btcrpc_conf(void* user, const char* section, const char* name
 
     rpc_conf_t* pconfig = (rpc_conf_t *)user;
 
-    if (strcmp(name, "rpcuser") == 0) {
+    if ((strcmp(name, "rpcuser") == 0) && (strlen(value) < SZ_RPC_USER)) {
         strcpy(pconfig->rpcuser, value);
-    } else if (strcmp(name, "rpcpassword") == 0) {
+    } else if ((strcmp(name, "rpcpassword") == 0) && (strlen(value) < SZ_RPC_PASSWD)) {
         strcpy(pconfig->rpcpasswd, value);
     } else if (strcmp(name, "rpcport") == 0) {
         pconfig->rpcport = atoi(value);
-    } else if (strcmp(name, "rpcurl") == 0) {
+    } else if ((strcmp(name, "rpcurl") == 0) && (strlen(value) < SZ_RPC_URL)) {
         //bitcoin.confには無い。ptarmiganテスト用。
         strcpy(pconfig->rpcurl, value);
     } else {

--- a/ptarmd/lnapp.c
+++ b/ptarmd/lnapp.c
@@ -304,7 +304,8 @@ bool lnapp_handshake(peer_conn_handshake_t *pConnHandshake)
         goto LABEL_EXIT;
     }
 
-    strcpy(conf.conn_str, pConnHandshake->conn.ipaddr);
+    strncpy(conf.conn_str, pConnHandshake->conn.ipaddr, SZ_CONN_STR);
+    conf.conn_str[SZ_CONN_STR] = '\0';
     conf.conn_port = pConnHandshake->conn.port;
     conf.routesync = pConnHandshake->conn.routesync;
 

--- a/ptarmd/ptarmd.c
+++ b/ptarmd/ptarmd.c
@@ -324,7 +324,8 @@ void ptarmd_nodefail_add(
 
         nodefaillist_t *nf = (nodefaillist_t *)UTL_DBG_MALLOC(sizeof(nodefaillist_t));
         memcpy(nf->node_id, pNodeId, BTC_SZ_PUBKEY);
-        strcpy(nf->ipaddr, pAddr);
+        strncpy(nf->ipaddr, pAddr, SZ_IPV4_LEN);
+        nf->ipaddr[SZ_IPV4_LEN] = '\0';
         nf->port = Port;
         LIST_INSERT_HEAD(&mNodeFailListHead, nf, list);
     }

--- a/ptarmd/ptarmd_main.c
+++ b/ptarmd/ptarmd_main.c
@@ -298,10 +298,12 @@ int main(int argc, char *argv[])
             goto LABEL_EXIT;
         }
         if (strlen(bitcoinrpcuser) > 0) {
-            strcpy(rpc_conf.rpcuser, bitcoinrpcuser);
+            strncpy(rpc_conf.rpcuser, bitcoinrpcuser, SZ_RPC_USER - 1);
+            rpc_conf.rpcuser[SZ_RPC_USER - 1] = '\0';
         }
         if (strlen(bitcoinrpcpassword) > 0) {
-            strcpy(rpc_conf.rpcpasswd, bitcoinrpcpassword);
+            strncpy(rpc_conf.rpcpasswd, bitcoinrpcpassword, SZ_RPC_PASSWD - 1);
+            rpc_conf.rpcuser[SZ_RPC_PASSWD - 1] = '\0';
         }
         if (bitcoinrpcport != 0) {
             rpc_conf.rpcport = bitcoinrpcport;
@@ -314,7 +316,8 @@ int main(int argc, char *argv[])
         }
     }
     if (strlen(bitcoinrpcurl) > 0) {
-        strcpy(rpc_conf.rpcurl, bitcoinrpcurl);
+        strncpy(rpc_conf.rpcurl, bitcoinrpcurl, SZ_RPC_URL - 1);
+        rpc_conf.rpcurl[SZ_RPC_URL - 1] = '\0';
     }
 #endif
     bret = btc_init(chain, true);


### PR DESCRIPTION
#1484 

元々、接続先はIPv4のみ許容するつもりだったのだが、JSON-RPCから指定した場合にチェックをしていなかった。
ただ、名前を使いたい要望があるため、REST-APIでのみ使えるようにする。
ただし、長さは15文字までである(IPv4の最大長)。