### PR TITLE
fix ptarmd_stop()

### DIFF
--- a/ptarmd/cmd_json.c
+++ b/ptarmd/cmd_json.c
@@ -467,9 +467,10 @@ LABEL_EXIT:
  */
 static cJSON *cmd_stop(jrpc_context *ctx, cJSON *params, cJSON *id)
 {
+    (void)ctx; (void)params; (void)id;
+
     LOGD("$$$: [JSONRPC]stop\n");
 
-    cmd_exit(ctx, params, id);
     ptarmd_stop();
 
     LOGD("exit\n");

--- a/ptarmd/cmd_json.h
+++ b/ptarmd/cmd_json.h
@@ -50,4 +50,10 @@ void cmd_json_stop(void);
 int cmd_json_connect(const uint8_t *pNodeId, const char *pIpAddr, uint16_t Port);
 
 
+/** send JSONRPC "EXIT" to myself
+ * 
+ */
+int cmd_json_exit(void);
+
+
 #endif  //CMD_JSON_H__

--- a/ptarmd/lnapp_manager.c
+++ b/ptarmd/lnapp_manager.c
@@ -168,7 +168,7 @@ void lnapp_manager_term_node(const uint8_t *pNodeId)
 }
 
 
-void lnapp_manager_prune_node()
+void lnapp_manager_prune_node(void)
 {
     pthread_mutex_lock(&mMuxAppconf);
     for (int lp = 0; lp < (int)ARRAY_SIZE(mAppConf); lp++) {

--- a/ptarmd/lnapp_manager.h
+++ b/ptarmd/lnapp_manager.h
@@ -45,7 +45,7 @@ void lnapp_manager_each_node(void (*pCallback)(lnapp_conf_t *pConf, void *pParam
 lnapp_conf_t *lnapp_manager_get_new_node(
     const uint8_t *pNodeId, void *(*pThreadChannelStart)(void *pArg));
 void lnapp_manager_free_node_ref(lnapp_conf_t *pConf);
-void lnapp_manager_prune_node();
+void lnapp_manager_prune_node(void);
 
 
 #ifdef __cplusplus

--- a/ptarmd/p2p.c
+++ b/ptarmd/p2p.c
@@ -55,7 +55,7 @@
  * macros
  ********************************************************************/
 
-#define M_TIMEOUT_MSEC              (TM_WAIT_CONNECT * 1000)    ///< poll timeout[msec]
+#define M_TIMEOUT_MSEC              (1000)  ///< poll timeout[msec]
 
 
 /********************************************************************

--- a/ptarmd/ptarmd.c
+++ b/ptarmd/ptarmd.c
@@ -235,6 +235,7 @@ int ptarmd_start(uint16_t RpcPort, const ln_node_t *pNode, btc_block_chain_t Gen
     cmd_json_start(RpcPort != 0 ? RpcPort : p_addr->port + 1);
 
     //ptarmd_stop()待ち
+    LOGD("$$$ STOP\n");
 
     //待ち合わせ
     pthread_join(th_svr, NULL);
@@ -261,9 +262,11 @@ void ptarmd_stop(void)
     if (mRunning) {
         mRunning = false;
         LOGD("$$$ stopage order\n");
-        cmd_json_stop();
+        monitor_disable_autoconn(true);
+        cmd_json_exit();
         monitor_stop();
         p2p_stop();
+        LOGD("$$$ stopage order: done\n");
     } else {
         LOGD("$$$ stopped\n");
     }
@@ -392,7 +395,7 @@ void ptarmd_call_script(ptarmd_event_t event, const char *param)
         snprintf(cmdline, sclen, "%s %s", script, param);
         LOGD("cmdline: %s\n", cmdline);
         int ret = system(cmdline);
-        LOGD("sytem=%d\n", ret);
+        LOGD("system=%d\n", ret);
         UTL_DBG_FREE(cmdline);      //UTL_DBG_MALLOC: この中
     }
 }

--- a/ptarmd/ptarmd.h
+++ b/ptarmd/ptarmd.h
@@ -62,8 +62,6 @@ extern "C" {
 #define SZ_CONN_STR                 (INET6_ADDRSTRLEN + 1 + 5)   ///< <IP addr>:<port>
 #define SZ_NODECONN_STR             (BTC_SZ_HASH256 * 2 + 1 + SZ_CONN_STR)  ///< <node_id>@<IP addr>:<port>
 
-#define TM_WAIT_CONNECT             (10)        ///< client socket接続待ち[sec]
-
 #define FNAME_CONF_ANNO             "anno.conf"
 #define FNAME_CONF_CHANNEL          "channel.conf"
 #define FNAME_CONF_CONNLIST         "connlist.conf"


### PR DESCRIPTION
`ptarmd_stop`を呼び出しても、ptarmdが終了しない。
`jrpc_server_stop()`呼び出しによって`jrpc_server_run()`から抜ける予定であったが、抜けないようだった。
JSON-RPC経由で呼び出すと抜けるようだったので、そうする。

* JSONRPC "EXIT"を追加
  * `jrpc_server_stop()`を呼び出す
* ptarmdから"EXIT"を呼ぶ `cmd_json_exit()`を追加
* `ptarmd_stop()`からは`cmd_json_exit()`を呼び出す
