### PR TITLE
return message group

### DIFF
--- a/ln/ln_msg.c
+++ b/ln/ln_msg.c
@@ -81,8 +81,22 @@ const char *ln_msg_name(uint16_t Type)
 }
 
 
-uint16_t ln_msg_type(const uint8_t *pData, uint16_t Len)
+uint16_t ln_msg_type(ln_msg_groupt_t *pGrp, const uint8_t *pData, uint16_t Len)
 {
     if (Len < 2) return 0x0000;
-    return utl_int_pack_u16be(pData);
+    uint16_t type = utl_int_pack_u16be(pData);
+    if (pGrp != NULL) {
+        if (/*(0 <= type) &&*/ (type <= 31)) {
+            *pGrp = MSGGROUP_SETUP_CTRL;
+        } else if ((32 <= type) && (type <= 127)) {
+            *pGrp = MSGGROUP_CHANNEL;
+        } else if ((128 <= type) && (type <= 255)) {
+            *pGrp = MSGGROUP_COMMIT;
+        } else if ((256 <= type) && (511 <= type)) {
+            *pGrp = MSGGROUP_ROUTING;
+        } else {
+            *pGrp = MSGGROUP_UNKNOWN;
+        }
+    }
+    return type;
 }

--- a/ln/ln_msg.h
+++ b/ln/ln_msg.h
@@ -70,6 +70,19 @@
 
 
 /**************************************************************************
+ * typedefs
+ **************************************************************************/
+
+typedef enum ln_msg_groupt_t {
+    MSGGROUP_UNKNOWN,       ///< unknown group
+    MSGGROUP_SETUP_CTRL,    ///< Setup & Control (types 0-31)
+    MSGGROUP_CHANNEL,       ///< Channel (types 32-127)
+    MSGGROUP_COMMIT,        ///< Commitment (types 128-255)
+    MSGGROUP_ROUTING,       ///< Routing (types 256-511)
+} ln_msg_groupt_t;
+
+
+/**************************************************************************
  * prototypes
  **************************************************************************/
 
@@ -81,7 +94,7 @@
 const char *ln_msg_name(uint16_t Type);
 
 
-uint16_t ln_msg_type(const uint8_t *pData, uint16_t Len);
+uint16_t ln_msg_type(ln_msg_groupt_t *pGrp, const uint8_t *pData, uint16_t Len);
 
 
 #endif /* LN_MSG_H__ */

--- a/ln/ln_normalope.c
+++ b/ln/ln_normalope.c
@@ -750,7 +750,7 @@ static bool poll_update_del_htlc_forward(ln_channel_t *pChannel)
     bool        b_commit = false;
     utl_buf_t   buf = UTL_BUF_INIT;
     while (ln_db_forward_del_htlc_cur_get(p_cur, &prev_short_channel_id, &prev_htlc_id, &buf)) {
-        uint32_t type = ln_msg_type(buf.buf, buf.len);
+        uint32_t type = ln_msg_type(NULL, buf.buf, buf.len);
         if (type == MSGTYPE_X_UPDATE_FULFILL_HTLC) {
             ln_msg_x_update_fulfill_htlc_t msg;
             if (!ln_msg_x_update_fulfill_htlc_read(&msg, buf.buf, buf.len)) {
@@ -1065,7 +1065,7 @@ static bool poll_update_del_htlc_forward_origin(ln_channel_t *pChannel)
     bool        b_commit = false;
     utl_buf_t   buf = UTL_BUF_INIT;
     while (ln_db_forward_del_htlc_cur_get(p_cur, &prev_short_channel_id, &prev_htlc_id, &buf)) {
-        uint32_t type = ln_msg_type(buf.buf, buf.len);
+        uint32_t type = ln_msg_type(NULL, buf.buf, buf.len);
         if (type == MSGTYPE_X_UPDATE_FULFILL_HTLC) {
             ln_msg_x_update_fulfill_htlc_t msg;
             if (!ln_msg_x_update_fulfill_htlc_read(&msg, buf.buf, buf.len)) {

--- a/ptarmd/lnapp_util.c
+++ b/ptarmd/lnapp_util.c
@@ -130,7 +130,7 @@ bool lnapp_send_peer_raw(lnapp_conf_t *p_conf, const utl_buf_t *pBuf)
 //peer送信(Noise Protocol送信)
 bool lnapp_send_peer_noise(lnapp_conf_t *p_conf, const utl_buf_t *pBuf)
 {
-    uint16_t type = utl_int_pack_u16be(pBuf->buf);
+    uint16_t type = ln_msg_type(NULL, pBuf->buf, pBuf->len);
     LOGD("[SEND]type=%04x(%s): sock=%d, Len=%d\n", type, ln_msg_name(type), p_conf->sock, pBuf->len);
 
 #ifdef M_DEBUG_ANNO


### PR DESCRIPTION
BOLT1のmessage groupを返すことができるようにした。
用途は今のところない。