### PR TITLE
Correct name of upcode 0x4e to OP_PUSHDATA4

### DIFF
--- a/btc/btc_script.c
+++ b/btc/btc_script.c
@@ -883,7 +883,7 @@ void btc_script_print(const uint8_t *pData, uint16_t Len)
                 ret = false;
                 break;
             }
-            LOGD("%sOP_PUSHDATA3 0x%02x ", INDENT, len);
+            LOGD("%sOP_PUSHDATA4 0x%02x ", INDENT, len);
             DUMPD(pData, len);
             pData += len;
         } else {

--- a/btc/btc_script.c
+++ b/btc/btc_script.c
@@ -871,7 +871,7 @@ void btc_script_print(const uint8_t *pData, uint16_t Len)
             LOGD("%sOP_PUSHDATA2 0x%02x ", INDENT, len);
             DUMPD(pData, len);
             pData += len;
-        } else if (*pData == OP_PUSHDATA3) {
+        } else if (*pData == OP_PUSHDATA4) {
             //pushdata
             if (pData + 5 > end) {
                 ret = false;

--- a/btc/btc_script.h
+++ b/btc/btc_script.h
@@ -83,7 +83,7 @@
 #define OP_0                    (0x00)
 #define OP_PUSHDATA1            (0x4c)
 #define OP_PUSHDATA2            (0x4d)
-#define OP_PUSHDATA3            (0x4e)
+#define OP_PUSHDATA4            (0x4e)
 #define OP_1NEGATE              (0x4f)
 #define OP_1                    (0x51)
 #define OP_2                    (0x52)


### PR DESCRIPTION
OP_PUSHDATA3 is not part of bitcoin script. Only OP_PUSHDATA1, OP_PUSHDATA2 and OP_PUSHDATA4 are valid. 

https://github.com/bitcoin/bitcoin/blob/master/src/script/script.h#L59-L61

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nayutaco/ptarmigan/1654)
<!-- Reviewable:end -->
