### PR TITLE
bitcoinj: `paytowallet` need commit_tx confirmation.

### DIFF
--- a/ln/ln_db.h
+++ b/ln/ln_db.h
@@ -48,7 +48,7 @@ extern "C" {
 #define LN_DB_WALLET_TYPE_TO_REMOTE     ((uint8_t)2)
 #define LN_DB_WALLET_TYPE_HTLC_OUTPUT   ((uint8_t)3)
 
-#define LN_DB_WALLET_INIT(t)    { t/*type*/, NULL/*p_txid*/, 0/*index*/, 0/*amount*/, 0/*sequence*/, 0/*locktime*/, 0/*wit_item_cnt*/, NULL/*p_wit_items*/ }
+#define LN_DB_WALLET_INIT(t)    { t/*type*/, NULL/*p_txid*/, 0/*index*/, 0/*amount*/, 0/*sequence*/, 0/*locktime*/, 0/*wit_item_cnt*/, NULL/*p_wit_items*/, 0/*mined_height*/ }
 
 
 /**************************************************************************
@@ -118,6 +118,7 @@ typedef struct {
     uint32_t    locktime;                   ///< <locktime>
     uint32_t    wit_item_cnt;
     utl_buf_t   *p_wit_items;               ///< p_wit_items[wit_item_cnt]
+    uint32_t    mined_height;               ///< outpointがminingされたblockcount
 } ln_db_wallet_t;
 
 
@@ -773,7 +774,7 @@ bool ln_db_revoked_tx_save(const ln_channel_t *pChannel, bool bUpdate, void *pDb
  * @param[in]   Index
  * @retval  true    読み込み成功
  */
-bool ln_db_wallet_load(utl_buf_t *pBuf, const uint8_t *pTxid, uint32_t Index);
+//bool ln_db_wallet_load(utl_buf_t *pBuf, const uint8_t *pTxid, uint32_t Index);
 
 
 /** 送金可能なINPUTを登録

--- a/ln/ln_version.h
+++ b/ln/ln_version.h
@@ -4,7 +4,7 @@
 /** @def    LN_DB_VERSION
  *  @brief  database version
  */
-#define LN_DB_VERSION    ((int32_t)(-69))
+#define LN_DB_VERSION    ((int32_t)(-70))
 /*
     -1 : first
     -2 : ln_update_add_htlc_t変更
@@ -115,6 +115,7 @@
     -67: update `ln_channel_t::status`
     -68: add `ln_channel_t::prev_remote_commit_txid`
     -69: add `ln_db_preimage_t::status` (auto update: -68 ==> -69)
+    -70: add `ln_db_wallet_t::mined_height` (bitcoind auto update: -69 ==> -70)
  */
 
 #endif /* LN_VERSION_H__ */

--- a/ptarmd/btcrpc.h
+++ b/ptarmd/btcrpc.h
@@ -99,6 +99,7 @@ bool btcrpc_gettxid_from_short_channel(uint8_t *pTxid, int BHeight, int BIndex);
 /** [bitcoin IF]search outpoint matched transaction from blocks
  *
  * @param[out]  pTx         transaction
+ * @param[out]  pMined      pTx mined blockcount
  * @param[in]   Blks        number of blocks
  * @param[in]   pTxid       search vin[0]
  * @param[in]   VIndex      vout index
@@ -107,7 +108,7 @@ bool btcrpc_gettxid_from_short_channel(uint8_t *pTxid, int BHeight, int BIndex);
  * @note
  *      - search only pTxid.vin_cnt equals 1
  */
-bool btcrpc_search_outpoint(btc_tx_t *pTx, uint32_t Blks, const uint8_t *pTxid, uint32_t VIndex);
+bool btcrpc_search_outpoint(btc_tx_t *pTx, uint32_t *pMined, uint32_t Blks, const uint8_t *pTxid, uint32_t VIndex);
 
 
 /** [bitcoin IF]search transactions matched scriptPubKey from blocks

--- a/ptarmd/btcrpc_bitcoind.c
+++ b/ptarmd/btcrpc_bitcoind.c
@@ -416,7 +416,7 @@ bool btcrpc_gettxid_from_short_channel(uint8_t *pTxid, int BHeight, int BIndex)
 }
 
 
-bool btcrpc_search_outpoint(btc_tx_t *pTx, uint32_t Blks, const uint8_t *pTxid, uint32_t VIndex)
+bool btcrpc_search_outpoint(btc_tx_t *pTx, uint32_t *pMined, uint32_t Blks, const uint8_t *pTxid, uint32_t VIndex)
 {
     if (Blks == 0) {
         return false;
@@ -434,6 +434,8 @@ bool btcrpc_search_outpoint(btc_tx_t *pTx, uint32_t Blks, const uint8_t *pTxid, 
         for (uint32_t lp = 0; lp < Blks; lp++) {
             ret = search_outpoint(pTx, height - lp, pTxid, VIndex);
             if (ret) {
+                *pMined = height - lp;
+                LOGD("  mined=%d\n", *pMined);
                 break;
             }
         }

--- a/ptarmd/btcrpc_bitcoinj.c
+++ b/ptarmd/btcrpc_bitcoinj.c
@@ -106,6 +106,7 @@ typedef struct {
 typedef struct {
     bool            ret;
     btc_tx_t        *p_tx;
+    uint32_t        *p_mined;
     uint32_t        blks;
     const uint8_t   *p_txid;
     uint32_t        v_index;
@@ -477,7 +478,7 @@ bool btcrpc_gettxid_from_short_channel(uint8_t *pTxid, int BHeight, int BIndex)
 }
 
 
-bool btcrpc_search_outpoint(btc_tx_t *pTx, uint32_t Blks, const uint8_t *pTxid, uint32_t VIndex)
+bool btcrpc_search_outpoint(btc_tx_t *pTx, uint32_t *pMined, uint32_t Blks, const uint8_t *pTxid, uint32_t VIndex)
 {
     if (utl_mem_is_all_zero(pTxid, BTC_SZ_TXID)) {
         return false;
@@ -487,6 +488,7 @@ bool btcrpc_search_outpoint(btc_tx_t *pTx, uint32_t Blks, const uint8_t *pTxid, 
 
     searchoutpoint_t param;
     param.p_tx = pTx;
+    param.p_mined = pMined;
     param.blks = Blks;
     param.p_txid = pTxid;
     param.v_index = VIndex;
@@ -878,11 +880,13 @@ static void jni_search_outpoint(void *pArg)
 
     searchoutpoint_t *p = (searchoutpoint_t *)pArg;
     btcj_buf_t *p_txbuf;
-    p->ret = btcj_search_outpoint(&p_txbuf, p->blks, p->p_txid, p->v_index);
+    p->ret = btcj_search_outpoint(&p_txbuf, p->p_mined, p->blks, p->p_txid, p->v_index);
     if (p->ret) {
         p->ret = btc_tx_read(p->p_tx, p_txbuf->buf, p_txbuf->len);
         UTL_DBG_FREE(p_txbuf->buf);
         UTL_DBG_FREE(p_txbuf);
+
+        LOGD("mined_height=%d\n", *p->p_mined);
     }
 }
 

--- a/ptarmd/jni/btcj_jni.h
+++ b/ptarmd/jni/btcj_jni.h
@@ -68,7 +68,7 @@ uint32_t btcj_gettxconfirm(const uint8_t *pTxid);
 
 bool btcj_get_short_channel_param(const uint8_t *pPeerId, int32_t *pHeight, int32_t *pbIndex, uint8_t *pMinedHash);
 bool btcj_gettxid_from_short_channel(uint64_t ShortChannelId, uint8_t **ppTxid);
-bool btcj_search_outpoint(btcj_buf_t **ppTx, uint32_t Blks, const uint8_t *pTxid, uint32_t VIndex);
+bool btcj_search_outpoint(btcj_buf_t **ppTx, uint32_t *pMined, uint32_t Blks, const uint8_t *pTxid, uint32_t VIndex);
 bool btcj_search_vout(btcj_buf_t **ppTxBuf, uint32_t blks, const btcj_buf_t *pVout);
 bool btcj_signraw_tx(uint64_t Amount, const btcj_buf_t *pScriptPubKey, btcj_buf_t **ppTxData);
 bool btcj_sendraw_tx(uint8_t *pTxid, int *pCode, const btcj_buf_t *pTxData);

--- a/ptarmd/lnapp.c
+++ b/ptarmd/lnapp.c
@@ -472,7 +472,7 @@ bool lnapp_close_channel_force(lnapp_conf_t *pConf)
 
     LOGD("close: bad way(local): htlc=%d\n", ln_commit_info_local(&pConf->channel)->num_htlc_outputs);
     ptarmd_eventlog(ln_channel_id(&pConf->channel), "close: bad way(local)");
-    (void)monitor_close_unilateral_local(&pConf->channel, NULL);
+    (void)monitor_close_unilateral_local(&pConf->channel);
 
     ret = true;
 

--- a/ptarmd/monitoring.h
+++ b/ptarmd/monitoring.h
@@ -72,9 +72,8 @@ uint32_t monitor_btc_feerate_per_kw(void);
 /** Unilateral Close(自分が展開)
  *
  * @param[in,out]       pChannel    チャネル情報
- * @param[in,out]       pDbParam    DB情報
  */
-bool monitor_close_unilateral_local(ln_channel_t *pChannel, void *pDbParam);
+bool monitor_close_unilateral_local(ln_channel_t *pChannel);
 
 
 #ifdef __cplusplus

--- a/ptarmd/tests/testinc_lnapp.cpp
+++ b/ptarmd/tests/testinc_lnapp.cpp
@@ -19,7 +19,7 @@ FAKE_VALUE_FUNC(bool, btcrpc_getgenesisblock, uint8_t*);
 FAKE_VALUE_FUNC(bool, btcrpc_get_confirmations, uint32_t*, const uint8_t*);
 FAKE_VALUE_FUNC(bool, btcrpc_get_short_channel_param, const uint8_t*, int32_t*, int32_t*, uint8_t*, const uint8_t*);
 FAKE_VALUE_FUNC(bool, btcrpc_gettxid_from_short_channel, uint8_t*, int, int);
-FAKE_VALUE_FUNC(bool, btcrpc_search_outpoint, btc_tx_t*, uint32_t, const uint8_t*, uint32_t);
+FAKE_VALUE_FUNC(bool, btcrpc_search_outpoint, btc_tx_t*, uin32_t*, uint32_t, const uint8_t*, uint32_t);
 FAKE_VALUE_FUNC(bool, btcrpc_search_vout, utl_buf_t*, uint32_t, const utl_buf_t*);
 FAKE_VALUE_FUNC(bool, btcrpc_sign_fundingtx, btc_tx_t*, const utl_buf_t*, uint64_t);
 FAKE_VALUE_FUNC(bool, btcrpc_send_rawtx, uint8_t*, int*, const uint8_t*, uint32_t);
@@ -38,7 +38,7 @@ FAKE_VALUE_FUNC(bool, ptarmd_nodefail_get, const uint8_t*, const char*, uint16_t
 FAKE_VALUE_FUNC(char*, ptarmd_error_str, int);
 FAKE_VALUE_FUNC(bool, monitor_btc_getblockcount, int32_t*);
 FAKE_VALUE_FUNC(uint32_t, monitor_btc_feerate_per_kw);
-FAKE_VALUE_FUNC(bool, monitor_close_unilateral_local, ln_channel_t*, void*);
+FAKE_VALUE_FUNC(bool, monitor_close_unilateral_local, ln_channel_t*);
 FAKE_VALUE_FUNC(int, cmd_json_connect, const uint8_t*, const char*, uint16_t);
 FAKE_VALUE_FUNC(int, cmd_json_pay, const char*, uint64_t);
 FAKE_VALUE_FUNC(int, cmd_json_pay_retry, const uint8_t*);

--- a/showdb/showdb.c
+++ b/showdb/showdb.c
@@ -248,7 +248,7 @@ static void ln_print_channel(const ln_channel_t *pChannel)
     printf(INDENT4 M_QQ("is_funding") ": %d,\n", ((pChannel->funding_info.state & LN_FUNDING_STATE_STATE_FUNDING) == LN_FUNDING_STATE_STATE_FUNDING));
     printf(INDENT4 M_QQ("is_opened") ": %d\n", ((pChannel->funding_info.state & LN_FUNDING_STATE_STATE_OPENED) == LN_FUNDING_STATE_STATE_OPENED));
     printf(INDENT3 "},\n");
-    printf(INDENT3 M_QQ("mined_block") ": \"");
+    printf(INDENT3 M_QQ("mined_blockhash") ": \"");
     btc_dbg_dump_txid(stdout, pChannel->funding_blockhash);
     printf("\",\n");
     printf(INDENT3 M_QQ("last_confirm") ": %" PRIu32 ",\n", pChannel->funding_last_confirm);
@@ -692,7 +692,8 @@ static bool dumpit_wallet_func(const ln_db_wallet_t *pWallet, void *p_param)
     printf(INDENT2 M_QQ("type") ": " M_QQ("%s") ",\n", p_type_str);
     printf(INDENT2 M_QQ("amount") ": %" PRIu64 ",\n", pWallet->amount);
     printf(INDENT2 M_QQ("sequence") ": %" PRIu32 ",\n", pWallet->sequence);
-    printf(INDENT2 M_QQ("locktime") ": %" PRIu32 "\n", pWallet->locktime);
+    printf(INDENT2 M_QQ("locktime") ": %" PRIu32 ",\n", pWallet->locktime);
+    printf(INDENT2 M_QQ("mined_height") ": %" PRIu32 "\n", pWallet->mined_height);
     // if (pWallet->wit_item_cnt > 0) {
     //     printf(INDENT2 M_QQ("privkey") ": \"");
     //     utl_dbg_dump(stdout, pWallet->p_wit_items[0].buf, pWallet->p_wit_items[0].len, false);


### PR DESCRIPTION
After unilateral close, to_local, to_remote and HTLC outputs save to wallet DB.
`ptarmcli --paytowallet` pay from wallet DB to Bitcoin blockchain spending some confirmation.
But, getting confirmation from TXID is difficult for bitcoinj.

wallet DB保存する際にminingされたblock countも保存するようにし、現在のblock countからconfirmationを計算するように変更する。
ただ、これはbitcoinjのみの対応とし、bitcoindについては`getrawtransaction`からconfirmationが取得できるため現状のままとする。

DBバージョンも1つ上げる。
bitcoind版は自動的に継続、bitcoinj版はwallet DBでconfirmationを確認する必要がない場合に自動継続する。bitcoinj版でconfirmationを確認する場合は起動不可。

そのせいで実装としてはbitcoindとbitcoinjに分かれてしまうが、致し方あるまい。