### PR TITLE
(announcement_signatures) fail the channel if not correct

### DIFF
--- a/ptarmd/lnapp.c
+++ b/ptarmd/lnapp.c
@@ -1263,6 +1263,9 @@ static void *thread_recv_start(void *pArg)
         }
         if (!ln_recv(&p_conf->channel, buf_recv.buf, buf_recv.len)) {
             LOGD("DISC: fail recv message\n");
+            if (strlen(p_conf->channel.err_msg) != 0) {
+                ptarmd_eventlog(ln_channel_id(&p_conf->channel), p_conf->channel.err_msg);
+            }
             lnapp_close_channel_force(p_conf);
             pthread_mutex_unlock(&p_conf->mux_conf); //unlock
             break;

--- a/showdb/showdb.c
+++ b/showdb/showdb.c
@@ -510,7 +510,8 @@ static void ln_print_channel(const ln_channel_t *pChannel)
                     pChannel->last_connected_addr.addr[3],
                     pChannel->last_connected_addr.port);
     }
-    printf(INDENT3 M_QQ("err") ": %d\n", pChannel->err);
+    printf(INDENT3 M_QQ("err") ": %d,\n", pChannel->err);
+    printf(INDENT3 M_QQ("err_msg") ": " M_QQ("%s") "\n", pChannel->err_msg);
 
     printf(INDENT2 "}");
 }


### PR DESCRIPTION
受信した`announcement_signatures`のデータがおかしい場合、fail channelする。
* short_channel_id == 0
* 自分のshort_channel_id !=0 で不一致
* verify fail
* DB保存に失敗