### PR TITLE
bitcoind: round JSON amount value

### DIFF
--- a/ptarmd/btcrpc_bitcoind.c
+++ b/ptarmd/btcrpc_bitcoind.c
@@ -1216,7 +1216,7 @@ static int create_funding_input(btc_tx_t *pTx, uint64_t *pSumAmount, uint64_t *p
 
             p = json_object_get(p_value, "amount");
             if (p && json_is_real(p)) {
-                tmp_amount = (uint64_t)(json_real_value(p) * (uint64_t)100000000);
+                tmp_amount = (uint64_t)(json_real_value(p) * (uint64_t)100000000 + 0.5);
             } else {
                 continue;
             }


### PR DESCRIPTION
JSON-RPC(`listunspent`) return BTC amount by string.
jansson library use `strtod()`  to convert double value to integer.
After convert, the value need round off.

```
#include <stdio.h>
#include <stdint.h>
#include <stdlib.h>
#include <inttypes.h>

#define VALUES		"20999991.99978481"

int main(void)
{
	double val = strtod(VALUES, NULL);
	printf("%20.8lf\n", val);
	printf("  %20.10lf\n", val);

	// NG "2099999199978480"
	printf("%" PRIu64 "\n", (uint64_t)(val * (uint64_t)100000000));
	// OK "2099999199978481"
	printf("%" PRIu64 "\n", (uint64_t)(val * (uint64_t)100000000 + 0.5));
	return 0;
}
```