### PR TITLE
Add BTCPayServer.Lightning.Tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,27 @@
+# This file is used to test `Ptarmigan in BTCPayServer.Lightning`
+# Perform 3 lightning interconnection tests from Ptarmigan.
+version: 2
+jobs:
+  build:
+    machine: 
+      docker_layer_caching: true
+    steps: 
+      - checkout
+
+  test:
+    machine:
+        docker_layer_caching: true
+    steps:
+      - checkout
+      - run:
+          command: |
+            cd tests/BTCPayServer.Lightning/
+            docker-compose down --v
+            docker-compose build
+            docker-compose run tests
+
+workflows:
+  version: 2
+  build_and_test:
+    jobs:
+      - test

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,9 @@ _build/
 _ggtest/
 /libs/*
 /install/
-/tests/
+/tests/*
+!/tests/BTCPayServer.Lightning
+
 .vscode/
 
 ptarmd/ptarmd

--- a/tests/BTCPayServer.Lightning/LICENSE
+++ b/tests/BTCPayServer.Lightning/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017-2018 BTCPayServer
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/tests/BTCPayServer.Lightning/README.md
+++ b/tests/BTCPayServer.Lightning/README.md
@@ -1,0 +1,57 @@
+# Testing Ptarmigan with BTCPayServer.Lightning.
+
+Perform the following test using [BTCPayServer.Lightning] (https://github.com/btcapayserver/BTCPayServer.Lightning).
+
+`` `
+1. BTCPayServer.Lightning Ptarmigan operation check
+2. Ptarmigan, LND, c-lightning, Eclair interconnection test
+`` `
+
+## 1. About BTCPayServer.Lightning Ptarmigan operation check
+
+Ptarmigan is currently refactoring for further stabilization.
+
+The refactoring also includes destructive things.
+
+It is not good that the latest Ptarmigan does not work with BTCPayServer.Lightning.
+
+In order for the latest Ptarmigan to work stably on BTCPayServer.Lightning, we have made it simultaneously check the operation on BTCPayServer.Lightning.
+
+## 2. About Ptarmigan, LND, clightning, Eclair interconnection test
+
+Test interconnection of Ptarmigan, LND, clightning, Eclair using BTCPayServer.Lightning.
+
+## About Divide Travis CI and Circle CI
+
+Since the tests performed by each CI are largely different, We decided to divide them.
+
+Travis CI tests Ptarmigan alone, and Circle CI tests BTCPayServer.Lightning.
+
+# BTCPayServer.Lightningを用いたPtarmiganのテスト
+
+[BTCPayServer.Lightning](https://github.com/btcpayserver/BTCPayServer.Lightning)を用いて以下のテストを行ってます。
+
+```
+1.  BTCPayServer.LightningのPtarmigan動作確認
+2.  Ptarmigan, LND, clightning, Eclairの相互接続テスト
+```
+
+## 1. BTCPayServer.LightningのPtarmigan動作確認について
+
+Ptarmiganは、現在、さらなる安定化のためにリファクタリングを続けています。
+
+そのリファクタリングには、破壊的なものも含まれております。
+
+最新のPtarmiganがBTCPayServer.Lightningで動かないのは、よくありません。
+
+常に最新のPtarmiganがBTCPayServer.Lightningで安定して動くために、BTCPayServer.Lightning上での動作確認を同時に実行するようにしました。
+
+## 2.  Ptarmigan, LND, clightning, Eclairの相互接続テスト
+
+BTCPayServer.Lightningを用いて、Ptarmigan, LND, clightning, Eclairの相互接続テストをします。
+
+## Travis CIとCircle CIに分けている理由
+
+各CIで行っているテストが大きく違うので、分けることにしました。
+
+Travis CIでは、Ptarmigan単体のテストを行い、Circle CIでは、BTCPayServer.Lightningを用いたテストを行うようにしています。

--- a/tests/BTCPayServer.Lightning/docker-compose.yml
+++ b/tests/BTCPayServer.Lightning/docker-compose.yml
@@ -1,0 +1,338 @@
+version: "3"
+
+services:
+
+  bitcoind:
+    restart: unless-stopped
+    image: nicolasdorier/docker-bitcoin:0.17.0
+    environment:
+      BITCOIN_NETWORK: regtest
+      BITCOIN_EXTRA_ARGS: |
+        rpcuser=ceiwHEbqWI83
+        rpcpassword=DwubwWsoo3
+        server=1
+        rpcport=43782
+        port=39388
+        whitelist=0.0.0.0/0
+        zmqpubrawblock=tcp://0.0.0.0:28332
+        zmqpubrawtx=tcp://0.0.0.0:28333
+        deprecatedrpc=signrawtransaction
+        addresstype=p2sh-segwit
+    ports: 
+      - "37393:43782"
+      - "23823:28332"
+    expose:
+      - "43782" # RPC
+      - "39388" # P2P
+    volumes:
+      - "bitcoind_dir:/data"
+
+  lightningd:
+    restart: unless-stopped
+    stop_signal: SIGKILL
+    image: btcpayserver/lightning:v0.7.0-1-dev
+    environment:
+      EXPOSE_TCP: "true"
+      LIGHTNINGD_OPT: |
+        bitcoin-datadir=/etc/bitcoin
+        bitcoin-rpcconnect=bitcoind
+        network=regtest
+        bind-addr=0.0.0.0
+        announce-addr=lightningd
+        log-level=debug
+        dev-broadcast-interval=1000
+        dev-bitcoind-poll=1
+    ports:
+      - "48532:9835" # api port
+    expose:
+      - "9735" # server port
+      - "9835" # api port
+    volumes:
+      - "bitcoind_dir:/etc/bitcoin"
+      - "lightningd_dir:/root/.lightning"
+    links:
+      - bitcoind
+
+  lightningd_dest:
+    restart: unless-stopped
+    stop_signal: SIGKILL
+    image: btcpayserver/lightning:v0.7.0-1-dev
+    environment:
+      EXPOSE_TCP: "true"
+      LIGHTNINGD_OPT: |
+        bitcoin-datadir=/etc/bitcoin
+        bitcoin-rpcconnect=bitcoind
+        network=regtest
+        bind-addr=0.0.0.0
+        announce-addr=lightningd_dest
+        log-level=debug
+        dev-broadcast-interval=1000
+        dev-bitcoind-poll=1
+    ports:
+      - "42549:9835" # api port
+    expose:
+      - "9735" # server port
+      - "9835" # api port
+    volumes:
+      - "bitcoind_dir:/etc/bitcoin"
+      - "lightningd_dest_dir:/root/.lightning"
+    links:
+      - bitcoind
+
+  charge:
+    restart: unless-stopped
+    image: shesek/lightning-charge:0.4.6-standalone
+    environment:
+      NETWORK: regtest
+      API_TOKEN: foiewnccewuify
+      BITCOIND_RPCCONNECT: bitcoind
+    volumes:
+      - "bitcoind_dir:/etc/bitcoin"
+      - "lightning_charge_dir:/data"
+      - "lightningd_dir:/etc/lightning"
+    expose:
+      - "9112" # Charge
+      - "9735" # Lightning
+    ports:
+      - "37462:9112" # Charge
+    links:
+      - lightningd
+
+  lnd:
+    restart: unless-stopped
+    image: btcpayserver/lnd:v0.6-beta
+    environment:
+      LND_CHAIN: "btc"
+      LND_ENVIRONMENT: "regtest"
+      LND_EXTRA_ARGS: |
+        restlisten=0.0.0.0:8080
+        bitcoin.node=bitcoind
+        bitcoind.rpchost=bitcoind:43782
+        bitcoind.zmqpubrawblock=tcp://bitcoind:28332
+        bitcoind.zmqpubrawtx=tcp://bitcoind:28333
+        trickledelay=1000
+        externalip=lnd:9735
+        no-macaroons=1
+        debuglevel=debug
+        noseedbackup=1
+    ports:
+      - "32736:8080"
+    expose:
+      - "9735"
+    volumes:
+      - "lnd_dir:/data"
+      - "bitcoind_dir:/deps/.bitcoin"
+    links:
+      - bitcoind
+
+  lnd_dest:
+    restart: unless-stopped
+    image: btcpayserver/lnd:v0.6-beta
+    environment:
+      LND_CHAIN: "btc"
+      LND_ENVIRONMENT: "regtest"
+      LND_EXTRA_ARGS: |
+        restlisten=0.0.0.0:8080
+        bitcoin.node=bitcoind
+        bitcoind.rpchost=bitcoind:43782
+        bitcoind.zmqpubrawblock=tcp://bitcoind:28332
+        bitcoind.zmqpubrawtx=tcp://bitcoind:28333
+        trickledelay=1000
+        externalip=lnd_dest:9735
+        no-macaroons=1
+        debuglevel=debug
+        noseedbackup=1
+    ports:
+      - "42802:8080"
+    expose:
+      - "9735"
+    volumes:
+      - "lnd_dest_dir:/data"
+      - "bitcoind_dir:/deps/.bitcoin"
+    links:
+      - bitcoind
+      
+  eclair:
+    restart: unless-stopped
+    stop_signal: SIGKILL
+    image: acinq/eclair:v0.3
+    environment:
+      JAVA_OPTS: |
+        -Xmx256m
+        -Declair.printToConsole
+        -Declair.headless
+        -Declair.chain=regtest
+        -Declair.server.binding-ip=0.0.0.0
+        -Declair.server.public-ips.0=eclair
+        -Declair.server.port=9735
+        -Declair.api.enabled=true
+        -Declair.api.binding-ip=0.0.0.0
+        -Declair.api.port=8080
+        -Declair.node-alias=eclair
+        -Declair.api.password=bukkake
+        -Declair.bitcoind.host=bitcoind
+        -Declair.bitcoind.rpcport=43782
+        -Declair.bitcoind.rpcuser=ceiwHEbqWI83
+        -Declair.bitcoind.rpcpassword=DwubwWsoo3
+        -Declair.bitcoind.zmqblock=tcp://bitcoind:28332
+        -Declair.bitcoind.zmqtx=tcp://bitcoind:28333
+        -Declair.max-feerate-mismatch=10000
+        -Declair.ping-disconnect=false
+    ports:
+      - "4570:8080" # api port
+      - "9735:9735" # server port
+    expose:
+      - "9735" # server port
+      - "8080" # api port
+    volumes:
+      - "bitcoind_dir:/etc/bitcoin"
+      - "eclair_dir:/data"
+    links:
+      - bitcoind
+      - eclair_dest
+      
+  eclair_dest:
+    restart: unless-stopped
+    stop_signal: SIGKILL
+    image: acinq/eclair:v0.3
+    environment:
+      JAVA_OPTS: |
+        -Xmx256m
+        -Declair.printToConsole
+        -Declair.headless
+        -Declair.chain=regtest
+        -Declair.server.binding-ip=0.0.0.0
+        -Declair.server.public-ips.0=eclair_dest
+        -Declair.server.port=9736
+        -Declair.api.enabled=true
+        -Declair.api.binding-ip=0.0.0.0
+        -Declair.api.port=8080
+        -Declair.api.password=bukkake
+        -Declair.node-alias=eclair_dest
+        -Declair.bitcoind.host=bitcoind
+        -Declair.bitcoind.rpcport=43782
+        -Declair.bitcoind.rpcuser=ceiwHEbqWI83
+        -Declair.bitcoind.rpcpassword=DwubwWsoo3
+        -Declair.bitcoind.zmqblock=tcp://bitcoind:28332
+        -Declair.bitcoind.zmqtx=tcp://bitcoind:28333
+        -Declair.max-feerate-mismatch=10000
+        -Declair.ping-disconnect=false
+    ports:
+      - "4571:8080" # api port
+      - "9736:9736" # server port
+    expose:
+      - "9736" # server port
+      - "8080" # api port
+    volumes:
+      - "bitcoind_dir:/etc/bitcoin"
+      - "eclair_dest_dir:/data"
+    links:
+      - bitcoind
+  
+  ptarmigan:
+    restart: unless-stopped
+    stop_signal: SIGKILL
+    build:
+      context: ../../
+      dockerfile: ./tests/BTCPayServer.Lightning/ptarm/Dockerfile
+    environment:
+      NODE_NAME: test
+      CHAIN: regtest
+      LIGHTNING_PORT: 12345
+      RPC_PORT: 43782
+      RPC_USER: ceiwHEbqWI83
+      RPC_PASSWORD: DwubwWsoo3
+      RPC_URL: bitcoind
+      ANNOUNCE_IP: ptarmigan
+    ports:
+      - "3000:3000"
+      - "12345:12345"
+    expose:
+      - "3000"
+      - "12345"
+    volumes:
+      - "bitcoind_dir:/root/.bitcoin"
+      - "ptarmigan_dir:/data"
+    links:
+      - bitcoind
+      
+  ptarmigan_dest:
+    restart: unless-stopped
+    stop_signal: SIGKILL
+    build:
+      context: ../../
+      dockerfile: ./tests/BTCPayServer.Lightning/ptarm/Dockerfile
+    environment:
+      NODE_NAME: test
+      CHAIN: regtest
+      LIGHTNING_PORT: 54321
+      RPC_PORT: 43782
+      RPC_USER: ceiwHEbqWI83
+      RPC_PASSWORD: DwubwWsoo3
+      RPC_URL: bitcoind
+      ANNOUNCE_IP: ptarmigan_dest
+    ports:
+      - "3001:3000"
+      - "54321:54321"
+    expose:
+      - "3001"
+      - "54321"
+    volumes:
+      - "bitcoind_dir:/root/.bitcoin"
+      - "ptarmigan_dest_dir:/data"
+    links:
+      - bitcoind
+      
+  dev:
+    image: coscale/docker-sleep
+    depends_on:
+      - bitcoind
+      - charge
+      - eclair
+      - eclair_dest
+      - lightningd
+      - lightningd_dest
+      - lnd
+      - lnd_dest
+      - ptarmigan
+      - ptarmigan_dest
+      
+  tests:
+    image: nayutaco/btcpayserver.lightning.tests:1.0.0
+    expose:
+      - "80"
+    links:
+      - bitcoind
+      - charge
+      - eclair
+      - eclair_dest
+      - lightningd
+      - lightningd_dest
+      - lnd
+      - lnd_dest
+      - ptarmigan
+      - ptarmigan_dest
+    depends_on:
+      - bitcoind
+      - charge
+      - eclair
+      - eclair_dest
+      - lightningd
+      - lightningd_dest
+      - lnd
+      - lnd_dest
+      - ptarmigan
+      - ptarmigan_dest
+      
+volumes:
+  lnd_dir:
+  lnd_dest_dir:
+  bitcoind_dir:
+  lightningd_dir:
+  lightning_charge_dir:
+  lightningd_dest_dir:
+  eclair_dir:
+  eclair_dest_dir:
+  ptarmigan_dir:
+  ptarmigan_dest_dir:
+

--- a/tests/BTCPayServer.Lightning/ptarm/Dockerfile
+++ b/tests/BTCPayServer.Lightning/ptarm/Dockerfile
@@ -1,0 +1,34 @@
+FROM ubuntu:18.04
+
+RUN apt-get update && apt-get install -y locales && rm -rf /var/lib/apt/lists/* \
+    && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
+ENV LANG en_US.utf8
+
+RUN apt-get update && apt-get install -y \
+    git \
+    autoconf \
+    pkg-config \
+    build-essential \
+    libtool \
+    python3 \
+    wget \
+    jq \
+    bc
+
+RUN apt-get install -y nodejs npm
+RUN npm install n -g
+RUN n stable
+RUN apt purge -y nodejs npm
+
+COPY . ptarmigan
+
+WORKDIR ptarmigan
+
+RUN make full
+
+RUN cd ./ptarmapi/ && npm install
+
+RUN cp ./tests/BTCPayServer.Lightning/ptarm/docker-entrypoint.sh ./
+RUN chmod +x docker-entrypoint.sh
+
+ENTRYPOINT ["./docker-entrypoint.sh"]

--- a/tests/BTCPayServer.Lightning/ptarm/docker-entrypoint.sh
+++ b/tests/BTCPayServer.Lightning/ptarm/docker-entrypoint.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+touch ./ptarmapi/.env
+
+{
+  echo PTARMD_PATH='"/bitcoin/ptarmigan/install"'
+  echo PTARMD_NODE_PATH='"/bitcoin/ptarmigan/install/node"'
+  echo PTARMD_RPC_PORT=`expr ${LIGHTNING_PORT} + 1`
+  echo PTARMD_HOST='"0.0.0.0"'
+  echo BITCOIND_RPC_PORT=${RPC_PORT}
+  echo BITCOIND_HOST='"'${RPC_URL}'"'
+  echo BITCOIND_USER='"'${RPC_USER}'"'
+  echo BITCOIND_PASS='"'${RPC_PASSWORD}'"'
+} >> ./ptarmapi/.env
+
+cd ./ptarmapi
+npm run start&
+
+cd ..
+cd ./install && ./new_nodedir.sh ${NODE_NAME}
+cd ${NODE_NAME}
+../ptarmd --network=${CHAIN} --port=${LIGHTNING_PORT} --bitcoinrpcport=${RPC_PORT} --bitcoinrpcuser=${RPC_USER} --bitcoinrpcpassword=${RPC_PASSWORD} --bitcoinrpcurl=${RPC_URL} --announceip=${ANNOUNCE_IP} --announceip_force


### PR DESCRIPTION
Add BTCPayServer.Lightning to Ptarmigan's test.

Perform the following test using  [BTCPayServer.Lightning](https://github.com/btcapayserver/BTCPayServer.Lightning).

### 1.  BTCPayServer.Lightning Ptarmigan operation check

In order for the latest Ptarmigan to work stably on BTCPayServer.Lightning.

### 2. Ptarmigan, LND, clightning, Eclair interconnection test

Test interconnection of Ptarmigan, LND, clightning, Eclair using BTCPayServer.Lightning.

### 3. Divide Travis CI and Circle CI

Since the tests performed by each CI are largely different, We decided to divide them.

Travis CI tests Ptarmigan alone, and Circle CI tests BTCPayServer.Lightning.