### PR TITLE
not wait funding_locked on Normal Operation status

### DIFF
--- a/ptarmd/lnapp.c
+++ b/ptarmd/lnapp.c
@@ -1117,6 +1117,7 @@ static bool exchange_funding_locked(lnapp_conf_t *p_conf)
         return false;
     }
 
+    if (ln_status_get(&p_conf->channel) < LN_STATUS_NORMAL_OPE) {
         //コールバックでのfunding_locked受信通知待ち
         LOGD("wait: funding_locked\n");
         while (p_conf->active && ((p_conf->flag_recv & LNAPP_FLAGRECV_FUNDINGLOCKED) == 0)) {
@@ -1129,7 +1130,6 @@ static bool exchange_funding_locked(lnapp_conf_t *p_conf)
         }
 
         // funding_locked exchange == "normal operation"
-    if (ln_status_get(&p_conf->channel) < LN_STATUS_NORMAL_OPE) {
         LOGD("Normal Operation!\n");
         ln_status_set(&p_conf->channel, LN_STATUS_NORMAL_OPE);
     }

--- a/ptarmd/lnapp.h
+++ b/ptarmd/lnapp.h
@@ -38,6 +38,18 @@ extern "C" {
 
 
 /********************************************************************
+ * macros
+ ********************************************************************/
+
+//lnapp_conf_t.flag_recv
+#define LNAPP_FLAGRECV_INIT             (0x01)  ///< receive init
+#define LNAPP_FLAGRECV_INIT_EXCHANGED   (0x02)  ///< exchange init
+#define LNAPP_FLAGRECV_REESTABLISH      (0x04)  ///< receive channel_reestablish
+#define LNAPP_FLAGRECV_FUNDINGLOCKED    (0x08)  ///< receive funding locked
+#define LNAPP_FLAGRECV_END              (0x80)  ///< 初期化完了
+
+
+/********************************************************************
  * typedefs
  ********************************************************************/
 

--- a/ptarmd/lnapp_cb.c
+++ b/ptarmd/lnapp_cb.c
@@ -78,13 +78,6 @@
  * macros
  **************************************************************************/
 
-//lnapp_conf_t.flag_recv
-#define M_FLAGRECV_INIT             (0x01)  ///< receive init
-#define M_FLAGRECV_INIT_EXCHANGED   (0x02)  ///< exchange init
-#define M_FLAGRECV_REESTABLISH      (0x04)  ///< receive channel_reestablish
-#define M_FLAGRECV_FUNDINGLOCKED    (0x08)  ///< receive funding locked
-#define M_FLAGRECV_END              (0x80)  ///< 初期化完了
-
 #define M_SZ_SCRIPT_PARAM       (512)
 
 #if 1
@@ -238,7 +231,7 @@ static void cb_init_recv(lnapp_conf_t *pConf, void *pParam)
     DBGTRACE_BEGIN
 
     //init受信待ち合わせ解除(*1)
-    pConf->flag_recv |= M_FLAGRECV_INIT;
+    pConf->flag_recv |= LNAPP_FLAGRECV_INIT;
 }
 
 
@@ -249,7 +242,7 @@ static void cb_channel_reestablish_recv(lnapp_conf_t *pConf, void *pParam)
     DBGTRACE_BEGIN
 
     //channel_reestablish受信待ち合わせ解除(*3)
-    pConf->flag_recv |= M_FLAGRECV_REESTABLISH;
+    pConf->flag_recv |= LNAPP_FLAGRECV_REESTABLISH;
 }
 
 
@@ -392,7 +385,7 @@ static void cb_funding_locked(lnapp_conf_t *pConf, void *pParam)
     (void)pParam;
     DBGTRACE_BEGIN
 
-    if ((pConf->flag_recv & M_FLAGRECV_REESTABLISH) == 0) {
+    if ((pConf->flag_recv & LNAPP_FLAGRECV_REESTABLISH) == 0) {
         //channel establish時のfunding_locked
         char str_sci[LN_SZ_SHORT_CHANNEL_ID_STR + 1];
         ln_short_channel_id_string(str_sci, ln_short_channel_id(&pConf->channel));
@@ -403,7 +396,7 @@ static void cb_funding_locked(lnapp_conf_t *pConf, void *pParam)
     }
 
     //funding_locked受信待ち合わせ解除(*4)
-    pConf->flag_recv |= M_FLAGRECV_FUNDINGLOCKED;
+    pConf->flag_recv |= LNAPP_FLAGRECV_FUNDINGLOCKED;
 }
 
 


### PR DESCRIPTION
[BOLT2 Message Retranmission](https://github.com/lightningnetwork/lightning-rfc/blob/8555709811e6b2326f80dc479021b161e850bf03/02-peer-protocol.md#requirements-14) describe " MUST send `funding_locked`", but do not describe "MUST receive `funding_locked`".
So, do not wait for receiving `funding_locked` on Normal Operation status.
