### PR TITLE
spv: use last blockhash

### DIFF
--- a/ln/ln.c
+++ b/ln/ln.c
@@ -387,7 +387,6 @@ void ln_short_channel_id_get_param(uint32_t *pHeight, uint32_t *pBIndex, uint32_
 }
 
 
-
 const uint8_t *ln_funding_blockhash(const ln_channel_t *pChannel)
 {
     return pChannel->funding_blockhash;
@@ -400,10 +399,20 @@ uint32_t ln_funding_last_confirm_get(const ln_channel_t *pChannel)
 }
 
 
-void ln_funding_last_confirm_set(ln_channel_t *pChannel, uint32_t Confirm)
+const uint8_t *ln_funding_last_blockhash(const ln_channel_t *pChannel)
+{
+    return pChannel->funding_last_blockhash;
+}
+
+
+void ln_funding_last_confirm_set(ln_channel_t *pChannel, uint32_t Confirm, const uint8_t *pHash, bool bSave)
 {
     if (Confirm > pChannel->funding_last_confirm) {
         pChannel->funding_last_confirm = Confirm;
+    }
+    memcpy(pChannel->funding_last_blockhash, pHash, BTC_SZ_HASH256);
+    if (bSave) {
+        M_DB_CHANNEL_SAVE(pChannel);
     }
 }
 

--- a/ln/ln.h
+++ b/ln/ln.h
@@ -383,6 +383,7 @@ struct ln_channel_t {
     ln_establish_t              establish;                      ///< [FUND_02]Establishワーク領域
     uint8_t                     funding_blockhash[BTC_SZ_HASH256];      ///< [FUNDSPV_01]funding_txがマイニングされたblock hash
     uint32_t                    funding_last_confirm;                   ///< [FUNDSPV_02]confirmation at calling btcrpc_set_channel()
+    uint8_t                     funding_last_blockhash[BTC_SZ_HASH256]; ///< [FUNDSPV_01]funding_txがマイニングされたblock hash
 
     //msg:announce
     uint8_t                     anno_flag;                      ///< [ANNO_01]announcement_signaturesなど
@@ -891,7 +892,16 @@ const uint8_t *ln_funding_blockhash(const ln_channel_t *pChannel);
 uint32_t ln_funding_last_confirm_get(const ln_channel_t *pChannel);
 
 
-void ln_funding_last_confirm_set(ln_channel_t *pChannel, uint32_t Conf);
+const uint8_t *ln_funding_last_blockhash(const ln_channel_t *pChannel);
+
+
+void ln_funding_last_confirm_set(ln_channel_t *pChannel, uint32_t Conf, const uint8_t *pHash, bool bSave);
+
+
+/** get last checked blockhash
+ * 
+ */
+const uint8_t *ln_funding_last_blockhash(const ln_channel_t *pChannel);
 
 
 bool ln_announcement_is_gossip_query(const ln_channel_t *pChannel);

--- a/ptarmd/btcrpc.h
+++ b/ptarmd/btcrpc.h
@@ -49,10 +49,11 @@ void btcrpc_term(void);
 
 /** [bitcoin IF]getblockcount
  *
- * @param[out]  *pBlockCount    current block count
+ * @param[out]  pBlockCount     current block count
+ * @param[out]  pHash           (!NULL)current block hash
  * @retval  true        success
  */
-bool btcrpc_getblockcount(int32_t *pBlockCount);
+bool btcrpc_getblockcount(int32_t *pBlockCount, uint8_t *pHash);
 
 
 /** [bitcoin IF]get genesis blockhash
@@ -199,6 +200,7 @@ void btcrpc_set_creationhash(const uint8_t *pHash);
  * @param[in]   pRedeemScript   funding_txのvout
  * @param[in]   pMinedHash      funding_tx mined blockhash(not change if NULL)
  * @param[in]   LastConfirm     last checked funding_tx confirmation
+ * @param[in]   pLastHash       last checked blockhash
  */
 void btcrpc_set_channel(const uint8_t *pPeerId,
                 uint64_t ShortChannelId,
@@ -206,7 +208,8 @@ void btcrpc_set_channel(const uint8_t *pPeerId,
                 int FundingIdx,
                 const utl_buf_t *pRedeemScript,
                 const uint8_t *pMinedHash,
-                uint32_t LastConfirm);
+                uint32_t LastConfirm,
+                const uint8_t *pLastHash);
 
 
 /** [bitcoin IF]delete channel watching

--- a/ptarmd/btcrpc_bitcoinj.c
+++ b/ptarmd/btcrpc_bitcoinj.c
@@ -174,6 +174,7 @@ typedef struct {
     const uint8_t   *p_scriptpubkey;
     const uint8_t   *mined_hash;
     uint32_t        last_confirm;
+    const uint8_t   *last_hash;
 } setchannel_t;
 
 
@@ -392,13 +393,13 @@ void btcrpc_set_creationhash(const uint8_t *pHash)
 }
 
 
-bool btcrpc_getblockcount(int32_t *pBlockCount)
+bool btcrpc_getblockcount(int32_t *pBlockCount, uint8_t *pHash)
 {
     LOGD_BTCTRACE("\n");
 
     getblockcount_t param;
     param.p_cnt = pBlockCount;
-    param.p_hash = NULL;
+    param.p_hash = pHash;
     call_jni(METHOD_PTARM_GETBLOCKCOUNT, &param);
 
     if (param.ret) {
@@ -648,7 +649,8 @@ void btcrpc_set_channel(const uint8_t *pPeerId,
                 int FundingIdx,
                 const utl_buf_t *pRedeemScript,
                 const uint8_t *pMinedHash,
-                uint32_t LastConfirm)
+                uint32_t LastConfirm,
+                const uint8_t *pLastHash)
 {
     LOGD_BTCTRACE("\n");
 
@@ -663,6 +665,7 @@ void btcrpc_set_channel(const uint8_t *pPeerId,
     param.p_scriptpubkey = witprog + BTC_OFFSET_WITPROG;
     param.mined_hash = pMinedHash;
     param.last_confirm = LastConfirm;
+    param.last_hash = pLastHash;
     call_jni(METHOD_PTARM_SETCHANNEL, &param);
 }
 
@@ -998,6 +1001,8 @@ static void jni_set_channel(void *pArg)
     LOGD("mined_hash=");
     TXIDD(p->mined_hash);
     LOGD("last_confirm=%" PRIu32 "\n", p->last_confirm);
+    LOGD("last_hash=");
+    TXIDD(p->last_hash);
 
     btcj_set_channel(p->p_peer_id,
                 p->short_channel_id,
@@ -1005,7 +1010,8 @@ static void jni_set_channel(void *pArg)
                 p->fundingidx,
                 p->p_scriptpubkey,
                 p->mined_hash,
-                p->last_confirm);
+                p->last_confirm,
+                p->last_hash);
 }
 
 

--- a/ptarmd/jni/btcj_jni.h
+++ b/ptarmd/jni/btcj_jni.h
@@ -83,7 +83,8 @@ void btcj_set_channel(
     int FundingIndex,
     const uint8_t *pScriptPubKey,
     const uint8_t *pMinedHash,
-    uint32_t LastConfirm);
+    uint32_t LastConfirm,
+    const uint8_t *pLastHash);
 void btcj_del_channel(const uint8_t *pPeerId);
 // void btcj_set_committxid(const uint8_t *peerId, )
 bool btcj_getbalance(uint64_t *pAmount);

--- a/ptarmd/lnapp_cb.c
+++ b/ptarmd/lnapp_cb.c
@@ -311,7 +311,16 @@ static void cb_funding_tx_wait(lnapp_conf_t *pConf, void *pParam)
         p_cb_param->ret = true;
     }
 
+    int32_t bcount;
+    uint8_t bhash[BTC_SZ_HASH256];
     if (p_cb_param->ret) {
+        p_cb_param->ret = btcrpc_getblockcount(&bcount, bhash);
+    }
+    if (p_cb_param->ret) {
+        LOGD("start blockhash: ");
+        TXIDD(bhash);
+        ln_funding_last_confirm_set(&pConf->channel, 0, bhash, true);
+
         //fundingの監視は thread_poll_start()に任せる
         LOGD("$$$ watch funding_txid: ");
         TXIDD(ln_funding_info_txid(&pConf->channel.funding_info));
@@ -324,7 +333,8 @@ static void cb_funding_tx_wait(lnapp_conf_t *pConf, void *pParam)
             ln_funding_info_txindex(&pConf->channel.funding_info),
             ln_funding_info_wit_script(&pConf->channel.funding_info),
             ln_funding_blockhash(&pConf->channel),
-            ln_funding_last_confirm_get(&pConf->channel));
+            ln_funding_last_confirm_get(&pConf->channel),
+            ln_funding_last_blockhash(&pConf->channel));
 
         const char *p_str;
         if (ln_funding_info_is_funder(&pConf->channel.funding_info, true)) {

--- a/ptarmd/ptarmd.c
+++ b/ptarmd/ptarmd.c
@@ -526,15 +526,14 @@ static bool comp_func_cnl(ln_channel_t *pChannel, void *p_db_param, void *p_para
 
     LOGD("short_channel_id=%016" PRIx64 "\n", ln_short_channel_id(pChannel));
 
-    const uint8_t *p_bhash;
-    p_bhash = ln_funding_blockhash(pChannel);
     btcrpc_set_channel(ln_remote_node_id(pChannel),
             ln_short_channel_id(pChannel),
             ln_funding_info_txid(&pChannel->funding_info),
             ln_funding_info_txindex(&pChannel->funding_info),
             ln_funding_info_wit_script(&pChannel->funding_info),
-            p_bhash,
-            ln_funding_last_confirm_get(pChannel));
+            ln_funding_blockhash(pChannel),
+            ln_funding_last_confirm_get(pChannel),
+            ln_funding_last_blockhash(pChannel));
 
     return false;
 }

--- a/ptarmd/tests/testinc_lnapp.cpp
+++ b/ptarmd/tests/testinc_lnapp.cpp
@@ -15,7 +15,7 @@ FAKE_VOID_FUNC(ptarmd_call_script, ptarmd_event_t, const char*);
 FAKE_VOID_FUNC_VARARG(ptarmd_eventlog, const uint8_t*, const char*, ...);
 FAKE_VOID_FUNC(cmd_json_pay_result, const uint8_t*, const char*);
 FAKE_VALUE_FUNC(bool, btcrpc_init, const rpc_conf_t*);
-FAKE_VALUE_FUNC(bool, btcrpc_getblockcount, int32_t*);
+FAKE_VALUE_FUNC(bool, btcrpc_getblockcount, int32_t*, uint8_t*);
 FAKE_VALUE_FUNC(bool, btcrpc_getgenesisblock, uint8_t*);
 FAKE_VALUE_FUNC(bool, btcrpc_get_confirmations, uint32_t*, const uint8_t*);
 FAKE_VALUE_FUNC(bool, btcrpc_get_short_channel_param, const uint8_t*, int32_t*, int32_t*, uint8_t*, const uint8_t*);
@@ -44,7 +44,7 @@ FAKE_VALUE_FUNC(int, cmd_json_connect, const uint8_t*, const char*, uint16_t);
 FAKE_VALUE_FUNC(int, cmd_json_pay, const char*, uint64_t);
 FAKE_VALUE_FUNC(int, cmd_json_pay_retry, const uint8_t*);
 
-FAKE_VOID_FUNC(btcrpc_set_channel, const uint8_t *, uint64_t , const uint8_t *, int , const utl_buf_t *, const uint8_t *, uint32_t );
+FAKE_VOID_FUNC(btcrpc_set_channel, const uint8_t *, uint64_t , const uint8_t *, int , const utl_buf_t *, const uint8_t *, uint32_t, const uint8_t*);
 FAKE_VOID_FUNC(btcrpc_set_committxid, const ln_channel_t*);
 
 

--- a/showdb/showdb.c
+++ b/showdb/showdb.c
@@ -252,6 +252,9 @@ static void ln_print_channel(const ln_channel_t *pChannel)
     btc_dbg_dump_txid(stdout, pChannel->funding_blockhash);
     printf("\",\n");
     printf(INDENT3 M_QQ("last_confirm") ": %" PRIu32 ",\n", pChannel->funding_last_confirm);
+    printf(INDENT3 M_QQ("last_blockhash") ": \"");
+    btc_dbg_dump_txid(stdout, pChannel->funding_last_blockhash);
+    printf("\",\n");
     printf(INDENT3 M_QQ("funding_local") ": {\n");
     printf(INDENT4 M_QQ("funding_txid") ": \"");
     btc_dbg_dump_txid(stdout, ln_funding_info_txid(&pChannel->funding_info));


### PR DESCRIPTION
* last blockhashをDB保存
  * DB versionは維持(追加なので)
  * 用途は、fundingしてminingされるまでの間に再接続した場合、過去のブロックをいくつまでたどるのかの指標。
  * mining後は使わないので、もったいないのだが、他のやり方が思いつかない。