### PR TITLE
Fix `Install` section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 ## Install
 
 ```bash
-sudo apt install -y git autoconf pkg-config build-essential libtool python3 wget jq bc
+sudo apt install -y git autoconf pkg-config build-essential libtool python python3 wget jq bc
 
 git clone https://github.com/nayutaco/ptarmigan.git
 cd ptarmigan


### PR DESCRIPTION
fixes #1509. `python` is not installed on the official docker image (ubuntu:18.04).