### PR TITLE
receive funding_locked before channel_reestablish

### DIFF
--- a/ln/ln_establish.c
+++ b/ln/ln_establish.c
@@ -596,8 +596,7 @@ bool /*HIDDEN*/ ln_funding_locked_send(ln_channel_t *pChannel)
     ln_callback(pChannel, LN_CB_TYPE_SEND_MESSAGE, &buf);
     utl_buf_free(&buf);
 
-    //channel_reestablishと同じ扱いにする
-    pChannel->init_flag |= M_INIT_FLAG_REEST_SEND;
+    pChannel->init_flag |= M_INIT_FLAG_FLOCK_SEND;
 
     LN_DBG_COMMIT_NUM_PRINT(pChannel);
     return true;
@@ -641,8 +640,7 @@ bool HIDDEN ln_funding_locked_recv(ln_channel_t *pChannel, const uint8_t *pData,
 
     ln_callback(pChannel, LN_CB_TYPE_NOTIFY_FUNDING_LOCKED_RECV, NULL);
 
-    //channel_reestablishと同じ扱いにする
-    pChannel->init_flag |= M_INIT_FLAG_REEST_RECV;
+    pChannel->init_flag |= M_INIT_FLAG_FLOCK_RECV;
 
     LN_DBG_COMMIT_NUM_PRINT(pChannel);
 
@@ -853,6 +851,7 @@ void ln_channel_reestablish_after(ln_channel_t *pChannel)
         }
         utl_buf_free(&buf);
     }
+    LN_DBG_COMMIT_NUM_PRINT(pChannel);
 }
 
 

--- a/ln/ln_normalope.c
+++ b/ln/ln_normalope.c
@@ -1151,8 +1151,11 @@ void ln_idle_proc(ln_channel_t *pChannel, uint32_t FeeratePerKw)
 {
     //XXX: should return the return code or SET_ERR
 
-    if (!M_INIT_CH_EXCHANGED(pChannel->init_flag)) return;
-    if (!M_INIT_FLAG_REEST_EXCHNAGED(pChannel->init_flag)) return;
+    if (!M_INIT_FLAG_EXCHNAGED(pChannel->init_flag)) return;
+    if ( !M_INIT_FLAG_REEST_EXCHNAGED(pChannel->init_flag) &&
+         !M_INIT_FLAG_FLOCK_EXCHNAGED(pChannel->init_flag) ) {
+        return;
+    }
     if (pChannel->status != LN_STATUS_NORMAL_OPE) return;
 
     if (ln_is_shutdowning(pChannel)) {

--- a/ln/ln_setupctl.h
+++ b/ln/ln_setupctl.h
@@ -45,10 +45,12 @@
 #define M_INIT_FLAG_REEST_RECV              (0x08)
 #define M_INIT_FLAG_REEST_EXCG              (M_INIT_FLAG_REEST_SEND | M_INIT_FLAG_REEST_RECV)
 #define M_INIT_FLAG_REEST_EXCHNAGED(flag)   (((flag) & M_INIT_FLAG_REEST_EXCG) == M_INIT_FLAG_REEST_EXCG)
-#define M_INIT_FLAG_ALL                     (M_INIT_FLAG_EXCG | M_INIT_FLAG_REEST_EXCG)
-#define M_INIT_CH_EXCHANGED(flag)           (((flag) & M_INIT_FLAG_ALL) == M_INIT_FLAG_ALL)
 #define M_INIT_ANNOSIG_SENT                 (0x10)          ///< announcement_signatures送信/再送済み
 #define M_INIT_GOSSIP_QUERY                 (0x20)          ///< gossip_queries
+#define M_INIT_FLAG_FLOCK_SEND              (0x40)
+#define M_INIT_FLAG_FLOCK_RECV              (0x80)
+#define M_INIT_FLAG_FLOCK_EXCG              (M_INIT_FLAG_FLOCK_SEND | M_INIT_FLAG_FLOCK_RECV)
+#define M_INIT_FLAG_FLOCK_EXCHNAGED(flag)   (((flag) & M_INIT_FLAG_FLOCK_EXCG) == M_INIT_FLAG_FLOCK_EXCG)
 
 
 #define M_SET_ERR(pChannel, err, fmt,...) { \

--- a/ptarmd/lnapp.c
+++ b/ptarmd/lnapp.c
@@ -1488,8 +1488,13 @@ static void poll_funding_wait(lnapp_conf_t *p_conf)
         LOGD("confirmation OK: %d\n", p_conf->funding_confirm);
 
         if (ln_status_get(&p_conf->channel) != LN_STATUS_ESTABLISH) {
-            // maybe unilateral close(remote) before funding
-            LOGE("not LN_STATUS_ESTABLISH\n");
+            if (ln_status_get(&p_conf->channel) == LN_STATUS_NORMAL_OPE) {
+                LOGD("already LN_STATUS_NORMAL_OPE\n");
+                p_conf->funding_waiting = false;
+            } else {
+                // maybe unilateral close(remote) before funding
+                LOGE("not LN_STATUS_ESTABLISH\n");
+            }
             return;
         }
 

--- a/ptarmd/monitoring.c
+++ b/ptarmd/monitoring.c
@@ -491,7 +491,7 @@ static bool funding_unspent(lnapp_conf_t *pConf, monparam_t *pParam, void *pDbPa
                     ptarmd_eventlog(
                         ln_channel_id(&pConf->channel),
                         "fail: set_channel\n");
-                    lnapp_stop_threads(pConf);
+                    ptarmd_stop();
                 }
             }
         }


### PR DESCRIPTION
再接続時、channel_reestablishより前にfunding_lockedを受信した場合、unilateral closeしていた。
channel_reestablish ==> funding_lockedと想定していたため、順番が違えばfail channelするからちょうど良かったのだが、BOLTとしてはどちらの順でも受け入れるべきと判断。

channel_reestablish送受信済みフラグをfunding_lockedと共通化していたため、funding_locked受信→channel_reestablish送信の時点で「channel_reestablish送受信済み」の処理を行ってしまい、next値の判定がうまくいっていなかった。
