### PR TITLE
bitcoinj: log to stdout

### DIFF
--- a/ptarmd/btcrpc_bitcoinj.c
+++ b/ptarmd/btcrpc_bitcoinj.c
@@ -57,7 +57,7 @@
 #define LOGD_BTCRESULT      LOGD
 #define DUMPD_BTCRESULT     DUMPD
 #define TXIDD_BTCRESULT     TXIDD
-#define LOGD_BTCFAIL        LOGD
+#define LOGD_BTCFAIL        LOGE
 #define LOGD_PTHREAD        LOGD
 #define LOGD_JNI            LOGD
 #endif
@@ -492,6 +492,7 @@ bool btcrpc_search_outpoint(btc_tx_t *pTx, uint32_t Blks, const uint8_t *pTxid, 
     param.v_index = VIndex;
     call_jni(METHOD_PTARM_SEARCHOUTPOINT, &param);
     if (param.ret) {
+        LOGD_BTCTRACE("success\n");
         btc_tx_print(pTx);
     } else {
         LOGD_BTCFAIL("fail\n");

--- a/ptarmd/jni/btcj_jni.c
+++ b/ptarmd/jni/btcj_jni.c
@@ -1,6 +1,5 @@
 #include <stdio.h>
 #include <stdlib.h>
-#include <time.h>
 #include <inttypes.h>
 #include <string.h>
 
@@ -132,19 +131,6 @@ bool btcj_init(btc_block_chain_t Gen)
                 ptarmd_execpath_get());
     LOGD("optjar=%s\n", optjar);
 
-    struct tm tmval;
-    time_t now = utl_time_time();
-    gmtime_r(&now, &tmval);
-    char str[512];
-    snprintf(str, sizeof(str),
-        "-Dorg.slf4j.simpleLogger.logFile=./logs/bitcoinj-ptarmigan%04d%02d%02dT%02d%02d%02dZ.log",
-            tmval.tm_year + 1900,
-            tmval.tm_mon + 1,
-            tmval.tm_mday,
-            tmval.tm_hour,
-            tmval.tm_min,
-            tmval.tm_sec);
-
     JavaVMOption opt[9];
     // .classファイルを配置するディレクトリか、.jarファイルのパスを指定する
     opt[0].optionString = optjar;
@@ -156,7 +142,7 @@ bool btcj_init(btc_block_chain_t Gen)
     opt[5].optionString = "-DsimpleLogger.showThreadName=false";
     opt[6].optionString = "-DsimpleLogger.showLogName=false";
     opt[7].optionString = "-Dorg.slf4j.simpleLogger.showShortLogName=true";
-    opt[8].optionString = str;
+    opt[8].optionString = "-Dorg.slf4j.simpleLogger.logFile=System.out";
     //
     JavaVMInitArgs vm_args = {
         .version = JNI_VERSION_1_8,


### PR DESCRIPTION
bitcoinj use SLF4J to output log.
change log output destination from file to stdout.

ファイルの場合は1ファイルに格納し続けるしか方法がなく、サイズを打ち切ることができなさそうだった。
標準出力にすると、`cronolog`などで制御しやすい。