### PR TITLE
wallet DB: check unspent

### DIFF
--- a/ptarmd/wallet.c
+++ b/ptarmd/wallet.c
@@ -234,22 +234,25 @@ static bool wallet_dbfunc(const ln_db_wallet_t *pWallet, void *p_param)
         return false;
     }
 
-    // bool unspent;
-    // bool ret = btcrpc_check_unspent(NULL, &unspent, NULL, pWallet->p_txid, pWallet->index);
-    // if (!ret || !unspent) {
-    //     *p_wlt->pp_result = UTL_DBG_STRDUP("not unspent");
-    //     LOGE("%s\n", *p_wlt->pp_result);
-    //     //remain DB if you cannot get.
-    //     //ln_db_wallet_del(pWallet->p_txid, pWallet->index);
-    //     return false;
-    // }
+#if defined(USE_BITCOIND)
+    bool unspent;
+    bool ret = btcrpc_check_unspent(NULL, &unspent, NULL, pWallet->p_txid, pWallet->index);
+    if (!ret || !unspent) {
+        LOGE("fail btcrpc_check_unspent() or already spent\n");
+        //remain DB if you cannot get.
+        //ln_db_wallet_del(pWallet->p_txid, pWallet->index);
+        return false;
+    }
+#else
+    bool ret;
+#endif
 
     if (pWallet->p_wit_items[0].len != BTC_SZ_PRIVKEY) {
         LOGE("FATAL: maybe BUG\n");
         return false;
     }
 
-    bool ret = true;
+    ret = true;
     char str_msg[512];
     if ( (pWallet->sequence != BTC_TX_SEQUENCE) ||
          ((p_wlt->tx.locktime != 0) && (p_wlt->tx.locktime < BTC_TX_LOCKTIME_LIMIT)) ) {

--- a/tests/2nodes_test/example_st3j.sh
+++ b/tests/2nodes_test/example_st3j.sh
@@ -12,6 +12,10 @@
 
 
 ADDR=`./ptarmcli --getnewaddress 4445 | jq -er '.result'`
+if [ "$ADDR" == "" ]; then
+    echo "??? fail getnewaddress ???"
+    exit 1
+fi
 echo sendtoaddress ${ADDR}
 bitcoin-cli -conf=`pwd`/regtest.conf -datadir=`pwd` sendtoaddress ${ADDR} 0.1
 ./generate.sh 1


### PR DESCRIPTION
#1519 #1514 

SPVの対応をしていてwallet DBのunspentチェックを外していたが、少なくともbitcoind版では不具合が発生していた(#1519)。
そのため、bitcoind版について元に戻す。
