### PR TITLE
to_remote append wallet DB once

### DIFF
--- a/ptarmd/monitoring.c
+++ b/ptarmd/monitoring.c
@@ -933,9 +933,20 @@ static bool close_unilateral_remote(ln_channel_t *pChannel, uint32_t MinedHeight
                 LOGE("fail: skip tx[%d]\n", lp);
                 continue;
             }
-            LOGD("$$$ to_remote tx ==> DB\n");
+            LOGD("$$$ to_remote tx\n");
             uint8_t pub[BTC_SZ_PUBKEY];
             btc_keys_priv2pub(pub, p_tx->vin[0].witness[0].buf);
+
+            bool unspent;
+            if (btcrpc_check_unspent(
+                    ln_remote_node_id(pChannel), &unspent, NULL,
+                    p_tx->vin[0].txid, p_tx->vin[0].index)) {
+                if (!unspent) {
+                    LOGD("already spent\n");
+                    continue;
+                }
+            }
+            LOGD("register to_remote ==> DB");
 
             if (MinedHeight > 0) {
                 ln_db_wallet_t wlt = LN_DB_WALLET_INIT(LN_DB_WALLET_TYPE_TO_REMOTE);


### PR DESCRIPTION
received HTLC outputを持つcommit_txをremoteが展開(remote unilateral close)された場合、

1. funding_txのspentを確認→wallet DBにto_remote outputを登録
2. `ptarmcli --paytowallet=1`でto_remoteをspentする
3. しばらく置いてminingされる

その後で`ptarmcli --paytowallet`を実行してwallet DBを見ると、またto_remoteが追加されている。
