### PR TITLE
SPV option: not DISABLE_PRINTFUND

### DIFF
--- a/options.mak
+++ b/options.mak
@@ -19,6 +19,7 @@ USE_OPENSSL=0
 
 # 0: enable print func 1:disable
 #  priority higher than PTARM_USE_PRINTFUNC
+#       NOTICE: if active this option, some `showdb` parameter cannot shown.
 DISABLE_PRINTFUND=0
 
 # 0: disable gcov 1:enable

--- a/tools/rpi_bj.sh
+++ b/tools/rpi_bj.sh
@@ -3,7 +3,7 @@ sed -i 's/NODE_TYPE=BITCOIND/NODE_TYPE=BITCOINJ/g' options.mak
 sed -i 's/JDK_COMPILE=x86_64/#JDK_COMPILE=x86_64/g' options.mak
 sed -i 's/#JDK_COMPILE=ARM_RASPI/JDK_COMPILE=ARM_RASPI/g' options.mak
 sed -i 's/USE_OPENSSL=0/USE_OPENSSL=1/g' options.mak
-sed -i 's/DISABLE_PRINTFUND=0/DISABLE_PRINTFUND=1/g' options.mak
+#sed -i 's/DISABLE_PRINTFUND=0/DISABLE_PRINTFUND=1/g' options.mak
 
 sed -i 's/TARGET=x86_64/#TARGET=x86_64/g' install/jdk.sh
 sed -i 's/#TARGET=ARM_RASPI/TARGET=ARM_RASPI/g' install/jdk.sh


### PR DESCRIPTION
`DISABLE_PRINTFUND`を有効にするとshowdbのパラメータがいくつか出力されないため、元に戻す。