### PR TITLE
fix: SPV unilateral close

### DIFF
--- a/ptarmd/wallet.c
+++ b/ptarmd/wallet.c
@@ -243,7 +243,7 @@ static bool wallet_dbfunc(const ln_db_wallet_t *pWallet, void *p_param)
         //ln_db_wallet_del(pWallet->p_txid, pWallet->index);
         return false;
     }
-#else
+#elif defined(USE_BITCOINJ)
     bool ret;
 #endif
 


### PR DESCRIPTION
* bitcoinjの場合、unilateral closeのcomit_tx outputに対するheightを保存するタイミングがなかったため追加
* [ptarmigan-jar](https://github.com/nayutaco/ptarmigan-jar/tree/da7c81bda795050de5be9cac180e1680af8cea6f)