### PR TITLE
funding amount max limitation

### DIFF
--- a/ln/ln_funding_info.h
+++ b/ln/ln_funding_info.h
@@ -37,7 +37,8 @@
  **************************************************************************/
 
 #define LN_FUNDING_SATOSHIS_MIN         (100000)        ///< minimum funding_sat(BOLTに規定はない)
-#define LN_FUNDING_SATOSHIS_MAX         (0x1000000 - 1) //2^24-1
+//#define LN_FUNDING_SATOSHIS_MAX         (0x1000000 - 1) //2^24-1
+#define LN_FUNDING_SATOSHIS_MAX         (5000000)       ///< maximum funding_sat
 
 
 #define LN_FUNDING_ROLE_FUNDEE                      (0x00)

--- a/ptarmcli/ptarmcli.c
+++ b/ptarmcli/ptarmcli.c
@@ -597,6 +597,7 @@ static void optfunc_funding(int *pOption, bool *pConn)
     funding_conf_t fundconf;
 
     conf_funding_init(&fundconf);
+    const char *p_error_str = "funding";
     const char *param = strtok(optarg, ",");
     char *endp = NULL;
     fundconf.funding_sat = (uint64_t)strtoul(param, &endp, 10);
@@ -604,7 +605,13 @@ static void optfunc_funding(int *pOption, bool *pConn)
         //変換失敗
         LOGE("fail: *endp = %p(%02x)\n", endp, *endp);
     } else {
-        bret = true;
+        if ( (fundconf.funding_sat >= LN_FUNDING_SATOSHIS_MIN) &&
+             (fundconf.funding_sat <= LN_FUNDING_SATOSHIS_MAX) ) {
+            bret = true;
+        } else {
+            snprintf(mErrStr, sizeof(mErrStr), "funding satoshis is out of range(%d - %d)", LN_FUNDING_SATOSHIS_MIN, LN_FUNDING_SATOSHIS_MAX);
+            p_error_str = NULL;
+        }
     }
     if (bret) {
         param = strtok(NULL, ",");
@@ -647,7 +654,9 @@ static void optfunc_funding(int *pOption, bool *pConn)
         *pConn = false;
         *pOption = M_OPT_FUND;
     } else {
-        strcpy(mErrStr, "funding");
+        if (p_error_str != NULL) {
+            strcpy(mErrStr, p_error_str);
+        }
         *pOption = M_OPTIONS_ERR;
     }
 }


### PR DESCRIPTION
funding_satの下限を1mBTCにしているように、上限を決めてもよいのかもしれない。
範囲外の時にはエラーメッセージで範囲を返すようにもする。